### PR TITLE
Pensive noether

### DIFF
--- a/opencode/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/opencode/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -152,6 +152,7 @@ async function createToolContext(agent: Agent.Info) {
     messageID,
     callID: Identifier.ascending("part"),
     agent: agent.name,
+    cwd: session.directory,
     abort: new AbortController().signal,
     messages: [],
     metadata: () => {},

--- a/opencode/packages/opencode/src/server/routes/file.ts
+++ b/opencode/packages/opencode/src/server/routes/file.ts
@@ -6,7 +6,7 @@ import { Ripgrep } from "../../file/ripgrep"
 import { LSP } from "../../lsp"
 import { Instance } from "../../project/instance"
 import { lazy } from "../../util/lazy"
-import { PreviewRegistry } from "../../tool/preview-file"
+import { PreviewRegistry } from "../../tool/display_file"
 
 export const FileRoutes = lazy(() =>
   new Hono()
@@ -136,11 +136,12 @@ export const FileRoutes = lazy(() =>
         "query",
         z.object({
           path: z.string(),
+          directory: z.string().optional(),
         }),
       ),
       async (c) => {
-        const path = c.req.valid("query").path
-        const content = await File.list(path)
+        const { path, directory } = c.req.valid("query")
+        const content = await File.list(path, { directory })
         return c.json(content)
       },
     )
@@ -165,11 +166,12 @@ export const FileRoutes = lazy(() =>
         "query",
         z.object({
           path: z.string(),
+          directory: z.string().optional(),
         }),
       ),
       async (c) => {
-        const path = c.req.valid("query").path
-        const content = await File.read(path)
+        const { path, directory } = c.req.valid("query")
+        const content = await File.read(path, { directory })
         return c.json(content)
       },
     )
@@ -190,8 +192,15 @@ export const FileRoutes = lazy(() =>
           },
         },
       }),
+      validator(
+        "query",
+        z.object({
+          directory: z.string().optional(),
+        }),
+      ),
       async (c) => {
-        const content = await File.status()
+        const { directory } = c.req.valid("query")
+        const content = await File.status({ directory })
         return c.json(content)
       },
     )

--- a/opencode/packages/opencode/src/session/compaction.ts
+++ b/opencode/packages/opencode/src/session/compaction.ts
@@ -101,6 +101,8 @@ export namespace SessionCompaction {
     const model = agent.model
       ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
       : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
+    // Get session to use its directory
+    const session = await Session.get(input.sessionID)
     const msg = (await Session.updateMessage({
       id: Identifier.ascending("message"),
       role: "assistant",
@@ -110,7 +112,7 @@ export namespace SessionCompaction {
       agent: "compaction",
       summary: true,
       path: {
-        cwd: Instance.directory,
+        cwd: session.directory,
         root: Instance.worktree,
       },
       cost: 0,

--- a/opencode/packages/opencode/src/session/index.ts
+++ b/opencode/packages/opencode/src/session/index.ts
@@ -133,12 +133,17 @@ export namespace Session {
         parentID: Identifier.schema("session").optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,
+        directory: z.string().optional().meta({
+          description: "Working directory for the session. Defaults to server's current directory if not specified.",
+        }),
       })
       .optional(),
     async (input) => {
+      // Use provided directory or fall back to Instance.directory
+      const directory = input?.directory || Instance.directory
       return createNext({
         parentID: input?.parentID,
-        directory: Instance.directory,
+        directory,
         title: input?.title,
         permission: input?.permission,
       })

--- a/opencode/packages/opencode/src/session/index.ts
+++ b/opencode/packages/opencode/src/session/index.ts
@@ -156,8 +156,10 @@ export namespace Session {
       messageID: Identifier.schema("message").optional(),
     }),
     async (input) => {
+      // Get parent session to inherit its directory
+      const parentSession = await get(input.sessionID)
       const session = await createNext({
-        directory: Instance.directory,
+        directory: parentSession.directory,
       })
       const msgs = await messages({ sessionID: input.sessionID })
       const idMap = new Map<string, string>()

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -980,8 +980,8 @@ export namespace SessionPrompt {
                   const base64Data = base64Match[1]
                   const buffer = Buffer.from(base64Data, "base64")
 
-                  // Save to project's .opencode/uploads directory (within sandbox)
-                  const uploadsDir = path.join(session.directory, ".opencode", "uploads", input.sessionID)
+                  // Save to project's .nine1bot/uploads directory (within sandbox)
+                  const uploadsDir = path.join(session.directory, ".nine1bot", "uploads", input.sessionID)
                   await fs.mkdir(uploadsDir, { recursive: true })
                   const uploadFilePath = path.join(uploadsDir, part.filename || `upload-${Date.now()}`)
                   await fs.writeFile(uploadFilePath, buffer)

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -971,27 +971,33 @@ export namespace SessionPrompt {
                   const base64Data = base64Match[1]
                   const buffer = Buffer.from(base64Data, "base64")
 
-                  // Save to current working directory's uploads folder
-                  const uploadsDir = path.join(process.cwd(), "uploads", input.sessionID)
+                  // Save to project's .opencode/uploads directory (within sandbox)
+                  const uploadsDir = path.join(Instance.directory, ".opencode", "uploads", input.sessionID)
                   await fs.mkdir(uploadsDir, { recursive: true })
                   const uploadFilePath = path.join(uploadsDir, part.filename || `upload-${Date.now()}`)
                   await fs.writeFile(uploadFilePath, buffer)
 
                   log.info("saved uploaded file", { path: uploadFilePath, mime: part.mime })
 
+                  // Determine file type description and skill hint
+                  const fileTypeMap: Record<string, { type: string; skill: string }> = {
+                    "application/pdf": { type: "PDF", skill: "pdf" },
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": { type: "Word document", skill: "docx" },
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation": { type: "PowerPoint presentation", skill: "pptx" },
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": { type: "Excel spreadsheet", skill: "xlsx" },
+                    "application/msword": { type: "Word document (legacy)", skill: "docx" },
+                    "application/vnd.ms-powerpoint": { type: "PowerPoint presentation (legacy)", skill: "pptx" },
+                    "application/vnd.ms-excel": { type: "Excel spreadsheet (legacy)", skill: "xlsx" },
+                  }
                   // Generate file type description
-                  const fileTypeDesc = part.mime.startsWith("image/")
-                    ? "an image"
-                    : part.mime === "application/pdf"
-                      ? "a PDF document"
-                      : part.mime.includes("wordprocessingml")
-                        ? "a Word document"
-                        : part.mime.includes("presentationml")
-                          ? "a PowerPoint presentation"
-                          : part.mime.includes("spreadsheetml")
-                            ? "an Excel spreadsheet"
-                            : "a file"
+                  const fileInfo = fileTypeMap[part.mime]
+                  const fileTypeDesc = fileInfo
+                    ? `a ${fileInfo.type}`
+                    : part.mime.startsWith("image/")
+                      ? "an image"
+                      : "a file"
 
+                  const skillHint = fileInfo?.skill ? `, or invoke the appropriate skill (e.g., /${fileInfo.skill}) for advanced operations` : ""
                   return [
                     {
                       id: Identifier.ascending("part"),
@@ -999,13 +1005,14 @@ export namespace SessionPrompt {
                       sessionID: input.sessionID,
                       type: "text",
                       synthetic: true,
-                      text: `User uploaded ${fileTypeDesc}: ${part.filename}\nFile saved to: ${uploadFilePath}\n\nUse the Read tool to view this file.`,
+                      text: `User uploaded ${fileTypeDesc}: ${part.filename}\nFile saved to: ${uploadFilePath}\n\nTo read or process this file, use the Read tool with the file path${skillHint}.`,
                     },
                     {
                       ...part,
                       id: part.id ?? Identifier.ascending("part"),
                       messageID: info.id,
                       sessionID: input.sessionID,
+                      // Replace data URL with file URL to avoid sending large base64 to model
                       url: `file://${uploadFilePath}`,
                     },
                   ]

--- a/opencode/packages/opencode/src/session/system.ts
+++ b/opencode/packages/opencode/src/session/system.ts
@@ -28,14 +28,14 @@ export namespace SystemPrompt {
     return [PROMPT_ANTHROPIC_WITHOUT_TODO]
   }
 
-  export async function environment(model: Provider.Model) {
+  export async function environment(model: Provider.Model, sessionDirectory: string) {
     const project = Instance.project
     const basePrompts = [
       [
         `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
         `Here is some useful information about the environment you are running in:`,
         `<env>`,
-        `  Working directory: ${Instance.directory}`,
+        `  Working directory: ${sessionDirectory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
         `  Today's date: ${new Date().toDateString()}`,
@@ -44,7 +44,7 @@ export namespace SystemPrompt {
         `  ${
           project.vcs === "git" && false
             ? await Ripgrep.tree({
-                cwd: Instance.directory,
+                cwd: sessionDirectory,
                 limit: 200,
               })
             : ""

--- a/opencode/packages/opencode/src/tool/apply_patch.ts
+++ b/opencode/packages/opencode/src/tool/apply_patch.ts
@@ -58,7 +58,7 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
     let totalDiff = ""
 
     for (const hunk of hunks) {
-      const filePath = path.resolve(Instance.directory, hunk.path)
+      const filePath = path.resolve(ctx.cwd, hunk.path)
       await assertExternalDirectory(ctx, filePath)
 
       switch (hunk.type) {
@@ -116,7 +116,7 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
             if (change.removed) deletions += change.count || 0
           }
 
-          const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
+          const movePath = hunk.move_path ? path.resolve(ctx.cwd, hunk.move_path) : undefined
           await assertExternalDirectory(ctx, movePath)
 
           fileChanges.push({

--- a/opencode/packages/opencode/src/tool/bash.ts
+++ b/opencode/packages/opencode/src/tool/bash.ts
@@ -41,7 +41,7 @@ export const BashTool = Tool.define("bash", async () => {
         ),
     }),
     async execute(params, ctx) {
-      const cwd = params.workdir || Instance.directory
+      const cwd = params.workdir || ctx.cwd
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }

--- a/opencode/packages/opencode/src/tool/command-analyzer.ts
+++ b/opencode/packages/opencode/src/tool/command-analyzer.ts
@@ -2,7 +2,7 @@ import { lazy } from "../util/lazy"
 import { Language } from "web-tree-sitter"
 import { $ } from "bun"
 import { fileURLToPath } from "url"
-import { Instance } from "../project/instance"
+import { Filesystem } from "../util/filesystem"
 import { BashArity } from "../permission/arity"
 import { Log } from "../util/log"
 
@@ -201,12 +201,12 @@ export namespace CommandAnalyzer {
    * Analyze a command string for security requirements
    *
    * @param command - The command string to analyze
-   * @param cwd - Working directory for path resolution (defaults to Instance.directory)
+   * @param cwd - Working directory for path resolution
    * @returns Analysis result with commands, external directories, and permission requirements
    */
   export async function analyze(
     command: string,
-    cwd: string = Instance.directory
+    cwd: string
   ): Promise<AnalysisResult> {
     const result: AnalysisResult = {
       isCommand: true,
@@ -228,11 +228,6 @@ export namespace CommandAnalyzer {
     }
 
     const directories = new Set<string>()
-
-    // Check if cwd is outside project
-    if (!Instance.containsPath(cwd)) {
-      directories.add(cwd)
-    }
 
     // Extract commands from AST
     for (const node of tree.rootNode.descendantsOfType("command")) {
@@ -278,7 +273,7 @@ export namespace CommandAnalyzer {
 
           if (resolved) {
             const normalized = normalizePathForPlatform(resolved)
-            if (!Instance.containsPath(normalized)) {
+            if (!Filesystem.contains(cwd, normalized)) {
               directories.add(normalized)
             }
           }

--- a/opencode/packages/opencode/src/tool/display_file.ts
+++ b/opencode/packages/opencode/src/tool/display_file.ts
@@ -157,7 +157,7 @@ Parameters:
   async execute(params, ctx) {
     let filepath = params.path
     if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
+      filepath = path.resolve(ctx.cwd, filepath)
     }
 
     const filename = path.basename(filepath)
@@ -185,7 +185,7 @@ Parameters:
     }
 
     // 生成预览 ID
-    const previewId = Identifier.ascending("preview")
+    const previewId = Identifier.ascending("tool")
 
     // 小文件内联，大文件注册到 Registry
     let content: string | undefined

--- a/opencode/packages/opencode/src/tool/edit.ts
+++ b/opencode/packages/opencode/src/tool/edit.ts
@@ -41,7 +41,7 @@ export const EditTool = Tool.define("edit", {
       throw new Error("oldString and newString must be different")
     }
 
-    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(ctx.cwd, params.filePath)
 
     await assertExternalDirectory(ctx, filePath)
 

--- a/opencode/packages/opencode/src/tool/external-directory.ts
+++ b/opencode/packages/opencode/src/tool/external-directory.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import type { Tool } from "./tool"
-import { Instance } from "../project/instance"
+import { Filesystem } from "../util/filesystem"
 
 type Kind = "file" | "directory"
 
@@ -14,7 +14,8 @@ export async function assertExternalDirectory(ctx: Tool.Context, target?: string
 
   if (options?.bypass) return
 
-  if (Instance.containsPath(target)) return
+  // Check if target is within the session's working directory (ctx.cwd)
+  if (Filesystem.contains(ctx.cwd, target)) return
 
   const kind = options?.kind ?? "file"
   const parentDir = kind === "directory" ? target : path.dirname(target)

--- a/opencode/packages/opencode/src/tool/glob.ts
+++ b/opencode/packages/opencode/src/tool/glob.ts
@@ -28,8 +28,8 @@ export const GlobTool = Tool.define("glob", {
       },
     })
 
-    let search = params.path ?? Instance.directory
-    search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
+    let search = params.path ?? ctx.cwd
+    search = path.isAbsolute(search) ? search : path.resolve(ctx.cwd, search)
 
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 

--- a/opencode/packages/opencode/src/tool/grep.ts
+++ b/opencode/packages/opencode/src/tool/grep.ts
@@ -32,8 +32,8 @@ export const GrepTool = Tool.define("grep", {
       },
     })
 
-    let searchPath = params.path ?? Instance.directory
-    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
+    let searchPath = params.path ?? ctx.cwd
+    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(ctx.cwd, searchPath)
 
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 

--- a/opencode/packages/opencode/src/tool/ls.ts
+++ b/opencode/packages/opencode/src/tool/ls.ts
@@ -42,7 +42,7 @@ export const ListTool = Tool.define("list", {
     ignore: z.array(z.string()).describe("List of glob patterns to ignore").optional(),
   }),
   async execute(params, ctx) {
-    const searchPath = path.resolve(Instance.directory, params.path || ".")
+    const searchPath = path.resolve(ctx.cwd, params.path || ".")
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     await ctx.ask({

--- a/opencode/packages/opencode/src/tool/lsp.ts
+++ b/opencode/packages/opencode/src/tool/lsp.ts
@@ -28,7 +28,7 @@ export const LspTool = Tool.define("lsp", {
     character: z.number().int().min(1).describe("The character offset (1-based, as shown in editors)"),
   }),
   execute: async (args, ctx) => {
-    const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
+    const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(ctx.cwd, args.filePath)
     await assertExternalDirectory(ctx, file)
 
     await ctx.ask({

--- a/opencode/packages/opencode/src/tool/read.ts
+++ b/opencode/packages/opencode/src/tool/read.ts
@@ -24,7 +24,7 @@ export const ReadTool = Tool.define("read", {
   async execute(params, ctx) {
     let filepath = params.filePath
     if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
+      filepath = path.resolve(ctx.cwd, filepath)
     }
     const title = path.relative(Instance.worktree, filepath)
 

--- a/opencode/packages/opencode/src/tool/registry.ts
+++ b/opencode/packages/opencode/src/tool/registry.ts
@@ -28,7 +28,7 @@ import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
 import { ApplyPatchTool } from "./apply_patch"
 import { SendFileTool } from "./send-file"
-import { DisplayFileTool } from "./preview-file"
+import { DisplayFileTool } from "./display_file"
 import {
   TerminalCreateTool,
   TerminalViewTool,
@@ -79,7 +79,7 @@ export namespace ToolRegistry {
         execute: async (args, ctx) => {
           const pluginCtx = {
             ...ctx,
-            directory: Instance.directory,
+            directory: ctx.cwd,
             worktree: Instance.worktree,
           } as unknown as PluginToolContext
           const result = await def.execute(args as any, pluginCtx)

--- a/opencode/packages/opencode/src/tool/send-file.ts
+++ b/opencode/packages/opencode/src/tool/send-file.ts
@@ -31,7 +31,7 @@ Example:
   async execute(params, ctx) {
     let filepath = params.path
     if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
+      filepath = path.resolve(ctx.cwd, filepath)
     }
 
     const filename = path.basename(filepath)

--- a/opencode/packages/opencode/src/tool/terminal/create.ts
+++ b/opencode/packages/opencode/src/tool/terminal/create.ts
@@ -31,7 +31,7 @@ Example usage:
     const terminal = await AgentTerminal.create({
       name: params.name,
       sessionID: ctx.sessionID,
-      cwd: params.cwd || Instance.directory,
+      cwd: params.cwd || ctx.cwd,
       rows: params.rows,
       cols: params.cols,
     })

--- a/opencode/packages/opencode/src/tool/terminal/write.ts
+++ b/opencode/packages/opencode/src/tool/terminal/write.ts
@@ -66,7 +66,7 @@ Examples:
     }
 
     // Security check: analyze command and request permissions if needed
-    const analysis = await CommandAnalyzer.analyze(input, Instance.directory)
+    const analysis = await CommandAnalyzer.analyze(input, ctx.cwd)
 
     if (analysis.isCommand && analysis.requiresPermission) {
       // Request external_directory permission if accessing paths outside project

--- a/opencode/packages/opencode/src/tool/tool.ts
+++ b/opencode/packages/opencode/src/tool/tool.ts
@@ -19,6 +19,7 @@ export namespace Tool {
     agent: string
     abort: AbortSignal
     callID?: string
+    cwd: string // 会话工作目录
     extra?: { [key: string]: any }
     messages: MessageV2.WithParts[]
     metadata(input: { title?: string; metadata?: M }): void

--- a/opencode/packages/opencode/src/tool/write.ts
+++ b/opencode/packages/opencode/src/tool/write.ts
@@ -23,7 +23,7 @@ export const WriteTool = Tool.define("write", {
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {
-    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(ctx.cwd, params.filePath)
 
     await assertExternalDirectory(ctx, filepath)
 

--- a/opencode/packages/opencode/test/tool/apply_patch.test.ts
+++ b/opencode/packages/opencode/test/tool/apply_patch.test.ts
@@ -10,6 +10,7 @@ const baseCtx = {
   messageID: "",
   callID: "",
   agent: "build",
+  cwd: Instance.directory,
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},

--- a/opencode/packages/opencode/test/tool/bash.test.ts
+++ b/opencode/packages/opencode/test/tool/bash.test.ts
@@ -6,18 +6,19 @@ import { tmpdir } from "../fixture/fixture"
 import type { PermissionNext } from "../../src/permission/next"
 import { Truncate } from "../../src/tool/truncation"
 
+const projectRoot = path.join(__dirname, "../..")
+
 const ctx = {
   sessionID: "test",
   messageID: "",
   callID: "",
   agent: "build",
+  cwd: projectRoot,
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
   ask: async () => {},
 }
-
-const projectRoot = path.join(__dirname, "../..")
 
 describe("tool.bash", () => {
   test("basic", async () => {

--- a/opencode/packages/opencode/test/tool/external-directory.test.ts
+++ b/opencode/packages/opencode/test/tool/external-directory.test.ts
@@ -1,78 +1,62 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import type { Tool } from "../../src/tool/tool"
-import { Instance } from "../../src/project/instance"
 import { assertExternalDirectory } from "../../src/tool/external-directory"
 import type { PermissionNext } from "../../src/permission/next"
 
-const baseCtx: Omit<Tool.Context, "ask"> = {
+const createBaseCtx = (cwd: string): Omit<Tool.Context, "ask"> => ({
   sessionID: "test",
   messageID: "",
   callID: "",
   agent: "build",
+  cwd,
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
-}
+})
 
 describe("tool.assertExternalDirectory", () => {
   test("no-ops for empty target", async () => {
     const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
     const ctx: Tool.Context = {
-      ...baseCtx,
+      ...createBaseCtx("/tmp"),
       ask: async (req) => {
         requests.push(req)
       },
     }
 
-    await Instance.provide({
-      directory: "/tmp",
-      fn: async () => {
-        await assertExternalDirectory(ctx)
-      },
-    })
-
+    await assertExternalDirectory(ctx)
     expect(requests.length).toBe(0)
   })
 
-  test("no-ops for paths inside Instance.directory", async () => {
+  test("no-ops for paths inside ctx.cwd", async () => {
     const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+    const cwd = "/tmp/project"
     const ctx: Tool.Context = {
-      ...baseCtx,
+      ...createBaseCtx(cwd),
       ask: async (req) => {
         requests.push(req)
       },
     }
 
-    await Instance.provide({
-      directory: "/tmp/project",
-      fn: async () => {
-        await assertExternalDirectory(ctx, path.join("/tmp/project", "file.txt"))
-      },
-    })
-
+    await assertExternalDirectory(ctx, path.join(cwd, "file.txt"))
     expect(requests.length).toBe(0)
   })
 
   test("asks with a single canonical glob", async () => {
     const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+    const cwd = "/tmp/project"
     const ctx: Tool.Context = {
-      ...baseCtx,
+      ...createBaseCtx(cwd),
       ask: async (req) => {
         requests.push(req)
       },
     }
 
-    const directory = "/tmp/project"
     const target = "/tmp/outside/file.txt"
     const expected = path.join(path.dirname(target), "*")
 
-    await Instance.provide({
-      directory,
-      fn: async () => {
-        await assertExternalDirectory(ctx, target)
-      },
-    })
+    await assertExternalDirectory(ctx, target)
 
     const req = requests.find((r) => r.permission === "external_directory")
     expect(req).toBeDefined()
@@ -82,23 +66,18 @@ describe("tool.assertExternalDirectory", () => {
 
   test("uses target directory when kind=directory", async () => {
     const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+    const cwd = "/tmp/project"
     const ctx: Tool.Context = {
-      ...baseCtx,
+      ...createBaseCtx(cwd),
       ask: async (req) => {
         requests.push(req)
       },
     }
 
-    const directory = "/tmp/project"
     const target = "/tmp/outside"
     const expected = path.join(target, "*")
 
-    await Instance.provide({
-      directory,
-      fn: async () => {
-        await assertExternalDirectory(ctx, target, { kind: "directory" })
-      },
-    })
+    await assertExternalDirectory(ctx, target, { kind: "directory" })
 
     const req = requests.find((r) => r.permission === "external_directory")
     expect(req).toBeDefined()
@@ -109,19 +88,13 @@ describe("tool.assertExternalDirectory", () => {
   test("skips prompting when bypass=true", async () => {
     const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
     const ctx: Tool.Context = {
-      ...baseCtx,
+      ...createBaseCtx("/tmp/project"),
       ask: async (req) => {
         requests.push(req)
       },
     }
 
-    await Instance.provide({
-      directory: "/tmp/project",
-      fn: async () => {
-        await assertExternalDirectory(ctx, "/tmp/outside/file.txt", { bypass: true })
-      },
-    })
-
+    await assertExternalDirectory(ctx, "/tmp/outside/file.txt", { bypass: true })
     expect(requests.length).toBe(0)
   })
 })

--- a/opencode/packages/opencode/test/tool/grep.test.ts
+++ b/opencode/packages/opencode/test/tool/grep.test.ts
@@ -4,18 +4,19 @@ import { GrepTool } from "../../src/tool/grep"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
+const projectRoot = path.join(__dirname, "../..")
+
 const ctx = {
   sessionID: "test",
   messageID: "",
   callID: "",
   agent: "build",
+  cwd: projectRoot,
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
   ask: async () => {},
 }
-
-const projectRoot = path.join(__dirname, "../..")
 
 describe("tool.grep", () => {
   test("basic search", async () => {

--- a/opencode/packages/opencode/test/tool/question.test.ts
+++ b/opencode/packages/opencode/test/tool/question.test.ts
@@ -8,6 +8,7 @@ const ctx = {
   messageID: "test-message",
   callID: "test-call",
   agent: "test-agent",
+  cwd: process.cwd(),
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},

--- a/opencode/packages/opencode/test/tool/read.test.ts
+++ b/opencode/packages/opencode/test/tool/read.test.ts
@@ -13,6 +13,7 @@ const ctx = {
   messageID: "",
   callID: "",
   agent: "build",
+  cwd: FIXTURES_DIR,
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -69,6 +69,14 @@ async function generateOpencodeConfig(config: Nine1BotConfig): Promise<string> {
         if (Object.keys(rest).length > 0) {
           opencodeConfig[key] = rest
         }
+      } else if (key === 'mcp') {
+        // 过滤掉 mcp 中的继承控制字段，这些字段由环境变量控制
+        const { inheritOpencode, inheritClaudeCode, ...mcpServers } = value as any
+        opencodeConfig[key] = mcpServers
+      } else if (key === 'provider') {
+        // 过滤掉 provider 中的继承控制字段
+        const { inheritOpencode, ...providers } = value as any
+        opencodeConfig[key] = providers
       } else {
         opencodeConfig[key] = value
       }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -72,6 +72,7 @@ const { handleSSEEvent: handlePreviewEvent } = useFilePreview()
 const {
   files,
   isLoading: filesLoading,
+  setDirectory: setFilesDirectory,
   loadFiles,
   toggleDirectory,
   // 文件查看
@@ -156,9 +157,11 @@ onUnmounted(() => {
   }
 })
 
-// 注意：currentDirectory 可能是绝对路径，但文件 API 只接受相对路径
-// 所以这里不再监听 currentDirectory 的变化来重新加载文件
-// 文件浏览始终显示项目根目录的内容
+// 监听当前目录变化，更新文件树工作目录
+watch(currentDirectory, async (newDir) => {
+  setFilesDirectory(newDir || undefined)
+  await loadFiles('.')
+})
 
 async function handleSend(content: string, files?: Array<{ type: 'file'; mime: string; filename: string; url: string }>, planMode?: boolean) {
   // sendMessage 会自动处理草稿模式，在发送前创建会话

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -42,6 +42,9 @@ const {
   clearSessionError,
   deleteSession,
   renameSession,
+  // 工作目录管理
+  changeDirectory,
+  canChangeDirectory,
   // 新增功能
   deleteMessagePart,
   updateMessagePart,
@@ -239,6 +242,8 @@ function closeFileViewer() {
       :files="files"
       :filesLoading="filesLoading"
       :activeTab="sidebarTab"
+      :currentDirectory="currentDirectory"
+      :canChangeDirectory="canChangeDirectory()"
       :isSessionRunning="isSessionRunning"
       :runningCount="runningCount"
       :maxParallelAgents="MAX_PARALLEL_AGENTS"
@@ -251,6 +256,7 @@ function closeFileViewer() {
       @rename-session="renameSession"
       @file-click="handleFileClick"
       @abort-session="abortSession"
+      @change-directory="changeDirectory"
     />
 
     <!-- Main Content -->
@@ -277,6 +283,8 @@ function closeFileViewer() {
           :pendingQuestions="pendingQuestions"
           :pendingPermissions="pendingPermissions"
           :sessionError="sessionError"
+          :currentDirectory="currentDirectory"
+          :canChangeDirectory="canChangeDirectory()"
           @question-answered="(id, answers) => answerQuestion(id, answers)"
           @question-rejected="rejectQuestion"
           @permission-responded="respondPermission"
@@ -284,6 +292,7 @@ function closeFileViewer() {
           @open-settings="openSettings"
           @delete-part="handleDeletePart"
           @update-part="handleUpdatePart"
+          @change-directory="changeDirectory"
         />
         <InputBox
           :disabled="isLoading"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -311,15 +311,16 @@ export const api = {
     return true
   },
 
-  // 更新会话（重命名等）
-  async updateSession(sessionId: string, updates: { title?: string }): Promise<Session> {
+  // 更新会话（重命名、修改工作目录等）
+  async updateSession(sessionId: string, updates: { title?: string; directory?: string }): Promise<Session> {
     const res = await fetch(`${BASE_URL}/session/${sessionId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(updates)
     })
     if (!res.ok) {
-      throw new Error(`Failed to update session: ${res.status}`)
+      const errorData = await res.json().catch(() => ({}))
+      throw new Error(errorData.error || `Failed to update session: ${res.status}`)
     }
     const data = await res.json()
     const session = data.data || data
@@ -414,6 +415,27 @@ export const api = {
     const res = await fetch(`${BASE_URL}/project`)
     const data = await res.json()
     return data.data || []
+  },
+
+  // 浏览目录（用于目录选择器）
+  async browseDirectory(path: string = '~'): Promise<{
+    path: string
+    parent: string | null
+    items: Array<{
+      name: string
+      path: string
+      type: 'file' | 'directory'
+      size?: number
+      modified?: number
+    }>
+  }> {
+    const params = new URLSearchParams({ path })
+    const res = await fetch(`${BASE_URL}/browse?${params}`)
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to browse directory: ${res.status}`)
+    }
+    return res.json()
   },
 
   // 订阅事件流（带自动重连）

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -379,9 +379,10 @@ export const api = {
   },
 
   // 获取文件列表
-  async getFiles(path: string = ''): Promise<FileItem[]> {
+  async getFiles(path: string = '', directory?: string): Promise<FileItem[]> {
     const params = new URLSearchParams()
     if (path) params.set('path', path)
+    if (directory) params.set('directory', directory)
     const res = await fetch(`${BASE_URL}/file?${params}`)
     const data = await res.json()
     // API 直接返回数组
@@ -389,8 +390,9 @@ export const api = {
   },
 
   // 获取文件内容
-  async getFileContent(path: string): Promise<FileContent> {
+  async getFileContent(path: string, directory?: string): Promise<FileContent> {
     const params = new URLSearchParams({ path })
+    if (directory) params.set('directory', directory)
     const res = await fetch(`${BASE_URL}/file/content?${params}`)
     if (!res.ok) {
       throw new Error(`Failed to get file content: ${res.status}`)

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -5,6 +5,7 @@ import type { Message, QuestionRequest, PermissionRequest } from '../api/client'
 import MessageItem from './MessageItem.vue'
 import AgentQuestion from './AgentQuestion.vue'
 import PermissionRequestVue from './PermissionRequest.vue'
+import DirectoryBrowser from './DirectoryBrowser.vue'
 
 const props = defineProps<{
   messages: Message[]
@@ -29,31 +30,30 @@ const emit = defineEmits<{
 }>()
 
 const scrollContainer = ref<HTMLDivElement>()
-const folderInputRef = ref<HTMLInputElement>()
+const showDirectoryBrowser = ref(false)
 
-// 打开系统原生的文件夹选择器
-function openFolderSelector() {
-  folderInputRef.value?.click()
+// 打开目录浏览器弹窗
+function openDirectoryBrowser() {
+  showDirectoryBrowser.value = true
 }
 
-// 处理文件夹选择
-function handleFolderSelect(e: Event) {
-  const target = e.target as HTMLInputElement
-  if (target.files && target.files.length > 0) {
-    // webkitdirectory 会返回选中文件夹中的所有文件
-    // 我们需要从文件路径中提取目录路径
-    const firstFile = target.files[0]
-    // webkitRelativePath 格式: "foldername/subfolder/file.txt"
-    const relativePath = (firstFile as any).webkitRelativePath || ''
-    if (relativePath) {
-      // 获取选中的文件夹名称（相对路径的第一部分）
-      const folderName = relativePath.split('/')[0]
-      // 由于浏览器安全限制，无法获取完整的绝对路径
-      // 我们只能传递文件夹名称，让后端在当前工作目录下查找
-      emit('changeDirectory', folderName)
-    }
-    target.value = ''  // 重置以允许重新选择相同文件夹
-  }
+// 处理目录选择
+function handleDirectorySelect(path: string) {
+  showDirectoryBrowser.value = false
+  emit('changeDirectory', path)
+}
+
+// 取消目录选择
+function handleDirectoryCancel() {
+  showDirectoryBrowser.value = false
+}
+
+// 获取目录显示名称
+function getDirectoryName(path: string): string {
+  if (!path || path === '~' || path === '.') return ''
+  // 处理 Windows 和 Unix 路径
+  const parts = path.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || path
 }
 
 watch(() => props.messages, async () => {
@@ -112,19 +112,10 @@ function scrollToBottom() {
 
       <!-- Directory Selector Button (shown only for draft/new sessions) -->
       <div v-if="canChangeDirectory" class="directory-selector-section">
-        <!-- 隐藏的文件夹选择 input -->
-        <input
-          ref="folderInputRef"
-          type="file"
-          webkitdirectory
-          style="display: none"
-          @change="handleFolderSelect"
-        />
-
-        <button class="directory-btn" @click="openFolderSelector">
+        <button class="directory-btn" @click="openDirectoryBrowser">
           <FolderOpen :size="20" />
           <span class="directory-btn-text">
-            {{ currentDirectory ? `工作目录: ${currentDirectory.split('/').pop()}` : '选择工作目录' }}
+            {{ currentDirectory && getDirectoryName(currentDirectory) ? `工作目录: ${getDirectoryName(currentDirectory)}` : '选择工作目录' }}
           </span>
         </button>
         <p class="directory-hint">选择一个工作目录来开始你的项目</p>
@@ -166,6 +157,14 @@ function scrollToBottom() {
       <!-- Added extra space at bottom for scrolling past the input box -->
       <div class="bottom-spacer"></div>
     </div>
+
+    <!-- Directory Browser Modal -->
+    <DirectoryBrowser
+      :visible="showDirectoryBrowser"
+      :initial-path="currentDirectory || '~'"
+      @select="handleDirectorySelect"
+      @cancel="handleDirectoryCancel"
+    />
   </div>
 </template>
 

--- a/web/src/components/DirectoryBrowser.vue
+++ b/web/src/components/DirectoryBrowser.vue
@@ -1,0 +1,364 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted } from 'vue'
+import { Folder, FolderOpen, ChevronUp, X, Loader2, AlertCircle, Home } from 'lucide-vue-next'
+import { api } from '../api/client'
+
+interface DirectoryItem {
+  name: string
+  path: string
+  type: 'file' | 'directory'
+  size?: number
+  modified?: number
+}
+
+const props = defineProps<{
+  visible: boolean
+  initialPath?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', path: string): void
+  (e: 'cancel'): void
+}>()
+
+const currentPath = ref('')
+const parentPath = ref<string | null>(null)
+const items = ref<DirectoryItem[]>([])
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+
+// 加载目录内容
+async function loadDirectory(path: string) {
+  isLoading.value = true
+  error.value = null
+
+  try {
+    const result = await api.browseDirectory(path)
+    currentPath.value = result.path
+    parentPath.value = result.parent
+    // 只显示目录，过滤掉文件
+    items.value = result.items.filter(item => item.type === 'directory')
+  } catch (e: any) {
+    error.value = e.message || '无法访问此目录'
+    // 如果是首次加载失败，尝试加载主目录
+    if (!currentPath.value) {
+      try {
+        const fallback = await api.browseDirectory('~')
+        currentPath.value = fallback.path
+        parentPath.value = fallback.parent
+        items.value = fallback.items.filter(item => item.type === 'directory')
+        error.value = null
+      } catch {
+        // 忽略回退错误
+      }
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// 返回上级目录
+function navigateUp() {
+  if (parentPath.value) {
+    loadDirectory(parentPath.value)
+  }
+}
+
+// 进入子目录
+function navigateTo(item: DirectoryItem) {
+  loadDirectory(item.path)
+}
+
+// 返回主目录
+function navigateHome() {
+  loadDirectory('~')
+}
+
+// 确认选择
+function confirm() {
+  emit('select', currentPath.value)
+}
+
+// 取消
+function cancel() {
+  emit('cancel')
+}
+
+// 点击遮罩关闭
+function handleOverlayClick(e: MouseEvent) {
+  if ((e.target as HTMLElement).classList.contains('modal-overlay')) {
+    cancel()
+  }
+}
+
+// 键盘事件处理
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && props.visible) {
+    cancel()
+  }
+}
+
+// 获取目录显示名称
+function getDisplayPath(path: string): string {
+  // Windows 路径处理
+  if (path.includes('\\')) {
+    return path
+  }
+  return path
+}
+
+// 监听 visible 变化，加载初始目录
+watch(() => props.visible, (visible) => {
+  if (visible) {
+    const path = props.initialPath || '~'
+    loadDirectory(path)
+  }
+})
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="modal-overlay" @click="handleOverlayClick">
+      <div class="modal directory-browser-modal">
+        <!-- Header -->
+        <div class="modal-header">
+          <h2 class="modal-title">选择工作目录</h2>
+          <button class="btn btn-ghost btn-icon sm" @click="cancel">
+            <X :size="18" />
+          </button>
+        </div>
+
+        <!-- Current Path Bar -->
+        <div class="directory-path-bar">
+          <button
+            class="path-btn home-btn"
+            @click="navigateHome"
+            title="返回主目录"
+          >
+            <Home :size="16" />
+          </button>
+          <button
+            class="path-btn up-btn"
+            @click="navigateUp"
+            :disabled="!parentPath"
+            title="返回上级目录"
+          >
+            <ChevronUp :size="16" />
+          </button>
+          <div class="current-path">
+            <FolderOpen :size="16" class="path-icon" />
+            <span class="path-text">{{ getDisplayPath(currentPath) }}</span>
+          </div>
+        </div>
+
+        <!-- Directory List -->
+        <div class="modal-body directory-list">
+          <!-- Loading State -->
+          <div v-if="isLoading" class="directory-state">
+            <Loader2 :size="24" class="spin" />
+            <span>加载中...</span>
+          </div>
+
+          <!-- Error State -->
+          <div v-else-if="error" class="directory-state error">
+            <AlertCircle :size="24" />
+            <span>{{ error }}</span>
+            <button class="btn btn-secondary btn-sm" @click="navigateHome">
+              返回主目录
+            </button>
+          </div>
+
+          <!-- Empty State -->
+          <div v-else-if="items.length === 0" class="directory-state">
+            <Folder :size="24" />
+            <span>此目录下没有子目录</span>
+          </div>
+
+          <!-- Directory Items -->
+          <div v-else class="directory-items">
+            <button
+              v-for="item in items"
+              :key="item.path"
+              class="directory-item"
+              @click="navigateTo(item)"
+              @dblclick="navigateTo(item)"
+            >
+              <Folder :size="18" class="item-icon" />
+              <span class="item-name">{{ item.name }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="modal-footer">
+          <button class="btn btn-secondary" @click="cancel">
+            取消
+          </button>
+          <button class="btn btn-primary" @click="confirm" :disabled="!currentPath">
+            选择此目录
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.directory-browser-modal {
+  width: 90%;
+  max-width: 550px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.directory-path-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.path-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+}
+
+.path-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.path-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.current-path {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--bg-primary);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  min-width: 0;
+}
+
+.path-icon {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.path-text {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.directory-list {
+  flex: 1;
+  min-height: 200px;
+  max-height: 400px;
+  padding: var(--space-sm) !important;
+}
+
+.directory-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  height: 100%;
+  min-height: 150px;
+  color: var(--text-tertiary);
+}
+
+.directory-state.error {
+  color: var(--status-error);
+}
+
+.directory-state .spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.directory-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.directory-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+  width: 100%;
+}
+
+.directory-item:hover {
+  background: var(--bg-secondary);
+}
+
+.directory-item:active {
+  background: var(--bg-tertiary);
+}
+
+.item-icon {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.item-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.875rem;
+}
+
+.modal-footer {
+  gap: var(--space-sm);
+}
+
+.btn-sm {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: 0.8125rem;
+}
+</style>

--- a/web/src/components/MessageItem.vue
+++ b/web/src/components/MessageItem.vue
@@ -61,6 +61,8 @@ marked.setOptions({
 const displayParts = computed(() => {
   const result: Array<{ type: string; part: MessagePart; index: number }> = []
   props.message.parts.forEach((part, index) => {
+    // 过滤 synthetic 文本（系统生成的上传描述等），不在用户气泡中显示
+    if (part.type === 'text' && (part as any).synthetic) return
     if (part.type === 'text' && part.text) {
       result.push({ type: 'text', part, index })
     } else if (part.type === 'tool') {
@@ -78,6 +80,14 @@ const displayParts = computed(() => {
 function isImageFile(part: MessagePart): boolean {
   const mime = (part as any).mime || ''
   return mime.startsWith('image/')
+}
+
+// 将 file:// URL 转为 HTTP URL（浏览器无法加载 file:// 协议）
+function resolveFileUrl(url: string): string {
+  if (url.startsWith('file://')) {
+    return `/file/upload?path=${encodeURIComponent(url.slice(7))}`
+  }
+  return url
 }
 
 // Image preview state
@@ -145,15 +155,15 @@ function formatText(text: string): string {
           <div v-else-if="item.type === 'file'" class="file-attachment">
             <img
               v-if="isImageFile(item.part)"
-              :src="(item.part as any).url"
+              :src="resolveFileUrl((item.part as any).url)"
               :alt="(item.part as any).filename || 'Uploaded image'"
               class="uploaded-image"
-              @click="openImagePreview((item.part as any).url)"
+              @click="openImagePreview(resolveFileUrl((item.part as any).url))"
             />
-            <div v-else class="file-badge">
+            <a v-else :href="resolveFileUrl((item.part as any).url)" target="_blank" class="file-badge">
               <span class="file-icon">📄</span>
               <span class="file-name">{{ (item.part as any).filename || 'File' }}</span>
-            </div>
+            </a>
           </div>
 
           <!-- Tool Call -->
@@ -607,6 +617,14 @@ function formatText(text: string): string {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: 13px;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.file-badge:hover {
+  background: var(--bg-elevated);
 }
 
 .file-icon {

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -156,7 +156,7 @@ function getSessionTitle(session: Session): string {
           <DirectorySelector
             :model-value="currentDirectory"
             :disabled="!canChangeDirectory"
-            @update:model-value="(val) => emit('change-directory', val)"
+            @update:model-value="(val: string) => emit('change-directory', val)"
           />
         </div>
         <div

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -3,8 +3,6 @@ import { ref } from 'vue'
 import { ChevronsLeft, ChevronsRight, MessageSquare, Plus, Folder, MessagesSquare, Pencil, Trash2, X, Check, Loader2, Square } from 'lucide-vue-next'
 import type { Session, FileItem } from '../api/client'
 import FileTree from './FileTree.vue'
-import DirectorySelector from './DirectorySelector.vue'
-
 defineProps<{
   collapsed: boolean
   sessions: Session[]
@@ -152,12 +150,6 @@ function getSessionTitle(session: Session): string {
               <span class="session-item-time">未保存</span>
             </div>
           </div>
-          <!-- 目录选择器 -->
-          <DirectorySelector
-            :model-value="currentDirectory"
-            :disabled="!canChangeDirectory"
-            @update:model-value="(val: string) => emit('change-directory', val)"
-          />
         </div>
         <div
           v-for="session in sessions"

--- a/web/src/composables/useFiles.ts
+++ b/web/src/composables/useFiles.ts
@@ -11,6 +11,7 @@ export function useFiles() {
   const files = ref<FileTreeNode[]>([])
   const isLoading = ref(false)
   const currentPath = ref('')
+  const currentDirectory = ref<string | undefined>(undefined)
 
   // 文件内容查看
   const fileContent = ref<FileContent | null>(null)
@@ -22,11 +23,16 @@ export function useFiles() {
   const isSearching = ref(false)
   const searchError = ref<string | null>(null)
 
+  // 设置工作目录
+  function setDirectory(directory: string | undefined) {
+    currentDirectory.value = directory
+  }
+
   async function loadFiles(path: string = '') {
     try {
       isLoading.value = true
       currentPath.value = path
-      const items = await api.getFiles(path)
+      const items = await api.getFiles(path, currentDirectory.value)
 
       // 排序：目录在前，文件在后，按名称排序
       files.value = items
@@ -53,7 +59,7 @@ export function useFiles() {
 
     node.isLoading = true
     try {
-      const children = await api.getFiles(node.path)
+      const children = await api.getFiles(node.path, currentDirectory.value)
       node.children = children
         .map(item => ({ ...item, children: undefined, isExpanded: false, isLoading: false }))
         .sort((a, b) => {
@@ -73,7 +79,7 @@ export function useFiles() {
     isLoadingContent.value = true
     contentError.value = null
     try {
-      fileContent.value = await api.getFileContent(path)
+      fileContent.value = await api.getFileContent(path, currentDirectory.value)
     } catch (error: any) {
       console.error('Failed to load file content:', error)
       contentError.value = error.message || '无法加载文件内容'
@@ -119,6 +125,8 @@ export function useFiles() {
     files,
     isLoading,
     currentPath,
+    currentDirectory,
+    setDirectory,
     loadFiles,
     toggleDirectory,
     // 文件内容


### PR DESCRIPTION
描述 / Summary
为新建会话添加工作目录选择功能。用户可以在开始对话前选择一个工作目录，点击按钮后会弹出系统原生的文件夹选择器。

类型 / Type of change
 新功能 (feature)
 Bug 修复 (bugfix)
 文档 (docs)
 重构 (refactor)
 其他 (describe):
关联的 issue（如果有）/ Related issues
无

变更点 / What changed
在聊天欢迎界面（"Hello, I'm Nine1Bot"下方）添加工作目录选择按钮
使用系统原生文件夹选择器（通过 <input type="file" webkitdirectory>）
后端新增 /browse API 端点用于目录浏览
Session API 支持 directory 参数（创建和更新时）
修复 nine1bot 配置中 inheritOpencode/inheritClaudeCode 字段导致的 opencode 配置验证错误
新会话（草稿模式）或无消息的会话可以修改工作目录，发送消息后目录锁定
如何测试 / How to test
启动服务 bun run packages/nine1bot/src/index.ts start --port 5002
打开浏览器访问 http://localhost:5002/
点击左侧 "+ 新对话" 创建新会话
在聊天区域中央可以看到"选择工作目录"按钮
点击按钮，系统会弹出原生的文件夹选择对话框
选择一个文件夹后，按钮文字会更新显示选中的目录名
发送一条消息后，目录选择按钮消失（目录已锁定）
截图（UI 变更时提供）/ Screenshots for UI changed
工作目录选择按钮位于欢迎界面正中央，"How can I help you today?" 文字下方，点击后触发系统原生文件选择器。

Checklist（合并前请确认） / Checklist
 本地已通过测试
备注 / Notes for reviewers
由于浏览器安全限制，webkitdirectory 只能获取文件夹的相对路径名称，无法获取完整绝对路径
修复了 packages/nine1bot/src/launcher/server.ts 中的配置过滤逻辑，确保 mcp.inheritOpencode 等字段不会传递给 opencode 导致验证失败