### PR TITLE
Pensive noether

### DIFF
--- a/opencode/packages/opencode/src/session/index.ts
+++ b/opencode/packages/opencode/src/session/index.ts
@@ -133,12 +133,17 @@ export namespace Session {
         parentID: Identifier.schema("session").optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,
+        directory: z.string().optional().meta({
+          description: "Working directory for the session. Defaults to server's current directory if not specified.",
+        }),
       })
       .optional(),
     async (input) => {
+      // Use provided directory or fall back to Instance.directory
+      const directory = input?.directory || Instance.directory
       return createNext({
         parentID: input?.parentID,
-        directory: Instance.directory,
+        directory,
         title: input?.title,
         permission: input?.permission,
       })

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -971,27 +971,33 @@ export namespace SessionPrompt {
                   const base64Data = base64Match[1]
                   const buffer = Buffer.from(base64Data, "base64")
 
-                  // Save to current working directory's uploads folder
-                  const uploadsDir = path.join(process.cwd(), "uploads", input.sessionID)
+                  // Save to project's .opencode/uploads directory (within sandbox)
+                  const uploadsDir = path.join(Instance.directory, ".opencode", "uploads", input.sessionID)
                   await fs.mkdir(uploadsDir, { recursive: true })
                   const uploadFilePath = path.join(uploadsDir, part.filename || `upload-${Date.now()}`)
                   await fs.writeFile(uploadFilePath, buffer)
 
                   log.info("saved uploaded file", { path: uploadFilePath, mime: part.mime })
 
+                  // Determine file type description and skill hint
+                  const fileTypeMap: Record<string, { type: string; skill: string }> = {
+                    "application/pdf": { type: "PDF", skill: "pdf" },
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": { type: "Word document", skill: "docx" },
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation": { type: "PowerPoint presentation", skill: "pptx" },
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": { type: "Excel spreadsheet", skill: "xlsx" },
+                    "application/msword": { type: "Word document (legacy)", skill: "docx" },
+                    "application/vnd.ms-powerpoint": { type: "PowerPoint presentation (legacy)", skill: "pptx" },
+                    "application/vnd.ms-excel": { type: "Excel spreadsheet (legacy)", skill: "xlsx" },
+                  }
                   // Generate file type description
-                  const fileTypeDesc = part.mime.startsWith("image/")
-                    ? "an image"
-                    : part.mime === "application/pdf"
-                      ? "a PDF document"
-                      : part.mime.includes("wordprocessingml")
-                        ? "a Word document"
-                        : part.mime.includes("presentationml")
-                          ? "a PowerPoint presentation"
-                          : part.mime.includes("spreadsheetml")
-                            ? "an Excel spreadsheet"
-                            : "a file"
+                  const fileInfo = fileTypeMap[part.mime]
+                  const fileTypeDesc = fileInfo
+                    ? `a ${fileInfo.type}`
+                    : part.mime.startsWith("image/")
+                      ? "an image"
+                      : "a file"
 
+                  const skillHint = fileInfo?.skill ? `, or invoke the appropriate skill (e.g., /${fileInfo.skill}) for advanced operations` : ""
                   return [
                     {
                       id: Identifier.ascending("part"),
@@ -999,13 +1005,14 @@ export namespace SessionPrompt {
                       sessionID: input.sessionID,
                       type: "text",
                       synthetic: true,
-                      text: `User uploaded ${fileTypeDesc}: ${part.filename}\nFile saved to: ${uploadFilePath}\n\nUse the Read tool to view this file.`,
+                      text: `User uploaded ${fileTypeDesc}: ${part.filename}\nFile saved to: ${uploadFilePath}\n\nTo read or process this file, use the Read tool with the file path${skillHint}.`,
                     },
                     {
                       ...part,
                       id: part.id ?? Identifier.ascending("part"),
                       messageID: info.id,
                       sessionID: input.sessionID,
+                      // Replace data URL with file URL to avoid sending large base64 to model
                       url: `file://${uploadFilePath}`,
                     },
                   ]

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -69,6 +69,14 @@ async function generateOpencodeConfig(config: Nine1BotConfig): Promise<string> {
         if (Object.keys(rest).length > 0) {
           opencodeConfig[key] = rest
         }
+      } else if (key === 'mcp') {
+        // 过滤掉 mcp 中的继承控制字段，这些字段由环境变量控制
+        const { inheritOpencode, inheritClaudeCode, ...mcpServers } = value as any
+        opencodeConfig[key] = mcpServers
+      } else if (key === 'provider') {
+        // 过滤掉 provider 中的继承控制字段
+        const { inheritOpencode, ...providers } = value as any
+        opencodeConfig[key] = providers
       } else {
         opencodeConfig[key] = value
       }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -42,6 +42,9 @@ const {
   clearSessionError,
   deleteSession,
   renameSession,
+  // 工作目录管理
+  changeDirectory,
+  canChangeDirectory,
   // 新增功能
   deleteMessagePart,
   updateMessagePart,
@@ -239,6 +242,8 @@ function closeFileViewer() {
       :files="files"
       :filesLoading="filesLoading"
       :activeTab="sidebarTab"
+      :currentDirectory="currentDirectory"
+      :canChangeDirectory="canChangeDirectory()"
       :isSessionRunning="isSessionRunning"
       :runningCount="runningCount"
       :maxParallelAgents="MAX_PARALLEL_AGENTS"
@@ -251,6 +256,7 @@ function closeFileViewer() {
       @rename-session="renameSession"
       @file-click="handleFileClick"
       @abort-session="abortSession"
+      @change-directory="changeDirectory"
     />
 
     <!-- Main Content -->
@@ -277,6 +283,8 @@ function closeFileViewer() {
           :pendingQuestions="pendingQuestions"
           :pendingPermissions="pendingPermissions"
           :sessionError="sessionError"
+          :currentDirectory="currentDirectory"
+          :canChangeDirectory="canChangeDirectory()"
           @question-answered="(id, answers) => answerQuestion(id, answers)"
           @question-rejected="rejectQuestion"
           @permission-responded="respondPermission"
@@ -284,6 +292,7 @@ function closeFileViewer() {
           @open-settings="openSettings"
           @delete-part="handleDeletePart"
           @update-part="handleUpdatePart"
+          @change-directory="changeDirectory"
         />
         <InputBox
           :disabled="isLoading"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -311,15 +311,16 @@ export const api = {
     return true
   },
 
-  // 更新会话（重命名等）
-  async updateSession(sessionId: string, updates: { title?: string }): Promise<Session> {
+  // 更新会话（重命名、修改工作目录等）
+  async updateSession(sessionId: string, updates: { title?: string; directory?: string }): Promise<Session> {
     const res = await fetch(`${BASE_URL}/session/${sessionId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(updates)
     })
     if (!res.ok) {
-      throw new Error(`Failed to update session: ${res.status}`)
+      const errorData = await res.json().catch(() => ({}))
+      throw new Error(errorData.error || `Failed to update session: ${res.status}`)
     }
     const data = await res.json()
     const session = data.data || data
@@ -414,6 +415,27 @@ export const api = {
     const res = await fetch(`${BASE_URL}/project`)
     const data = await res.json()
     return data.data || []
+  },
+
+  // 浏览目录（用于目录选择器）
+  async browseDirectory(path: string = '~'): Promise<{
+    path: string
+    parent: string | null
+    items: Array<{
+      name: string
+      path: string
+      type: 'file' | 'directory'
+      size?: number
+      modified?: number
+    }>
+  }> {
+    const params = new URLSearchParams({ path })
+    const res = await fetch(`${BASE_URL}/browse?${params}`)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to browse directory: ${res.status}`)
+    }
+    return res.json()
   },
 
   // 订阅事件流（带自动重连）

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -156,7 +156,7 @@ function getSessionTitle(session: Session): string {
           <DirectorySelector
             :model-value="currentDirectory"
             :disabled="!canChangeDirectory"
-            @update:model-value="(val) => emit('change-directory', val)"
+            @update:model-value="(val: string) => emit('change-directory', val)"
           />
         </div>
         <div


### PR DESCRIPTION
描述 / Summary
为新建会话添加工作目录选择功能。用户可以在开始对话前选择一个工作目录，点击按钮后会弹出系统原生的文件夹选择器。

类型 / Type of change
 新功能 (feature)
 Bug 修复 (bugfix)
 文档 (docs)
 重构 (refactor)
 其他 (describe):
关联的 issue（如果有）/ Related issues
无

变更点 / What changed
在聊天欢迎界面（"Hello, I'm Nine1Bot"下方）添加工作目录选择按钮
使用系统原生文件夹选择器（通过 <input type="file" webkitdirectory>）
后端新增 /browse API 端点用于目录浏览
Session API 支持 directory 参数（创建和更新时）
修复 nine1bot 配置中 inheritOpencode/inheritClaudeCode 字段导致的 opencode 配置验证错误
新会话（草稿模式）或无消息的会话可以修改工作目录，发送消息后目录锁定
如何测试 / How to test
启动服务 bun run packages/nine1bot/src/index.ts start --port 5002
打开浏览器访问 http://localhost:5002/
点击左侧 "+ 新对话" 创建新会话
在聊天区域中央可以看到"选择工作目录"按钮
点击按钮，系统会弹出原生的文件夹选择对话框
选择一个文件夹后，按钮文字会更新显示选中的目录名
发送一条消息后，目录选择按钮消失（目录已锁定）
截图（UI 变更时提供）/ Screenshots for UI changed
工作目录选择按钮位于欢迎界面正中央，"How can I help you today?" 文字下方，点击后触发系统原生文件选择器。

Checklist（合并前请确认） / Checklist
 本地已通过测试
备注 / Notes for reviewers
由于浏览器安全限制，webkitdirectory 只能获取文件夹的相对路径名称，无法获取完整绝对路径
修复了 packages/nine1bot/src/launcher/server.ts 中的配置过滤逻辑，确保 mcp.inheritOpencode 等字段不会传递给 opencode 导致验证失败