### PR TITLE
feat: add agent terminal persistence and user interaction support

### DIFF
--- a/opencode/packages/opencode/src/pty/agent-terminal.ts
+++ b/opencode/packages/opencode/src/pty/agent-terminal.ts
@@ -77,6 +77,7 @@ export namespace AgentTerminal {
       z.object({
         id: Identifier.schema("agt"),
         screen: z.string(),
+        screenAnsi: z.string(),
         cursor: z.object({ row: z.number(), col: z.number() }),
       })
     ),
@@ -259,10 +260,12 @@ export namespace AgentTerminal {
    */
   function publishScreen(session: ActiveSession) {
     const screen = session.buffer.getScreenText()
+    const screenAnsi = session.buffer.getScreenAnsi()
     const cursor = session.buffer.getCursor()
     Bus.publish(Event.Screen, {
       id: session.info.id,
       screen,
+      screenAnsi,
       cursor,
     })
   }
@@ -287,6 +290,15 @@ export namespace AgentTerminal {
     const session = state().get(id)
     if (!session) return undefined
     return session.buffer.getScreenText()
+  }
+
+  /**
+   * 获取带 ANSI 转义序列的屏幕内容
+   */
+  export function getScreenAnsi(id: string): string | undefined {
+    const session = state().get(id)
+    if (!session) return undefined
+    return session.buffer.getScreenAnsi()
   }
 
   /**

--- a/opencode/packages/opencode/src/server/routes/agent-terminal.ts
+++ b/opencode/packages/opencode/src/server/routes/agent-terminal.ts
@@ -1,0 +1,196 @@
+import { Hono } from "hono"
+import { describeRoute, validator, resolver } from "hono-openapi"
+import z from "zod"
+import { AgentTerminal } from "@/pty/agent-terminal"
+import { Storage } from "../../storage/storage"
+import { errors } from "../error"
+import { lazy } from "../../util/lazy"
+
+export const AgentTerminalRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "List Agent Terminals",
+        description: "Get a list of all active agent terminal sessions.",
+        operationId: "agentTerminal.list",
+        responses: {
+          200: {
+            description: "List of sessions",
+            content: {
+              "application/json": {
+                schema: resolver(AgentTerminal.Info.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const sessionID = c.req.query("sessionID")
+        return c.json(AgentTerminal.list(sessionID))
+      },
+    )
+    .get(
+      "/:id",
+      describeRoute({
+        summary: "Get Agent Terminal",
+        description: "Retrieve detailed information about a specific agent terminal session.",
+        operationId: "agentTerminal.get",
+        responses: {
+          200: {
+            description: "Session info",
+            content: {
+              "application/json": {
+                schema: resolver(AgentTerminal.Info),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      validator("param", z.object({ id: z.string() })),
+      async (c) => {
+        const info = AgentTerminal.get(c.req.valid("param").id)
+        if (!info) {
+          throw new Storage.NotFoundError({ message: "Agent terminal not found" })
+        }
+        return c.json(info)
+      },
+    )
+    .post(
+      "/:id/resize",
+      describeRoute({
+        summary: "Resize Agent Terminal",
+        description: "Resize an agent terminal to the specified dimensions.",
+        operationId: "agentTerminal.resize",
+        responses: {
+          200: {
+            description: "Terminal resized successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ id: z.string() })),
+      validator(
+        "json",
+        z.object({
+          rows: z.number().int().min(1).max(500),
+          cols: z.number().int().min(1).max(500),
+        })
+      ),
+      async (c) => {
+        const { id } = c.req.valid("param")
+        const { rows, cols } = c.req.valid("json")
+        const success = AgentTerminal.resize(id, rows, cols)
+        if (!success) {
+          throw new Storage.NotFoundError({ message: "Agent terminal not found or not running" })
+        }
+        return c.json(true)
+      },
+    )
+    .get(
+      "/:id/screen",
+      describeRoute({
+        summary: "Get Agent Terminal Screen",
+        description: "Get the current screen content of an agent terminal.",
+        operationId: "agentTerminal.screen",
+        responses: {
+          200: {
+            description: "Screen content",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    screen: z.string(),
+                    screenAnsi: z.string(),
+                    cursor: z.object({ row: z.number(), col: z.number() }),
+                  })
+                ),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      validator("param", z.object({ id: z.string() })),
+      async (c) => {
+        const { id } = c.req.valid("param")
+        const screen = AgentTerminal.getScreen(id)
+        const screenAnsi = AgentTerminal.getScreenAnsi(id)
+        const cursor = AgentTerminal.getCursor(id)
+
+        if (screen === undefined || screenAnsi === undefined || cursor === undefined) {
+          throw new Storage.NotFoundError({ message: "Agent terminal not found" })
+        }
+
+        return c.json({ screen, screenAnsi, cursor })
+      },
+    )
+    .post(
+      "/:id/write",
+      describeRoute({
+        summary: "Write to Agent Terminal",
+        description: "Send input data to an agent terminal (user interaction).",
+        operationId: "agentTerminal.write",
+        responses: {
+          200: {
+            description: "Data written successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ id: z.string() })),
+      validator(
+        "json",
+        z.object({
+          data: z.string(),
+        })
+      ),
+      async (c) => {
+        const { id } = c.req.valid("param")
+        const { data } = c.req.valid("json")
+        const success = AgentTerminal.write(id, data)
+        if (!success) {
+          throw new Storage.NotFoundError({ message: "Agent terminal not found or not running" })
+        }
+        return c.json(true)
+      },
+    )
+    .delete(
+      "/:id",
+      describeRoute({
+        summary: "Close Agent Terminal",
+        description: "Close and terminate an agent terminal session.",
+        operationId: "agentTerminal.close",
+        responses: {
+          200: {
+            description: "Terminal closed successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      validator("param", z.object({ id: z.string() })),
+      async (c) => {
+        const success = await AgentTerminal.close(c.req.valid("param").id)
+        if (!success) {
+          throw new Storage.NotFoundError({ message: "Agent terminal not found" })
+        }
+        return c.json(true)
+      },
+    ),
+)

--- a/opencode/packages/opencode/src/server/server.ts
+++ b/opencode/packages/opencode/src/server/server.ts
@@ -42,6 +42,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { PreferencesRoutes } from "./routes/preferences"
+import { AgentTerminalRoutes } from "./routes/agent-terminal"
 import { MDNS } from "./mdns"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
@@ -175,6 +176,7 @@ export namespace Server {
         .route("/", FileRoutes())
         .route("/mcp", McpRoutes())
         .route("/preferences", PreferencesRoutes())
+        .route("/agent-terminal", AgentTerminalRoutes())
         .route("/tui", TuiRoutes())
         .post(
           "/instance/dispose",

--- a/web/src/components/TerminalPanel.vue
+++ b/web/src/components/TerminalPanel.vue
@@ -12,6 +12,7 @@ const {
   isPanelOpen,
   selectTerminal,
   closePanel,
+  closeTerminal,
 } = useAgentTerminal()
 
 const terminalViewerRef = ref<InstanceType<typeof AgentTerminalViewer> | null>(null)
@@ -35,6 +36,12 @@ function formatTime(ts: number): string {
   if (diff < 60000) return `${Math.floor(diff / 1000)}s`
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m`
   return `${Math.floor(diff / 3600000)}h`
+}
+
+// 关闭终端
+async function handleCloseTerminal(id: string, e: Event) {
+  e.stopPropagation()
+  await closeTerminal(id)
 }
 
 // 清理 resize 事件监听器
@@ -121,12 +128,15 @@ watch(panelWidth, () => {
         v-for="term in terminals"
         :key="term.id"
         class="terminal-tab"
-        :class="{ active: activeTerminalId === term.id }"
+        :class="{ active: activeTerminalId === term.id, exited: term.status === 'exited' }"
         @click="selectTerminal(term.id)"
       >
         <span class="status-dot" :style="{ background: getStatusColor(term.status) }"></span>
         <span class="tab-name">{{ term.name }}</span>
         <span class="tab-time">{{ formatTime(term.lastActivity) }}</span>
+        <button class="close-tab-btn" @click="handleCloseTerminal(term.id, $event)" title="关闭终端">
+          <X :size="12" />
+        </button>
       </button>
     </div>
 
@@ -141,13 +151,23 @@ watch(panelWidth, () => {
           <span :style="{ color: getStatusColor(activeTerminal.status) }">
             {{ activeTerminal.status }}
           </span>
+          <button
+            class="close-single-btn"
+            @click="closeTerminal(activeTerminal.id)"
+            title="关闭终端"
+          >
+            <X :size="14" />
+          </button>
         </div>
         <AgentTerminalViewer
           ref="terminalViewerRef"
+          :terminal-id="activeTerminal.id"
           :screen="activeScreen.screen"
+          :screen-ansi="activeScreen.screenAnsi"
           :cursor="activeScreen.cursor"
           :rows="activeTerminal.rows"
           :cols="activeTerminal.cols"
+          :status="activeTerminal.status"
         />
       </template>
       <template v-else-if="terminals.length === 0">
@@ -284,6 +304,10 @@ watch(panelWidth, () => {
   color: white;
 }
 
+.terminal-tab.exited {
+  opacity: 0.7;
+}
+
 .terminal-tab.active .status-dot {
   border: 1px solid white;
 }
@@ -307,6 +331,27 @@ watch(panelWidth, () => {
   opacity: 0.7;
 }
 
+.close-tab-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  opacity: 0.5;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: all var(--transition-fast);
+}
+
+.close-tab-btn:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.2);
+}
+
 .terminal-content {
   flex: 1;
   display: flex;
@@ -326,6 +371,27 @@ watch(panelWidth, () => {
   color: var(--text-muted);
   margin-bottom: var(--space-sm);
   flex-shrink: 0;
+}
+
+.close-single-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+}
+
+.close-single-btn:hover {
+  background: var(--danger, #f7768e);
+  color: white;
 }
 
 .separator {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       '/provider': 'http://localhost:4096',
       '/config': 'http://localhost:4096',
       '/auth': 'http://localhost:4096',
+      '/agent-terminal': 'http://localhost:4096',
     }
   }
 })


### PR DESCRIPTION
- Add terminal screen buffer with ANSI support for state persistence
- Add agent-terminal API routes (list, get, screen, resize, write, close)
- Enable user input to terminals (disableStdin: false)
- Add close buttons for terminal tabs
- Fix vite proxy config to include /agent-terminal route
- Fix event handler registration order to capture server.connected event
- Add terminal initialization on SSE connect for page refresh recovery