### PR TITLE
feat: migrate browser relay to embedded runtime diagnostics

### DIFF
--- a/opencode/packages/opencode/src/tool/browser.ts
+++ b/opencode/packages/opencode/src/tool/browser.ts
@@ -61,6 +61,29 @@ Call this first to discover which browsers are available and get tab IDs.`,
       }
     }
 
+    if (status.runtime) {
+      lines.push(`Runtime: ${status.runtime.mode} @ ${status.runtime.serverOrigin}`)
+      lines.push(`  Instance: ${status.runtime.instanceId}`)
+      lines.push(
+        `  Extension handshake: ${status.runtime.extension.connected ? "connected" : "disconnected"}`
+        + `${status.runtime.extension.version ? ` (v${status.runtime.extension.version})` : ""}`,
+      )
+
+      if (status.runtime.extension.serverOrigin || status.runtime.extension.pairedInstanceId) {
+        lines.push(
+          `  Extension pairing: ${status.runtime.extension.serverOrigin ?? "unknown origin"}`
+          + `${status.runtime.extension.pairedInstanceId ? ` / ${status.runtime.extension.pairedInstanceId}` : ""}`,
+        )
+      }
+
+      for (const conflict of status.runtime.conflicts) {
+        lines.push(`  Warning: ${conflict.message}`)
+      }
+      for (const issue of status.runtime.issues) {
+        lines.push(`  ${issue.severity === "error" ? "Error" : "Warning"}: ${issue.message}`)
+      }
+    }
+
     return {
       title: "Browser status",
       output: lines.join("\n"),
@@ -519,7 +542,7 @@ Parameters:
     }
 
     const lines = matches.map(
-      (m, i) =>
+      (m: any, i: number) =>
         `${i + 1}. [${m.ref}] <${m.tag}>${m.role ? ` role=${m.role}` : ""}${m.label ? ` label="${m.label}"` : ""}\n   ${m.text ? `Text: "${m.text.slice(0, 80)}"` : "(no text)"}   Score: ${m.score}`,
     )
 
@@ -604,6 +627,100 @@ Parameters:
       title: "JavaScript executed",
       output: `Result:\n${output}`,
       metadata: {},
+    }
+  },
+})
+
+// ==================== 15. browser_console_messages ====================
+
+export const BrowserConsoleMessagesTool = Tool.define("browser_console_messages", {
+  description: `Capture console messages from the user browser tab (extension channel, on-demand sampling).
+
+Parameters:
+- tabId: Tab ID
+- sampleMs: Sampling window in ms (default: 1500)
+- max: Maximum entries (default: 50)
+- sinceMs: Only include entries newer than now-sinceMs
+- level: Optional level filter (log, warning, error, etc.)`,
+  parameters: z.object({
+    tabId: z.string().describe("Tab ID"),
+    browser: browserParam,
+    sampleMs: z.number().optional().describe("Sampling window in ms (default: 1500)"),
+    max: z.number().optional().describe("Maximum entries (default: 50)"),
+    sinceMs: z.number().optional().describe("Only include entries newer than now-sinceMs"),
+    level: z.string().optional().describe("Console level filter"),
+  }),
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "browser_console_messages",
+      patterns: ["*"],
+      always: ["*"],
+      metadata: { tabId: params.tabId },
+    })
+
+    const bridge = requireBridge()
+    const entries = await bridge.readConsoleMessages(
+      params.tabId,
+      {
+        sampleMs: params.sampleMs,
+        max: params.max,
+        sinceMs: params.sinceMs,
+        level: params.level,
+      },
+      params.browser as BrowserTarget | undefined,
+    )
+
+    return {
+      title: `Console messages (${entries.length})`,
+      output: JSON.stringify(entries, null, 2),
+      metadata: { count: entries.length },
+    }
+  },
+})
+
+// ==================== 16. browser_network_requests ====================
+
+export const BrowserNetworkRequestsTool = Tool.define("browser_network_requests", {
+  description: `Capture network requests from the user browser tab (extension channel, on-demand sampling).
+
+Parameters:
+- tabId: Tab ID
+- sampleMs: Sampling window in ms (default: 1500)
+- max: Maximum entries (default: 50)
+- sinceMs: Only include entries newer than now-sinceMs
+- resourceType: Optional filter (Document, Script, XHR, Fetch, etc.)`,
+  parameters: z.object({
+    tabId: z.string().describe("Tab ID"),
+    browser: browserParam,
+    sampleMs: z.number().optional().describe("Sampling window in ms (default: 1500)"),
+    max: z.number().optional().describe("Maximum entries (default: 50)"),
+    sinceMs: z.number().optional().describe("Only include entries newer than now-sinceMs"),
+    resourceType: z.string().optional().describe("Network resource type filter"),
+  }),
+  async execute(params, ctx) {
+    await ctx.ask({
+      permission: "browser_network_requests",
+      patterns: ["*"],
+      always: ["*"],
+      metadata: { tabId: params.tabId },
+    })
+
+    const bridge = requireBridge()
+    const entries = await bridge.readNetworkRequests(
+      params.tabId,
+      {
+        sampleMs: params.sampleMs,
+        max: params.max,
+        sinceMs: params.sinceMs,
+        resourceType: params.resourceType,
+      },
+      params.browser as BrowserTarget | undefined,
+    )
+
+    return {
+      title: `Network requests (${entries.length})`,
+      output: JSON.stringify(entries, null, 2),
+      metadata: { count: entries.length },
     }
   },
 })

--- a/packages/browser-extension/manifest.json
+++ b/packages/browser-extension/manifest.json
@@ -2,14 +2,18 @@
   "manifest_version": 3,
   "name": "Nine1Bot Browser Control",
   "version": "0.1.0",
-  "description": "Browser automation and control for Nine1Bot via MCP protocol",
+  "description": "Browser automation and control for Nine1Bot via the built-in browser relay",
   "permissions": [
     "tabs",
     "activeTab",
     "scripting",
     "debugger",
     "storage",
-    "webNavigation"
+    "webNavigation",
+    "tabGroups",
+    "sidePanel",
+    "offscreen",
+    "notifications"
   ],
   "host_permissions": [
     "<all_urls>"
@@ -39,5 +43,20 @@
       "128": "icons/icon128.png"
     },
     "default_title": "Nine1Bot Browser Control"
+  },
+  "side_panel": {
+    "default_path": "sidepanel/index.html"
+  },
+  "commands": {
+    "open-side-panel": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+E",
+        "mac": "Command+Shift+E"
+      },
+      "description": "Open Nine1Bot Side Panel"
+    }
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; frame-src 'self' http://127.0.0.1:* http://localhost:* https://127.0.0.1:* https://localhost:*"
   }
 }

--- a/packages/browser-extension/sidepanel/index.html
+++ b/packages/browser-extension/sidepanel/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nine1Bot Browser Control</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f4f7fb;
+        color: #122033;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        background:
+          radial-gradient(circle at top right, rgba(79, 124, 255, 0.14), transparent 32%),
+          linear-gradient(180deg, #f8fbff 0%, #eef4fb 100%);
+      }
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 14px;
+        border-bottom: 1px solid rgba(18, 32, 51, 0.08);
+        background: rgba(255, 255, 255, 0.84);
+        backdrop-filter: blur(8px);
+      }
+
+      .title {
+        font-size: 14px;
+        font-weight: 700;
+      }
+
+      #status {
+        font-size: 12px;
+        color: #6c7a90;
+      }
+
+      #status.connected {
+        color: #14774b;
+      }
+
+      button {
+        border: 0;
+        border-radius: 999px;
+        padding: 8px 12px;
+        background: #1f5eff;
+        color: white;
+        cursor: pointer;
+        font-size: 12px;
+      }
+
+      main {
+        position: relative;
+        flex: 1;
+        min-height: 0;
+      }
+
+      #app-frame {
+        border: 0;
+        width: 100%;
+        height: 100%;
+        min-height: calc(100vh - 62px);
+        background: white;
+      }
+
+      #fallback {
+        display: none;
+        box-sizing: border-box;
+        margin: 16px;
+        padding: 16px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.95);
+        border: 1px solid rgba(18, 32, 51, 0.08);
+      }
+
+      #fallback.visible {
+        display: block;
+      }
+
+      code {
+        display: inline-block;
+        margin-top: 8px;
+        padding: 4px 6px;
+        border-radius: 8px;
+        background: #eef3ff;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <div class="title">Nine1Bot Side Panel</div>
+        <div id="status">checking relay...</div>
+      </div>
+      <button id="reload" type="button">Reload</button>
+    </header>
+    <main>
+      <section id="fallback" aria-live="polite">
+        <strong>Unable to load the embedded UI.</strong>
+        <div id="fallback-copy">The side panel will retry the configured server URL below.</div>
+        <code id="target-url"></code>
+      </section>
+      <iframe id="app-frame" title="Nine1Bot UI"></iframe>
+    </main>
+    <script type="module" src="/src/sidepanel/index.ts"></script>
+  </body>
+</html>

--- a/packages/browser-extension/src/background/diagnostics-buffer.ts
+++ b/packages/browser-extension/src/background/diagnostics-buffer.ts
@@ -1,0 +1,14 @@
+let listenersInstalled = false
+
+export function setupDiagnosticsListeners(): void {
+  if (listenersInstalled) return
+  listenersInstalled = true
+
+  self.addEventListener('error', (event) => {
+    console.warn('[Relay Client] Unhandled background error:', event.message)
+  })
+
+  self.addEventListener('unhandledrejection', (event) => {
+    console.warn('[Relay Client] Unhandled background rejection:', event.reason)
+  })
+}

--- a/packages/browser-extension/src/background/index.ts
+++ b/packages/browser-extension/src/background/index.ts
@@ -2,19 +2,14 @@
  * Nine1Bot Browser Control Extension - Service Worker
  *
  * This is the main entry point for the Chrome extension's background service worker.
- * It initializes both the MCP server (for direct connections) and the Relay Client
- * (for connecting to Nine1Bot Bridge Server).
+ * It initializes the Relay Client that connects to Nine1Bot's built-in /browser relay.
  */
 
-import { setupMcpServer } from './mcp-server'
-import { initRelayClient, isRelayConnected, connectToRelay, disconnectFromRelay } from './relay-client'
+import { initRelayClient, isRelayConnected, connectToRelay } from './relay-client'
 
 console.log('[Nine1Bot Browser Control] Service Worker starting...')
 
-// Initialize MCP server (for backward compatibility)
-setupMcpServer()
-
-// Initialize Relay Client (connects to Bridge Server)
+// Initialize Relay Client (connects to the built-in browser relay)
 initRelayClient()
 
 // Extension installation/update handler
@@ -40,19 +35,30 @@ chrome.runtime.onStartup.addListener(() => {
 chrome.action.onClicked.addListener((tab) => {
   console.log('[Nine1Bot Browser Control] Extension icon clicked, tab:', tab.id)
 
-  // Show connection status
-  const connected = isRelayConnected()
-  console.log('[Nine1Bot Browser Control] Relay connection status:', connected ? 'Connected' : 'Disconnected')
-
-  if (tab.id) {
-    chrome.tabs.get(tab.id, (tabInfo) => {
-      console.log('[Nine1Bot Browser Control] Current tab info:', {
-        url: tabInfo.url,
-        title: tabInfo.title,
-        relayConnected: connected,
-      })
+  // Prefer opening side panel on icon click
+  const windowId = tab.windowId
+  chrome.sidePanel
+    .open({ windowId })
+    .catch((error) => {
+      console.warn('[Nine1Bot Browser Control] Failed to open side panel:', error)
     })
+})
+
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command !== 'open-side-panel') return
+  const windowId = tab?.windowId
+  if (windowId === undefined) return
+  chrome.sidePanel.open({ windowId }).catch((error) => {
+    console.warn('[Nine1Bot Browser Control] Failed to open side panel via command:', error)
+  })
+})
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === 'nine1bot-sidepanel-health-check') {
+    sendResponse({ connected: isRelayConnected() })
+    return true
   }
+  return false
 })
 
 // Keep service worker alive periodically
@@ -65,4 +71,4 @@ setInterval(() => {
 }, KEEP_ALIVE_INTERVAL)
 
 console.log('[Nine1Bot Browser Control] Service Worker initialized')
-console.log('[Nine1Bot Browser Control] Relay Client will connect to ws://127.0.0.1:4096/browser/extension')
+console.log('[Nine1Bot Browser Control] Relay Client will connect to the configured Nine1Bot /browser/extension endpoint')

--- a/packages/browser-extension/src/background/relay-client.ts
+++ b/packages/browser-extension/src/background/relay-client.ts
@@ -1,46 +1,153 @@
 /**
  * Relay Client - 连接到 Nine1Bot Bridge Server 的 Extension Relay
  *
- * 这个模块负责：
+ * 负责：
  * 1. 建立与 Bridge Server 的 WebSocket 连接
  * 2. 接收并执行 CDP 命令
  * 3. 将 CDP 事件转发回 Bridge Server
+ * 4. 维护命令生命周期（超时、取消、状态心跳）
  */
 
 import { toolExecutors } from '../tools'
+import { isAbortError } from '../tools/execution-context'
+import { setupDiagnosticsListeners } from './diagnostics-buffer'
+import {
+  addTabToNine1Group,
+  getTabsInGroupByTab,
+  setNine1GroupActive,
+  setNine1GroupIdle,
+  setupTabGroupCleanup,
+} from './tab-group-manager'
 
-// 配置 - relay URL 可通过 chrome.storage.sync 修改
-const DEFAULT_RELAY_URL = 'ws://127.0.0.1:4096/browser/extension'
+const DEFAULT_SERVER_ORIGIN = 'http://127.0.0.1:4096'
+const EXTENSION_PROTOCOL_VERSION = '2026-03-15'
 
-/**
- * 从 chrome.storage.sync 获取 relay URL（支持用户自定义）
- */
-async function getConfiguredRelayUrl(): Promise<string> {
+const RECONNECT_BASE_INTERVAL = 5000
+const RECONNECT_MAX_INTERVAL = 60000
+const HEALTH_REPORT_INTERVAL = 60000
+const AGENT_HEARTBEAT_INTERVAL = 1500
+const DEFAULT_TOOL_TIMEOUT_MS = 30000
+
+let configuredServerOrigin = DEFAULT_SERVER_ORIGIN
+let pairedInstanceId: string | null = null
+
+function normalizeServerOrigin(serverOrigin: string): string {
   try {
-    const { relayUrl } = await chrome.storage.sync.get({ relayUrl: DEFAULT_RELAY_URL })
-    return relayUrl
+    const parsed = new URL(serverOrigin)
+    return `${parsed.protocol}//${parsed.host}`
   } catch {
-    return DEFAULT_RELAY_URL
+    return DEFAULT_SERVER_ORIGIN
   }
 }
-const RECONNECT_INTERVAL = 5000
-const PING_INTERVAL = 5000
+
+function serverOriginToRelayUrl(serverOrigin: string): string {
+  const parsed = new URL(serverOrigin)
+  const protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${parsed.host}/browser/extension`
+}
+
+function relayUrlToServerOrigin(relayUrl: string): string {
+  try {
+    const parsed = new URL(relayUrl)
+    const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:'
+    return `${protocol}//${parsed.host}`
+  } catch {
+    return DEFAULT_SERVER_ORIGIN
+  }
+}
+
+async function migrateLegacyServerConfig(): Promise<string> {
+  try {
+    const stored = await chrome.storage.sync.get({
+      serverOrigin: '',
+      relayUrl: '',
+      webUiUrl: '',
+    })
+
+    const fromServerOrigin = typeof stored.serverOrigin === 'string' && stored.serverOrigin.trim()
+      ? normalizeServerOrigin(stored.serverOrigin)
+      : ''
+    const fromWebUi = typeof stored.webUiUrl === 'string' && stored.webUiUrl.trim()
+      ? normalizeServerOrigin(stored.webUiUrl)
+      : ''
+    const fromRelay = typeof stored.relayUrl === 'string' && stored.relayUrl.trim()
+      ? relayUrlToServerOrigin(stored.relayUrl)
+      : ''
+
+    const serverOrigin = fromServerOrigin || fromWebUi || fromRelay || DEFAULT_SERVER_ORIGIN
+
+    if (serverOrigin !== stored.serverOrigin || stored.relayUrl || stored.webUiUrl) {
+      await chrome.storage.sync.set({ serverOrigin })
+      await chrome.storage.sync.remove(['relayUrl', 'webUiUrl'])
+    }
+
+    return serverOrigin
+  } catch {
+    return DEFAULT_SERVER_ORIGIN
+  }
+}
+
+async function fetchBootstrap(serverOrigin: string): Promise<{ serverOrigin?: string; instanceId?: string } | null> {
+  try {
+    const response = await fetch(`${serverOrigin}/browser/bootstrap`)
+    if (!response.ok) return null
+    return await response.json() as { serverOrigin?: string; instanceId?: string }
+  } catch {
+    return null
+  }
+}
+
+async function getConfiguredRelayUrl(): Promise<string> {
+  const storedServerOrigin = await migrateLegacyServerConfig()
+  const bootstrap = await fetchBootstrap(storedServerOrigin)
+  configuredServerOrigin = normalizeServerOrigin(bootstrap?.serverOrigin ?? storedServerOrigin)
+  pairedInstanceId = typeof bootstrap?.instanceId === 'string' ? bootstrap.instanceId : null
+
+  try {
+    await chrome.storage.sync.set({ serverOrigin: configuredServerOrigin })
+  } catch {
+    // ignore storage sync failures
+  }
+
+  return serverOriginToRelayUrl(configuredServerOrigin)
+}
+
+interface RunningCommand {
+  id: number
+  tabId?: number
+  method: string
+  toolName?: string
+  sessionId?: string
+  startedAt: number
+  controller: AbortController
+  cancelReason?: string
+  taskLabel?: string
+}
 
 // WebSocket 连接状态
 let ws: WebSocket | null = null
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
-let pingTimer: ReturnType<typeof setInterval> | null = null
+let healthTimer: ReturnType<typeof setInterval> | null = null
+let agentHeartbeatTimer: ReturnType<typeof setInterval> | null = null
 let isConnecting = false
+let intentionalDisconnect = false
+let reconnectAttempt = 0
+let lastPongAt = 0
 
 // 当前活动的标签页 session
 const activeSessions = new Map<number, string>() // tabId -> sessionId
+
+// 命令状态
+const runningCommands = new Map<number, RunningCommand>()
+const tabActiveCommandCount = new Map<number, number>()
+const tabStopRequestedAt = new Map<number, number>()
 
 /**
  * 生成唯一的 session ID
  */
 function generateSessionId(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(16))
-  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
   return `session_${Date.now()}_${hex}`
 }
 
@@ -63,6 +170,241 @@ function forwardCdpEvent(method: string, params?: unknown, sessionId?: string): 
   })
 }
 
+function sendExtensionHello(): void {
+  sendToRelay({
+    method: 'extension.hello',
+    params: {
+      version: chrome.runtime.getManifest().version,
+      protocolVersion: EXTENSION_PROTOCOL_VERSION,
+      serverOrigin: configuredServerOrigin,
+      pairedInstanceId,
+      tools: Object.keys(toolExecutors),
+      capabilities: {
+        cancelCDPCommand: true,
+        agentState: true,
+        diagnostics: true,
+      },
+    },
+  })
+}
+
+function sendExtensionHealth(): void {
+  sendToRelay({
+    method: 'extension.health',
+    params: {
+      timestamp: Date.now(),
+      lastPongAt,
+      activeCommands: runningCommands.size,
+      reconnectAttempt,
+    },
+  })
+}
+
+async function sendAgentStateToTabs(tabId: number, taskLabel?: string): Promise<void> {
+  const activeForTab = (tabActiveCommandCount.get(tabId) ?? 0) > 0
+  const stopRequestedAt = tabStopRequestedAt.get(tabId) ?? 0
+  const isStopping = !activeForTab && stopRequestedAt > 0 && Date.now() - stopRequestedAt < 5000
+  const state: 'active' | 'idle' | 'stopping' = activeForTab ? 'active' : isStopping ? 'stopping' : 'idle'
+  let groupTabs: number[] = [tabId]
+
+  try {
+    groupTabs = await getTabsInGroupByTab(tabId)
+  } catch {
+    groupTabs = [tabId]
+  }
+
+  const now = Date.now()
+  const sendPromises = groupTabs.map(async (targetTabId) => {
+    try {
+      await chrome.tabs.sendMessage(targetTabId, {
+        type: 'nine1bot-agent-state',
+        state,
+        heartbeatAt: now,
+        activeInThisTab: (activeForTab || isStopping) && targetTabId === tabId,
+        sameGroupActive: activeForTab && targetTabId !== tabId,
+        taskLabel,
+      })
+    } catch {
+      // ignore tabs where content script is unavailable
+    }
+  })
+
+  await Promise.all(sendPromises)
+
+  sendToRelay({
+    method: 'extension.agentState',
+    params: {
+      tabId,
+      state,
+      heartbeatAt: now,
+      taskLabel,
+    },
+  })
+
+  if (!isStopping && stopRequestedAt > 0) {
+    tabStopRequestedAt.delete(tabId)
+  }
+}
+
+function bumpTabActiveCount(tabId: number, delta: number): number {
+  const next = Math.max(0, (tabActiveCommandCount.get(tabId) ?? 0) + delta)
+  if (next === 0) {
+    tabActiveCommandCount.delete(tabId)
+  } else {
+    tabActiveCommandCount.set(tabId, next)
+  }
+  return next
+}
+
+async function markCommandStart(command: RunningCommand): Promise<void> {
+  if (command.tabId === undefined) return
+  tabStopRequestedAt.delete(command.tabId)
+  bumpTabActiveCount(command.tabId, 1)
+  await addTabToNine1Group(command.tabId, command.taskLabel)
+  await setNine1GroupActive(command.tabId, command.taskLabel)
+  await sendAgentStateToTabs(command.tabId, command.taskLabel)
+}
+
+async function markCommandFinish(command: RunningCommand): Promise<void> {
+  if (command.tabId === undefined) return
+  const remaining = bumpTabActiveCount(command.tabId, -1)
+  if (remaining === 0) {
+    await setNine1GroupIdle(command.tabId)
+  }
+  await sendAgentStateToTabs(command.tabId, command.taskLabel)
+}
+
+function startHealthReporting(): void {
+  if (healthTimer) return
+  healthTimer = setInterval(() => {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      sendExtensionHealth()
+    }
+  }, HEALTH_REPORT_INTERVAL)
+}
+
+function startAgentHeartbeat(): void {
+  if (agentHeartbeatTimer) return
+  agentHeartbeatTimer = setInterval(() => {
+    const activeTabs = Array.from(tabActiveCommandCount.keys())
+    for (const tabId of activeTabs) {
+      sendAgentStateToTabs(tabId).catch(() => {
+        // ignore heartbeat send errors
+      })
+    }
+  }, AGENT_HEARTBEAT_INTERVAL)
+}
+
+function stopTimers(): void {
+  if (healthTimer) {
+    clearInterval(healthTimer)
+    healthTimer = null
+  }
+  if (agentHeartbeatTimer) {
+    clearInterval(agentHeartbeatTimer)
+    agentHeartbeatTimer = null
+  }
+}
+
+function cancelRunningCommands(options: {
+  commandId?: number
+  tabId?: number
+  reason: string
+}): number {
+  const { commandId, tabId, reason } = options
+  let cancelled = 0
+
+  for (const [id, command] of runningCommands) {
+    if (commandId !== undefined && id !== commandId) continue
+    if (tabId !== undefined && command.tabId !== tabId) continue
+    if (command.controller.signal.aborted) continue
+
+    command.cancelReason = reason
+    command.controller.abort(reason)
+    cancelled += 1
+  }
+
+  return cancelled
+}
+
+async function executeExtensionToolCommand(options: {
+  commandId: number
+  tabId?: number
+  sessionId?: string
+  toolName: string
+  args: Record<string, unknown>
+  timeoutMs?: number
+  taskLabel?: string
+}): Promise<unknown> {
+  const { commandId, tabId, sessionId, toolName, args, timeoutMs, taskLabel } = options
+
+  const ALLOWED_TOOLS: ReadonlySet<string> = new Set(Object.keys(toolExecutors))
+  if (!ALLOWED_TOOLS.has(toolName)) {
+    throw new Error(`Unknown extension tool: ${toolName}. Available: ${[...ALLOWED_TOOLS].join(', ')}`)
+  }
+
+  const executor = toolExecutors[toolName as keyof typeof toolExecutors]
+  const toolArgs: Record<string, unknown> = { ...(args || {}) }
+  if (tabId && toolArgs.tabId === undefined) {
+    toolArgs.tabId = tabId
+  }
+
+  const controller = new AbortController()
+  const command: RunningCommand = {
+    id: commandId,
+    method: 'Extension.callTool',
+    toolName,
+    tabId,
+    sessionId,
+    startedAt: Date.now(),
+    controller,
+    taskLabel,
+  }
+
+  runningCommands.set(commandId, command)
+  await markCommandStart(command)
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+  if ((timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS) > 0) {
+    timeoutHandle = setTimeout(() => {
+      command.cancelReason = 'timeout'
+      controller.abort('timeout')
+    }, timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS)
+  }
+
+  try {
+    const result = await executor(toolArgs, {
+      signal: controller.signal,
+      commandId,
+      tabId,
+    })
+
+    if (controller.signal.aborted) {
+      const reason = command.cancelReason ?? 'cancelled'
+      throw new Error(reason === 'timeout' ? 'Command timeout' : `Command cancelled (${reason})`)
+    }
+
+    if (result.isError && result.content[0]?.text === 'Cancelled') {
+      throw new Error('Command cancelled (tool cooperative stop)')
+    }
+
+    return result
+  } catch (error) {
+    if (isAbortError(error) || controller.signal.aborted) {
+      const reason = command.cancelReason ?? 'cancelled'
+      throw new Error(reason === 'timeout' ? 'Command timeout' : `Command cancelled (${reason})`)
+    }
+    throw error
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
+      timeoutHandle = null
+    }
+    runningCommands.delete(commandId)
+    await markCommandFinish(command)
+  }
+}
+
 /**
  * 处理来自 Relay Server 的消息
  */
@@ -77,7 +419,18 @@ async function handleRelayMessage(data: string): Promise<void> {
 
   // 处理 ping
   if (message.method === 'ping') {
+    lastPongAt = Date.now()
     sendToRelay({ method: 'pong' })
+    return
+  }
+
+  if (message.method === 'cancelCDPCommand') {
+    const cancelled = cancelRunningCommands({
+      commandId: typeof message.params?.commandId === 'number' ? message.params.commandId : undefined,
+      tabId: typeof message.params?.tabId === 'number' ? message.params.tabId : undefined,
+      reason: message.params?.reason || 'server_cancel',
+    })
+    sendToRelay({ id: message.id, result: { cancelled } })
     return
   }
 
@@ -87,7 +440,7 @@ async function handleRelayMessage(data: string): Promise<void> {
     const { method, params, sessionId } = message.params || {}
 
     try {
-      const result = await handleCdpCommand(method, params, sessionId)
+      const result = await handleCdpCommand(id, method, params, sessionId)
       sendToRelay({ id, result })
     } catch (error) {
       sendToRelay({
@@ -102,9 +455,8 @@ async function handleRelayMessage(data: string): Promise<void> {
 /**
  * 处理 CDP 命令
  */
-async function handleCdpCommand(method: string, params: any, sessionId?: string): Promise<unknown> {
+async function handleCdpCommand(commandId: number, method: string, params: any, sessionId?: string): Promise<unknown> {
   console.log('[Relay Client] Handling CDP command:', method, 'sessionId:', sessionId)
-  console.log('[Relay Client] activeSessions:', Array.from(activeSessions.entries()))
 
   // 获取 tabId（从 sessionId 或使用当前活动标签）
   let tabId: number | undefined
@@ -114,72 +466,81 @@ async function handleCdpCommand(method: string, params: any, sessionId?: string)
     for (const [tid, sid] of activeSessions) {
       if (sid === sessionId) {
         tabId = tid
-        console.log('[Relay Client] Found tabId from sessionId:', tabId)
         break
       }
     }
   }
 
   if (!tabId) {
-    // 使用当前活动标签
-    console.log('[Relay Client] sessionId not found in activeSessions, using active tab')
     const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true })
     tabId = activeTab?.id
-    console.log('[Relay Client] Active tab:', tabId)
   }
 
   // 根据 CDP method 调用相应的工具
   switch (method) {
+    case 'cancelCDPCommand': {
+      const cancelled = cancelRunningCommands({
+        commandId: typeof params?.commandId === 'number' ? params.commandId : undefined,
+        tabId: typeof params?.tabId === 'number' ? params.tabId : tabId,
+        reason: params?.reason || 'cancelCDPCommand',
+      })
+      return { cancelled }
+    }
+
     // 扩展工具直接转发（不受 CSP 限制）
     case 'Extension.callTool': {
-      const { toolName, args } = params || {}
-      // 白名单校验：仅允许已注册的工具名
-      const ALLOWED_TOOLS: ReadonlySet<string> = new Set(Object.keys(toolExecutors))
-      if (typeof toolName !== 'string' || !ALLOWED_TOOLS.has(toolName)) {
-        throw new Error(`Unknown extension tool: ${toolName}. Available: ${[...ALLOWED_TOOLS].join(', ')}`)
+      const { toolName, args, timeoutMs, taskLabel } = params || {}
+
+      if (typeof toolName !== 'string') {
+        throw new Error('toolName is required for Extension.callTool')
       }
-      const executor = toolExecutors[toolName as keyof typeof toolExecutors]
-      const toolArgs: Record<string, unknown> = { ...(args || {}) }
-      if (tabId && toolArgs.tabId === undefined) {
-        toolArgs.tabId = tabId
-      }
-      return await executor(toolArgs)
+
+      return await executeExtensionToolCommand({
+        commandId,
+        tabId,
+        sessionId,
+        toolName,
+        args: (args ?? {}) as Record<string, unknown>,
+        timeoutMs: typeof timeoutMs === 'number' ? timeoutMs : undefined,
+        taskLabel: typeof taskLabel === 'string' ? taskLabel : undefined,
+      })
     }
 
     case 'Page.captureScreenshot': {
-      console.log('[Relay Client] Taking screenshot for tabId:', tabId)
-      const result = await toolExecutors.screenshot({ tabId })
-      console.log('[Relay Client] Screenshot result:', result.content[0]?.type, result.isError)
+      const result = await toolExecutors.screenshot({ tabId }, { commandId, signal: undefined, tabId })
       if (result.content[0]?.type === 'image' && result.content[0].data) {
         return { data: result.content[0].data }
       }
-      // Return error details if available
       const errorText = result.content[0]?.text || 'Screenshot failed'
       throw new Error(errorText)
     }
 
     case 'Page.navigate': {
-      const result = await toolExecutors.navigate({ tabId, url: params?.url })
+      await toolExecutors.navigate({ tabId, url: params?.url }, { commandId, signal: undefined, tabId })
       return { frameId: 'main' }
     }
 
     case 'Runtime.evaluate': {
       if (!tabId) throw new Error('No active tab')
 
-      const results = await chrome.scripting.executeScript({
-        target: { tabId },
-        func: (expr: string) => {
-          try {
-            return { result: { value: eval(expr) } }
-          } catch (e) {
-            return { exceptionDetails: { text: String(e) } }
-          }
-        },
-        args: [params?.expression || ''],
-      })
+      await ensureDebuggerAttached(tabId)
+      const expression = typeof params?.expression === 'string' ? params.expression : ''
+      const returnByValue = params?.returnByValue !== false
 
-      const evalResult = results[0]?.result
-      return evalResult || {}
+      const result = await chrome.debugger.sendCommand(
+        { tabId },
+        'Runtime.evaluate',
+        {
+          expression,
+          returnByValue,
+          awaitPromise: true,
+        },
+      ) as {
+        exceptionDetails?: { text?: string }
+        result?: { value?: unknown }
+      }
+
+      return result || {}
     }
 
     case 'Input.dispatchMouseEvent': {
@@ -187,7 +548,6 @@ async function handleCdpCommand(method: string, params: any, sessionId?: string)
 
       const { type, x, y, button, clickCount } = params || {}
 
-      // 使用 chrome.debugger API
       await ensureDebuggerAttached(tabId)
       await chrome.debugger.sendCommand({ tabId }, 'Input.dispatchMouseEvent', {
         type,
@@ -277,7 +637,6 @@ async function handleCdpCommand(method: string, params: any, sessionId?: string)
     case 'Target.getTargetInfo':
     case 'Target.setAutoAttach':
     case 'Target.setDiscoverTargets':
-      // 这些命令由 Relay Server 处理
       return {}
 
     default:
@@ -355,6 +714,8 @@ function setupTabListeners(): void {
       })
       activeSessions.delete(tabId)
       attachedTabs.delete(tabId)
+      cancelRunningCommands({ tabId, reason: 'tab_removed' })
+      tabActiveCommandCount.delete(tabId)
     }
   })
 
@@ -408,15 +769,50 @@ async function sendInitialTargets(): Promise<void> {
   }
 }
 
+function setupRuntimeListeners(): void {
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message?.type !== 'nine1bot-agent-stop-request') return false
+
+    const senderTabId = sender.tab?.id
+    const requestedTabId = typeof message.tabId === 'number' ? message.tabId : senderTabId
+    const cancelled = cancelRunningCommands({
+      tabId: requestedTabId,
+      reason: 'user_stop',
+    })
+
+    if (requestedTabId !== undefined) {
+      tabStopRequestedAt.set(requestedTabId, Date.now())
+      sendAgentStateToTabs(requestedTabId).catch(() => {
+        // ignore state send errors
+      })
+    }
+
+    sendResponse({ ok: true, cancelled, tabId: requestedTabId })
+    return true
+  })
+}
+
 /**
  * 连接到 Relay Server
  */
-export function connectToRelay(url: string = DEFAULT_RELAY_URL): void {
+export function connectToRelay(url?: string): void {
+  if (!url) {
+    getConfiguredRelayUrl()
+      .then((resolvedUrl) => {
+        connectToRelay(resolvedUrl)
+      })
+      .catch((error) => {
+        console.error('[Relay Client] Failed to resolve relay URL:', error)
+      })
+    return
+  }
+
   if (isConnecting || (ws && ws.readyState === WebSocket.OPEN)) {
     return
   }
 
   isConnecting = true
+  intentionalDisconnect = false
   console.log('[Relay Client] Connecting to:', url)
 
   try {
@@ -425,21 +821,18 @@ export function connectToRelay(url: string = DEFAULT_RELAY_URL): void {
     ws.onopen = () => {
       console.log('[Relay Client] Connected to Relay Server')
       isConnecting = false
+      reconnectAttempt = 0
+      lastPongAt = Date.now()
 
-      // 清除重连定时器
       if (reconnectTimer) {
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
 
-      // 设置 ping 定时器
-      pingTimer = setInterval(() => {
-        if (ws && ws.readyState === WebSocket.OPEN) {
-          // Relay Server 会发 ping，我们这里保持连接活跃
-        }
-      }, PING_INTERVAL)
-
-      // 发送当前所有标签页
+      sendExtensionHello()
+      sendExtensionHealth()
+      startHealthReporting()
+      startAgentHeartbeat()
       sendInitialTargets()
     }
 
@@ -450,7 +843,9 @@ export function connectToRelay(url: string = DEFAULT_RELAY_URL): void {
     ws.onclose = () => {
       console.log('[Relay Client] Disconnected from Relay Server')
       cleanup()
-      scheduleReconnect(url)
+      if (!intentionalDisconnect) {
+        scheduleReconnect(url)
+      }
     }
 
     ws.onerror = (error) => {
@@ -469,36 +864,47 @@ export function connectToRelay(url: string = DEFAULT_RELAY_URL): void {
  */
 function cleanup(): void {
   isConnecting = false
-
-  if (pingTimer) {
-    clearInterval(pingTimer)
-    pingTimer = null
-  }
+  stopTimers()
 
   if (ws) {
     ws = null
   }
 
   activeSessions.clear()
+
+  for (const [commandId, command] of runningCommands) {
+    command.cancelReason = 'relay_disconnected'
+    command.controller.abort('relay_disconnected')
+    runningCommands.delete(commandId)
+  }
+  tabActiveCommandCount.clear()
 }
 
 /**
- * 安排重连
+ * 安排重连（指数退避 + 抖动）
  */
 function scheduleReconnect(url: string): void {
   if (reconnectTimer) return
 
-  console.log(`[Relay Client] Reconnecting in ${RECONNECT_INTERVAL / 1000}s...`)
+  reconnectAttempt += 1
+  const base = Math.min(RECONNECT_BASE_INTERVAL * 2 ** Math.max(0, reconnectAttempt - 1), RECONNECT_MAX_INTERVAL)
+  const jitter = Math.floor(Math.random() * 1000)
+  const delay = base + jitter
+
+  console.log(`[Relay Client] Reconnecting in ${Math.round(delay / 1000)}s... (attempt ${reconnectAttempt})`)
+
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null
     connectToRelay(url)
-  }, RECONNECT_INTERVAL)
+  }, delay)
 }
 
 /**
  * 断开连接
  */
 export function disconnectFromRelay(): void {
+  intentionalDisconnect = true
+
   if (reconnectTimer) {
     clearTimeout(reconnectTimer)
     reconnectTimer = null
@@ -526,7 +932,10 @@ export function initRelayClient(): void {
   console.log('[Relay Client] Initializing...')
 
   setupTabListeners()
-  console.log('[Relay Client] Tab listeners set up')
+  setupRuntimeListeners()
+  setupDiagnosticsListeners()
+  setupTabGroupCleanup()
+  console.log('[Relay Client] Tab/runtime listeners set up')
 
   // 监听 debugger 断开
   chrome.debugger.onDetach.addListener((source) => {
@@ -536,12 +945,5 @@ export function initRelayClient(): void {
   })
 
   // 尝试连接（使用 chrome.storage 中配置的 URL）
-  console.log('[Relay Client] About to connect...')
-  getConfiguredRelayUrl().then((url) => {
-    try {
-      connectToRelay(url)
-    } catch (error) {
-      console.error('[Relay Client] Error in connectToRelay:', error)
-    }
-  })
+  connectToRelay()
 }

--- a/packages/browser-extension/src/background/tab-group-manager.ts
+++ b/packages/browser-extension/src/background/tab-group-manager.ts
@@ -1,0 +1,90 @@
+const NINE1_TAB_GROUP_TITLE = 'Nine1Bot'
+const NINE1_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'blue'
+
+let cleanupInstalled = false
+
+function formatGroupTitle(taskLabel?: string): string {
+  if (!taskLabel) return NINE1_TAB_GROUP_TITLE
+  const trimmed = taskLabel.trim()
+  if (!trimmed) return NINE1_TAB_GROUP_TITLE
+  return `${NINE1_TAB_GROUP_TITLE}: ${trimmed.slice(0, 32)}`
+}
+
+async function getGroupIdForTab(tabId: number): Promise<number | null> {
+  try {
+    const tab = await chrome.tabs.get(tabId)
+    return typeof tab.groupId === 'number' && tab.groupId >= 0 ? tab.groupId : null
+  } catch {
+    return null
+  }
+}
+
+async function updateGroup(groupId: number, options: {
+  collapsed?: boolean
+  taskLabel?: string
+}): Promise<void> {
+  await chrome.tabGroups.update(groupId, {
+    title: formatGroupTitle(options.taskLabel),
+    color: NINE1_TAB_GROUP_COLOR,
+    collapsed: options.collapsed ?? false,
+  })
+}
+
+export async function addTabToNine1Group(tabId: number, taskLabel?: string): Promise<number | null> {
+  try {
+    const existingGroupId = await getGroupIdForTab(tabId)
+    if (existingGroupId !== null) {
+      await updateGroup(existingGroupId, { collapsed: false, taskLabel })
+      return existingGroupId
+    }
+
+    const groupId = await chrome.tabs.group({ tabIds: [tabId] })
+    await updateGroup(groupId, { collapsed: false, taskLabel })
+    return groupId
+  } catch {
+    return null
+  }
+}
+
+export async function getTabsInGroupByTab(tabId: number): Promise<number[]> {
+  try {
+    const groupId = await getGroupIdForTab(tabId)
+    if (groupId === null) return [tabId]
+    const tabs = await chrome.tabs.query({ groupId })
+    const tabIds = tabs
+      .map((tab) => tab.id)
+      .filter((candidate): candidate is number => typeof candidate === 'number')
+    return tabIds.length > 0 ? tabIds : [tabId]
+  } catch {
+    return [tabId]
+  }
+}
+
+export async function setNine1GroupActive(tabId: number, taskLabel?: string): Promise<void> {
+  try {
+    const groupId = await addTabToNine1Group(tabId, taskLabel)
+    if (groupId === null) return
+    await updateGroup(groupId, { collapsed: false, taskLabel })
+  } catch {
+    // ignore tab/group lifecycle races
+  }
+}
+
+export async function setNine1GroupIdle(tabId: number): Promise<void> {
+  try {
+    const groupId = await getGroupIdForTab(tabId)
+    if (groupId === null) return
+    await updateGroup(groupId, { collapsed: true })
+  } catch {
+    // ignore tab/group lifecycle races
+  }
+}
+
+export function setupTabGroupCleanup(): void {
+  if (cleanupInstalled) return
+  cleanupInstalled = true
+
+  chrome.tabs.onRemoved.addListener(() => {
+    // Tab groups self-heal as tabs close; this keeps setup idempotent.
+  })
+}

--- a/packages/browser-extension/src/sidepanel/index.ts
+++ b/packages/browser-extension/src/sidepanel/index.ts
@@ -1,0 +1,111 @@
+const DEFAULT_SERVER_ORIGIN = 'http://127.0.0.1:4096'
+
+function normalizeServerOrigin(serverOrigin: string): string {
+  try {
+    const parsed = new URL(serverOrigin)
+    return `${parsed.protocol}//${parsed.host}`
+  } catch {
+    return DEFAULT_SERVER_ORIGIN
+  }
+}
+
+function relayUrlToWebUrl(relayUrl: string): string {
+  try {
+    const parsed = new URL(relayUrl)
+    const scheme = parsed.protocol === 'wss:' ? 'https:' : 'http:'
+    return `${scheme}//${parsed.host}`
+  } catch {
+    return DEFAULT_SERVER_ORIGIN
+  }
+}
+
+async function getWebUiUrl(): Promise<string> {
+  try {
+    const stored = await chrome.storage.sync.get({
+      serverOrigin: '',
+      webUiUrl: '',
+      relayUrl: '',
+    })
+
+    const serverOrigin = typeof stored.serverOrigin === 'string' && stored.serverOrigin.trim()
+      ? normalizeServerOrigin(stored.serverOrigin)
+      : typeof stored.webUiUrl === 'string' && stored.webUiUrl.trim()
+        ? normalizeServerOrigin(stored.webUiUrl)
+        : typeof stored.relayUrl === 'string' && stored.relayUrl.trim()
+          ? relayUrlToWebUrl(stored.relayUrl)
+          : DEFAULT_SERVER_ORIGIN
+
+    await chrome.storage.sync.set({ serverOrigin })
+    await chrome.storage.sync.remove(['webUiUrl', 'relayUrl'])
+    return serverOrigin
+  } catch {
+    // ignore
+  }
+  return DEFAULT_SERVER_ORIGIN
+}
+
+async function checkExtensionHealth(): Promise<boolean> {
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'nine1bot-sidepanel-health-check' })
+    return Boolean(response?.connected)
+  } catch {
+    return false
+  }
+}
+
+function setStatus(connected: boolean): void {
+  const status = document.getElementById('status')
+  if (!status) return
+  status.textContent = connected ? 'relay connected' : 'relay disconnected'
+  status.classList.toggle('connected', connected)
+}
+
+function showFallback(targetUrl: string, visible: boolean): void {
+  const fallback = document.getElementById('fallback')
+  const target = document.getElementById('target-url')
+  const frame = document.getElementById('app-frame') as HTMLIFrameElement | null
+  if (!fallback || !target || !frame) return
+
+  target.textContent = targetUrl
+  fallback.classList.toggle('visible', visible)
+  frame.style.display = visible ? 'none' : 'block'
+}
+
+async function mountFrame(): Promise<void> {
+  const targetUrl = await getWebUiUrl()
+  const frame = document.getElementById('app-frame') as HTMLIFrameElement | null
+  if (!frame) return
+
+  showFallback(targetUrl, false)
+  frame.src = targetUrl
+
+  let loaded = false
+  const fallbackTimer = setTimeout(() => {
+    if (!loaded) {
+      showFallback(targetUrl, true)
+    }
+  }, 3000)
+
+  frame.onload = () => {
+    loaded = true
+    clearTimeout(fallbackTimer)
+    showFallback(targetUrl, false)
+  }
+}
+
+async function init(): Promise<void> {
+  const connected = await checkExtensionHealth()
+  setStatus(connected)
+  await mountFrame()
+
+  const reloadButton = document.getElementById('reload')
+  reloadButton?.addEventListener('click', () => {
+    mountFrame().catch((error) => {
+      console.warn('[SidePanel] Failed to reload frame:', error)
+    })
+  })
+}
+
+init().catch((error) => {
+  console.error('[SidePanel] Failed to initialize:', error)
+})

--- a/packages/browser-extension/src/tools/execution-context.ts
+++ b/packages/browser-extension/src/tools/execution-context.ts
@@ -1,0 +1,14 @@
+export interface ToolExecutionContext {
+  signal?: AbortSignal
+  commandId?: number
+  tabId?: number
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return true
+  if (!(error instanceof Error)) return false
+
+  return error.name === 'AbortError'
+    || error.message === 'The operation was aborted.'
+    || /abort(ed)?/i.test(error.message)
+}

--- a/packages/browser-extension/src/tools/index.ts
+++ b/packages/browser-extension/src/tools/index.ts
@@ -1,3 +1,5 @@
+import type { ToolExecutionContext } from './execution-context'
+
 // Tool definitions for MCP Server
 
 export interface ToolDefinition {
@@ -19,6 +21,8 @@ export interface ToolResult {
   }>
   isError?: boolean
 }
+
+export type ToolExecutor = (args: unknown, context?: ToolExecutionContext) => Promise<ToolResult>
 
 // Re-export all tools
 export * from './screenshot'
@@ -48,7 +52,7 @@ export const tools: Record<string, ToolDefinition> = {
   tabs_create_mcp: tabsCreateTool.definition,
 }
 
-export const toolExecutors: Record<string, (args: unknown) => Promise<ToolResult>> = {
+export const toolExecutors: Record<string, ToolExecutor> = {
   screenshot: screenshotTool.execute,
   navigate: navigateTool.execute,
   read_page: readPageTool.execute,

--- a/packages/browser-extension/src/tools/tabs.ts
+++ b/packages/browser-extension/src/tools/tabs.ts
@@ -1,7 +1,19 @@
 import type { ToolDefinition, ToolResult } from './index'
+import { addTabToNine1Group } from '../background/tab-group-manager'
 
 interface TabsContextArgs {
   createIfEmpty?: boolean
+  url?: string
+}
+
+interface TabsCreateArgs {
+  url?: string
+}
+
+function normalizeNewTabUrl(url?: string): string {
+  if (typeof url !== 'string') return 'about:blank'
+  const trimmed = url.trim()
+  return trimmed.length > 0 ? trimmed : 'about:blank'
 }
 
 // Track tabs created by this extension (MCP tab group)
@@ -25,7 +37,7 @@ export const tabsContextTool = {
   } satisfies ToolDefinition,
 
   async execute(args: unknown): Promise<ToolResult> {
-    const { createIfEmpty = false } = (args as TabsContextArgs) || {}
+    const { createIfEmpty = false, url } = (args as TabsContextArgs) || {}
 
     try {
       // Clean up closed tabs from our tracking
@@ -65,9 +77,10 @@ export const tabsContextTool = {
 
       // Create a new tab if requested and none exist
       if (createIfEmpty && managedTabs.length === 0) {
-        const newTab = await chrome.tabs.create({ url: 'about:blank' })
+        const newTab = await chrome.tabs.create({ url: normalizeNewTabUrl(url) })
         if (newTab.id) {
           mcpTabIds.add(newTab.id)
+          await addTabToNine1Group(newTab.id)
           managedTabs.push({
             id: newTab.id,
             url: newTab.url,
@@ -122,14 +135,21 @@ export const tabsCreateTool = {
     description: 'Creates a new empty tab in the MCP tab group. Use tabs_context_mcp first to see existing tabs.',
     inputSchema: {
       type: 'object' as const,
-      properties: {},
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional initial URL to open in the new tab. Defaults to about:blank.',
+        },
+      },
       required: [],
     },
   } satisfies ToolDefinition,
 
-  async execute(_args: unknown): Promise<ToolResult> {
+  async execute(args: unknown): Promise<ToolResult> {
     try {
-      const newTab = await chrome.tabs.create({ url: 'about:blank' })
+      const { url } = (args as TabsCreateArgs) || {}
+      const initialUrl = normalizeNewTabUrl(url)
+      const newTab = await chrome.tabs.create({ url: initialUrl })
 
       if (!newTab.id) {
         return {
@@ -139,6 +159,7 @@ export const tabsCreateTool = {
       }
 
       mcpTabIds.add(newTab.id)
+      await addTabToNine1Group(newTab.id)
 
       return {
         content: [
@@ -150,6 +171,7 @@ export const tabsCreateTool = {
                 url: newTab.url,
                 title: newTab.title,
                 windowId: newTab.windowId,
+                requestedUrl: initialUrl,
                 message: 'New tab created and added to MCP tab group',
               },
               null,

--- a/packages/browser-extension/vite.config.ts
+++ b/packages/browser-extension/vite.config.ts
@@ -8,6 +8,9 @@ function copyStaticFiles() {
     name: 'copy-static-files',
     closeBundle() {
       const distDir = resolve(__dirname, 'dist')
+      if (!existsSync(distDir)) {
+        mkdirSync(distDir, { recursive: true })
+      }
 
       // Copy manifest.json
       copyFileSync(
@@ -46,6 +49,7 @@ export default defineConfig({
       input: {
         background: resolve(__dirname, 'src/background/index.ts'),
         content: resolve(__dirname, 'src/content/index.ts'),
+        sidepanel: resolve(__dirname, 'sidepanel/index.html'),
       },
       output: {
         entryFileNames: '[name]/index.js',

--- a/packages/browser-mcp-server/src/bridge/relay-routes.ts
+++ b/packages/browser-mcp-server/src/bridge/relay-routes.ts
@@ -1,13 +1,10 @@
 /**
  * Extension Relay - Bun/Hono Native WebSocket Implementation
  *
- * Rewrite of core/extension-relay.ts using Hono's upgradeWebSocket()
- * instead of Node.js 'ws' library, for integration with Bun.serve().
- *
  * Architecture:
  * - Chrome Extension connects to /extension WebSocket endpoint
- * - External CDP clients (Playwright, etc.) connect to /cdp endpoint
- * - Relay forwards CDP commands to extension, extension executes and returns results
+ * - External CDP clients connect to /cdp endpoint
+ * - Relay forwards CDP commands to extension and routes events back to CDP clients
  */
 
 import { Hono } from 'hono'
@@ -28,9 +25,38 @@ export interface ConnectedTarget {
   targetInfo: TargetInfo
 }
 
+export interface ExtensionHelloPayload {
+  version?: string
+  protocolVersion?: string
+  serverOrigin?: string
+  pairedInstanceId?: string
+  tools: string[]
+  capabilities?: Record<string, unknown>
+}
+
+export interface ExtensionHealthPayload {
+  timestamp: number
+  lastPongAt?: number
+  activeCommands?: number
+  reconnectAttempt?: number
+}
+
+export interface ExtensionAgentStatePayload {
+  tabId: number
+  state: 'active' | 'idle' | 'stopping'
+  heartbeatAt: number
+  taskLabel?: string
+}
+
 export interface ExtensionRelay {
   extensionConnected: () => boolean
   getTargets: () => ConnectedTarget[]
+  getTools: () => string[]
+  getCapabilities: () => Record<string, unknown>
+  getHealth: () => ExtensionHealthPayload | null
+  getHelloAt: () => number | null
+  getHello: () => ExtensionHelloPayload | null
+  getAgentStates: () => ExtensionAgentStatePayload[]
   sendCommand: (method: string, params?: unknown, targetId?: string) => Promise<unknown>
   stop: () => Promise<void>
 }
@@ -40,13 +66,23 @@ export interface ExtensionRelay {
 let extensionWs: WSContext | null = null
 const cdpClients = new Set<WSContext>()
 const connectedTargets = new Map<string, ConnectedTarget>()
-const pendingExtension = new Map<number, {
-  resolve: (result: unknown) => void
-  reject: (error: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}>()
+const pendingExtension = new Map<
+  number,
+  {
+    resolve: (result: unknown) => void
+    reject: (error: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  }
+>()
 let nextExtensionId = 1
 let pingInterval: ReturnType<typeof setInterval> | null = null
+
+let extensionTools: string[] = []
+let extensionCapabilities: Record<string, unknown> = {}
+let extensionHealth: ExtensionHealthPayload | null = null
+let extensionHelloAt: number | null = null
+let extensionHello: ExtensionHelloPayload | null = null
+const extensionAgentStates = new Map<number, ExtensionAgentStatePayload>()
 
 // ==================== Internal Helpers ====================
 
@@ -81,6 +117,20 @@ function sendResponseToCdp(ws: WSContext, res: unknown): void {
   ws.send(JSON.stringify(res))
 }
 
+function validateExtensionToolIfPossible(cmd: { method: string; params?: unknown }): void {
+  if (cmd.method !== 'Extension.callTool') return
+  if (extensionTools.length === 0) return
+
+  const params = (cmd.params ?? {}) as { toolName?: string }
+  const toolName = params.toolName
+  if (!toolName || typeof toolName !== 'string') {
+    throw new Error('Extension.callTool requires string toolName')
+  }
+  if (!extensionTools.includes(toolName)) {
+    throw new Error(`Unknown extension tool: ${toolName}. Available: ${extensionTools.join(', ')}`)
+  }
+}
+
 async function routeCdpCommand(cmd: { id: number; method: string; params?: unknown; sessionId?: string }): Promise<unknown> {
   switch (cmd.method) {
     case 'Browser.getVersion':
@@ -101,7 +151,7 @@ async function routeCdpCommand(cmd: { id: number; method: string; params?: unkno
 
     case 'Target.getTargets':
       return {
-        targetInfos: Array.from(connectedTargets.values()).map(t => ({
+        targetInfos: Array.from(connectedTargets.values()).map((t) => ({
           ...t.targetInfo,
           attached: true,
         })),
@@ -144,6 +194,8 @@ async function routeCdpCommand(cmd: { id: number; method: string; params?: unkno
     }
 
     default: {
+      validateExtensionToolIfPossible(cmd)
+
       const id = nextExtensionId++
       return await sendToExtension({
         id,
@@ -182,81 +234,124 @@ function handleExtensionMessage(data: string): void {
     return
   }
 
-  // Handle event from extension
-  if (parsed && typeof parsed === 'object' && 'method' in parsed) {
-    if (parsed.method === 'pong') return
-    if (parsed.method !== 'forwardCDPEvent') return
+  // Handle event/notification from extension
+  if (!parsed || typeof parsed !== 'object' || typeof parsed.method !== 'string') {
+    return
+  }
 
-    const evt = parsed as { params: { method: string; params?: unknown; sessionId?: string } }
-    const method = evt.params?.method
-    const params = evt.params?.params
-    const sessionId = evt.params?.sessionId
-
-    if (!method || typeof method !== 'string') return
-
-    // Handle Target.attachedToTarget - track connected tabs
-    if (method === 'Target.attachedToTarget') {
-      const attached = (params ?? {}) as { sessionId?: string; targetInfo?: TargetInfo }
-      const targetType = attached?.targetInfo?.type ?? 'page'
-      if (targetType !== 'page') return
-
-      if (attached?.sessionId && attached?.targetInfo?.targetId) {
-        const prev = connectedTargets.get(attached.sessionId)
-        const nextTargetId = attached.targetInfo.targetId
-        const prevTargetId = prev?.targetId
-        const changedTarget = Boolean(prev && prevTargetId && prevTargetId !== nextTargetId)
-
-        connectedTargets.set(attached.sessionId, {
-          sessionId: attached.sessionId,
-          targetId: nextTargetId,
-          targetInfo: attached.targetInfo,
-        })
-
-        if (changedTarget && prevTargetId) {
-          broadcastToCdpClients({
-            method: 'Target.detachedFromTarget',
-            params: { sessionId: attached.sessionId, targetId: prevTargetId },
-            sessionId: attached.sessionId,
-          })
-        }
-
-        if (!prev || changedTarget) {
-          broadcastToCdpClients({ method, params, sessionId })
-        }
-        return
-      }
+  if (parsed.method === 'pong') {
+    if (extensionHealth) {
+      extensionHealth.lastPongAt = Date.now()
     }
+    return
+  }
 
-    // Handle Target.detachedFromTarget
-    if (method === 'Target.detachedFromTarget') {
-      const detached = (params ?? {}) as { sessionId?: string }
-      if (detached?.sessionId) {
-        connectedTargets.delete(detached.sessionId)
+  if (parsed.method === 'extension.hello') {
+    const params = (parsed.params ?? {}) as ExtensionHelloPayload
+    extensionHello = params
+    extensionTools = Array.isArray(params.tools) ? params.tools.filter((x) => typeof x === 'string') : []
+    extensionCapabilities = params.capabilities ?? {}
+    extensionHelloAt = Date.now()
+    console.log('[Extension Relay] Extension hello:', {
+      version: params.version,
+      protocolVersion: params.protocolVersion,
+      serverOrigin: params.serverOrigin,
+      pairedInstanceId: params.pairedInstanceId,
+      tools: extensionTools.length,
+      capabilities: Object.keys(extensionCapabilities),
+    })
+    return
+  }
+
+  if (parsed.method === 'extension.health') {
+    const params = parsed.params as ExtensionHealthPayload
+    extensionHealth = {
+      timestamp: params?.timestamp ?? Date.now(),
+      lastPongAt: params?.lastPongAt,
+      activeCommands: params?.activeCommands,
+      reconnectAttempt: params?.reconnectAttempt,
+    }
+    return
+  }
+
+  if (parsed.method === 'extension.agentState') {
+    const params = parsed.params as ExtensionAgentStatePayload
+    if (typeof params?.tabId === 'number') {
+      extensionAgentStates.set(params.tabId, params)
+    }
+    return
+  }
+
+  if (parsed.method !== 'forwardCDPEvent') return
+
+  const evt = parsed as { params: { method: string; params?: unknown; sessionId?: string } }
+  const method = evt.params?.method
+  const params = evt.params?.params
+  const sessionId = evt.params?.sessionId
+
+  if (!method || typeof method !== 'string') return
+
+  // Handle Target.attachedToTarget - track connected tabs
+  if (method === 'Target.attachedToTarget') {
+    const attached = (params ?? {}) as { sessionId?: string; targetInfo?: TargetInfo }
+    const targetType = attached?.targetInfo?.type ?? 'page'
+    if (targetType !== 'page') return
+
+    if (attached?.sessionId && attached?.targetInfo?.targetId) {
+      const prev = connectedTargets.get(attached.sessionId)
+      const nextTargetId = attached.targetInfo.targetId
+      const prevTargetId = prev?.targetId
+      const changedTarget = Boolean(prev && prevTargetId && prevTargetId !== nextTargetId)
+
+      connectedTargets.set(attached.sessionId, {
+        sessionId: attached.sessionId,
+        targetId: nextTargetId,
+        targetInfo: attached.targetInfo,
+      })
+
+      if (changedTarget && prevTargetId) {
+        broadcastToCdpClients({
+          method: 'Target.detachedFromTarget',
+          params: { sessionId: attached.sessionId, targetId: prevTargetId },
+          sessionId: attached.sessionId,
+        })
       }
-      broadcastToCdpClients({ method, params, sessionId })
+
+      if (!prev || changedTarget) {
+        broadcastToCdpClients({ method, params, sessionId })
+      }
       return
     }
+  }
 
-    // Handle Target.targetInfoChanged - update cached metadata
-    if (method === 'Target.targetInfoChanged') {
-      const changed = (params ?? {}) as { targetInfo?: TargetInfo }
-      const targetInfo = changed?.targetInfo
-      const targetId = targetInfo?.targetId
+  // Handle Target.detachedFromTarget
+  if (method === 'Target.detachedFromTarget') {
+    const detached = (params ?? {}) as { sessionId?: string }
+    if (detached?.sessionId) {
+      connectedTargets.delete(detached.sessionId)
+    }
+    broadcastToCdpClients({ method, params, sessionId })
+    return
+  }
 
-      if (targetId && (targetInfo?.type ?? 'page') === 'page') {
-        for (const [sid, target] of connectedTargets) {
-          if (target.targetId !== targetId) continue
-          connectedTargets.set(sid, {
-            ...target,
-            targetInfo: { ...target.targetInfo, ...targetInfo },
-          })
-        }
+  // Handle Target.targetInfoChanged - update cached metadata
+  if (method === 'Target.targetInfoChanged') {
+    const changed = (params ?? {}) as { targetInfo?: TargetInfo }
+    const targetInfo = changed?.targetInfo
+    const targetId = targetInfo?.targetId
+
+    if (targetId && (targetInfo?.type ?? 'page') === 'page') {
+      for (const [sid, target] of connectedTargets) {
+        if (target.targetId !== targetId) continue
+        connectedTargets.set(sid, {
+          ...target,
+          targetInfo: { ...target.targetInfo, ...targetInfo },
+        })
       }
     }
-
-    // Broadcast to CDP clients
-    broadcastToCdpClients({ method, params, sessionId })
   }
+
+  broadcastToCdpClients({ method, params, sessionId })
 }
 
 function cleanupExtension(): void {
@@ -276,6 +371,14 @@ function cleanupExtension(): void {
   }
   pendingExtension.clear()
 
+  // Clear extension metadata caches
+  extensionTools = []
+  extensionCapabilities = {}
+  extensionHealth = null
+  extensionHelloAt = null
+  extensionHello = null
+  extensionAgentStates.clear()
+
   // Clear targets
   connectedTargets.clear()
 
@@ -294,93 +397,100 @@ function cleanupExtension(): void {
 
 export function createRelayRoutes(): Hono {
   return new Hono()
-    .get('/extension', async (c, next) => {
-      // Reject if extension already connected
-      if (extensionWs && extensionWs.readyState === 1) {
-        return c.text('Extension already connected', 409)
-      }
-      return next()
-    }, upgradeWebSocket(() => ({
-      onOpen(_event, ws) {
-        console.log('[Extension Relay] Extension connected')
-        extensionWs = ws
-
-        // Ping to keep connection alive
-        pingInterval = setInterval(() => {
-          if (!extensionWs || extensionWs.readyState !== 1) return
-          extensionWs.send(JSON.stringify({ method: 'ping' }))
-        }, 5000)
+    .get(
+      '/extension',
+      async (c, next) => {
+        if (extensionWs && extensionWs.readyState === 1) {
+          return c.text('Extension already connected', 409)
+        }
+        return next()
       },
-      onMessage(event) {
-        handleExtensionMessage(String(event.data))
-      },
-      onClose() {
-        cleanupExtension()
-      },
-    })))
-    .get('/cdp', async (c, next) => {
-      // Reject if extension not connected
-      if (!extensionWs || extensionWs.readyState !== 1) {
-        return c.text('Extension not connected', 503)
-      }
-      return next()
-    }, upgradeWebSocket(() => {
-      let thisWs: WSContext
-      return {
+      upgradeWebSocket(() => ({
         onOpen(_event, ws) {
-          console.log('[Extension Relay] CDP client connected')
-          thisWs = ws
-          cdpClients.add(ws)
+          console.log('[Extension Relay] Extension connected')
+          extensionWs = ws
 
-          // Send current targets to new client
-          for (const target of connectedTargets.values()) {
-            ws.send(JSON.stringify({
-              method: 'Target.attachedToTarget',
-              params: {
-                sessionId: target.sessionId,
-                targetInfo: { ...target.targetInfo, attached: true },
-                waitingForDebugger: false,
-              },
-            }))
-          }
+          // Ping to keep connection alive
+          pingInterval = setInterval(() => {
+            if (!extensionWs || extensionWs.readyState !== 1) return
+            extensionWs.send(JSON.stringify({ method: 'ping' }))
+          }, 5000)
         },
-        async onMessage(event) {
-          let cmd: any = null
-          try {
-            cmd = JSON.parse(String(event.data))
-          } catch {
-            return
-          }
-
-          if (!cmd || typeof cmd !== 'object') return
-          if (typeof cmd.id !== 'number' || typeof cmd.method !== 'string') return
-
-          if (!extensionWs) {
-            sendResponseToCdp(thisWs, {
-              id: cmd.id,
-              sessionId: cmd.sessionId,
-              error: { message: 'Extension not connected' },
-            })
-            return
-          }
-
-          try {
-            const result = await routeCdpCommand(cmd)
-            sendResponseToCdp(thisWs, { id: cmd.id, sessionId: cmd.sessionId, result })
-          } catch (err) {
-            sendResponseToCdp(thisWs, {
-              id: cmd.id,
-              sessionId: cmd.sessionId,
-              error: { message: err instanceof Error ? err.message : String(err) },
-            })
-          }
+        onMessage(event) {
+          handleExtensionMessage(String(event.data))
         },
         onClose() {
-          console.log('[Extension Relay] CDP client disconnected')
-          cdpClients.delete(thisWs)
+          cleanupExtension()
         },
-      }
-    }))
+      })),
+    )
+    .get(
+      '/cdp',
+      async (c, next) => {
+        if (!extensionWs || extensionWs.readyState !== 1) {
+          return c.text('Extension not connected', 503)
+        }
+        return next()
+      },
+      upgradeWebSocket(() => {
+        let thisWs: WSContext
+        return {
+          onOpen(_event, ws) {
+            console.log('[Extension Relay] CDP client connected')
+            thisWs = ws
+            cdpClients.add(ws)
+
+            for (const target of connectedTargets.values()) {
+              ws.send(
+                JSON.stringify({
+                  method: 'Target.attachedToTarget',
+                  params: {
+                    sessionId: target.sessionId,
+                    targetInfo: { ...target.targetInfo, attached: true },
+                    waitingForDebugger: false,
+                  },
+                }),
+              )
+            }
+          },
+          async onMessage(event) {
+            let cmd: any = null
+            try {
+              cmd = JSON.parse(String(event.data))
+            } catch {
+              return
+            }
+
+            if (!cmd || typeof cmd !== 'object') return
+            if (typeof cmd.id !== 'number' || typeof cmd.method !== 'string') return
+
+            if (!extensionWs) {
+              sendResponseToCdp(thisWs, {
+                id: cmd.id,
+                sessionId: cmd.sessionId,
+                error: { message: 'Extension not connected' },
+              })
+              return
+            }
+
+            try {
+              const result = await routeCdpCommand(cmd)
+              sendResponseToCdp(thisWs, { id: cmd.id, sessionId: cmd.sessionId, result })
+            } catch (err) {
+              sendResponseToCdp(thisWs, {
+                id: cmd.id,
+                sessionId: cmd.sessionId,
+                error: { message: err instanceof Error ? err.message : String(err) },
+              })
+            }
+          },
+          onClose() {
+            console.log('[Extension Relay] CDP client disconnected')
+            cdpClients.delete(thisWs)
+          },
+        }
+      }),
+    )
 }
 
 // ==================== Public API (for BridgeServer direct calls) ====================
@@ -389,12 +499,17 @@ export function getExtensionRelay(): ExtensionRelay {
   return {
     extensionConnected: () => Boolean(extensionWs && extensionWs.readyState === 1),
     getTargets: () => Array.from(connectedTargets.values()),
+    getTools: () => [...extensionTools],
+    getCapabilities: () => ({ ...extensionCapabilities }),
+    getHealth: () => (extensionHealth ? { ...extensionHealth } : null),
+    getHelloAt: () => extensionHelloAt,
+    getHello: () => (extensionHello ? { ...extensionHello } : null),
+    getAgentStates: () => Array.from(extensionAgentStates.values()).map((state) => ({ ...state })),
     sendCommand: async (method: string, params?: unknown, targetId?: string) => {
       if (!extensionWs || extensionWs.readyState !== 1) {
         throw new Error('Chrome extension not connected')
       }
 
-      // Find sessionId for targetId
       let sessionId: string | undefined
       if (targetId) {
         for (const target of connectedTargets.values()) {

--- a/packages/browser-mcp-server/src/bridge/server.ts
+++ b/packages/browser-mcp-server/src/bridge/server.ts
@@ -13,6 +13,7 @@
  */
 
 import { Hono } from 'hono'
+import { Socket } from 'node:net'
 import {
   listCdpTargets,
   captureScreenshot,
@@ -31,6 +32,8 @@ import type {
   ExtensionToolResult,
   BrowserTarget,
   BrowserStatus,
+  BrowserRuntimeConflict,
+  BrowserRuntimeStatus,
   SnapshotResult,
   ClickOptions,
 } from '../core/types'
@@ -44,6 +47,45 @@ export interface BridgeServerOptions {
   cdpPort?: number
   autoLaunch?: boolean
   headless?: boolean
+  serverOrigin?: string
+  instanceId?: string
+}
+
+const DEFAULT_SERVER_ORIGIN = 'http://127.0.0.1:4096'
+const LEGACY_BROWSER_PORTS = [18791, 18793]
+const EXTENSION_PROTOCOL_VERSION = '2026-03-15'
+
+function normalizeServerOrigin(serverOrigin: string): string {
+  try {
+    const parsed = new URL(serverOrigin)
+    return `${parsed.protocol}//${parsed.host}`
+  } catch {
+    return DEFAULT_SERVER_ORIGIN
+  }
+}
+
+function generateInstanceId(): string {
+  return `browser_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+async function isLocalPortListening(host: string, port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const socket = new Socket()
+    let settled = false
+
+    const finish = (value: boolean) => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      resolve(value)
+    }
+
+    socket.setTimeout(250)
+    socket.once('connect', () => finish(true))
+    socket.once('timeout', () => finish(false))
+    socket.once('error', () => finish(false))
+    socket.connect(port, host)
+  })
 }
 
 /**
@@ -61,6 +103,8 @@ export class BridgeServer {
       cdpPort: options.cdpPort ?? 9222,
       autoLaunch: options.autoLaunch ?? true,
       headless: options.headless ?? false,
+      serverOrigin: normalizeServerOrigin(options.serverOrigin ?? DEFAULT_SERVER_ORIGIN),
+      instanceId: options.instanceId ?? generateInstanceId(),
     }
   }
 
@@ -171,7 +215,79 @@ export class BridgeServer {
       botStatus = { running: false, tabs: [] }
     }
 
-    return { user: userStatus, bot: botStatus }
+    return {
+      user: userStatus,
+      bot: botStatus,
+      runtime: await this.getRuntimeStatus(),
+    }
+  }
+
+  private async getRuntimeStatus(): Promise<BrowserRuntimeStatus> {
+    const hello = this.relay?.getHello() ?? null
+    const helloAt = this.relay?.getHelloAt() ?? null
+    const conflicts = await this.detectLegacyPortConflicts()
+    const issues: BrowserRuntimeStatus['issues'] = []
+
+    if (hello?.serverOrigin && normalizeServerOrigin(hello.serverOrigin) !== this.options.serverOrigin) {
+      issues.push({
+        code: 'extension_server_origin_mismatch',
+        severity: 'error',
+        message: `Extension is paired with ${hello.serverOrigin}, but this server expects ${this.options.serverOrigin}.`,
+      })
+    }
+
+    if (hello?.pairedInstanceId && hello.pairedInstanceId !== this.options.instanceId) {
+      issues.push({
+        code: 'extension_instance_mismatch',
+        severity: 'error',
+        message: `Extension is paired with instance ${hello.pairedInstanceId}, but this server instance is ${this.options.instanceId}.`,
+      })
+    }
+
+    for (const conflict of conflicts) {
+      issues.push({
+        code: `legacy_port_${conflict.port}`,
+        severity: 'warning',
+        message: conflict.message,
+      })
+    }
+
+    return {
+      mode: 'embedded',
+      serverOrigin: this.options.serverOrigin,
+      instanceId: this.options.instanceId,
+      extension: {
+        connected: this.isExtensionConnected,
+        helloAt,
+        version: hello?.version ?? null,
+        protocolVersion: hello?.protocolVersion ?? null,
+        serverOrigin: hello?.serverOrigin ?? null,
+        pairedInstanceId: hello?.pairedInstanceId ?? null,
+      },
+      conflicts,
+      issues,
+    }
+  }
+
+  private async detectLegacyPortConflicts(): Promise<BrowserRuntimeConflict[]> {
+    let currentPort: number | null = null
+    try {
+      currentPort = Number(new URL(this.options.serverOrigin).port || 80)
+    } catch {
+      currentPort = null
+    }
+
+    const conflicts: BrowserRuntimeConflict[] = []
+    for (const port of LEGACY_BROWSER_PORTS) {
+      if (currentPort === port) continue
+      if (!(await isLocalPortListening('127.0.0.1', port))) continue
+      conflicts.push({
+        host: '127.0.0.1',
+        port,
+        message: `Detected a legacy browser bridge listener on 127.0.0.1:${port}. Browser control now uses ${this.options.serverOrigin}/browser/* only.`,
+      })
+    }
+    return conflicts
   }
 
   /**
@@ -516,6 +632,15 @@ export class BridgeServer {
     const checkExpression = `document.body.innerText.includes(${JSON.stringify(text)})`
 
     while (Date.now() - startTime < maxWait) {
+      if (channel === 'extension') {
+        const targetNumericId = Number(tabId)
+        const states = this.relay?.getAgentStates() ?? []
+        const state = states.find((s) => s.tabId === targetNumericId)
+        if (state?.state === 'stopping') {
+          throw new Error('Wait cancelled by user stop request')
+        }
+      }
+
       let found = false
 
       if (channel === 'extension') {
@@ -718,8 +843,27 @@ export class BridgeServer {
         'Runtime.evaluate',
         { expression, returnByValue: true },
         tabId
-      ) as { result?: { value?: unknown } }
-      return result?.result?.value
+      ) as unknown
+
+      if (result && typeof result === 'object') {
+        const record = result as {
+          exceptionDetails?: { text?: string }
+          result?: { value?: unknown }
+          value?: unknown
+        }
+
+        if (record.exceptionDetails?.text) {
+          throw new Error(record.exceptionDetails.text)
+        }
+        if (record.result && typeof record.result === 'object' && 'value' in record.result) {
+          return record.result.value
+        }
+        if ('value' in record) {
+          return record.value
+        }
+      }
+
+      return result
     }
 
     const wsUrl = await this.getTargetWsUrl(tabId)
@@ -728,16 +872,58 @@ export class BridgeServer {
 
   // ==================== Extension Tool Forwarding ====================
 
-  async callExtensionTool(tabId: string, toolName: string, args: Record<string, unknown> = {}): Promise<ExtensionToolResult> {
+  async callExtensionTool(
+    tabId: string,
+    toolName: string,
+    args: Record<string, unknown> = {},
+    options?: { timeoutMs?: number; taskLabel?: string },
+  ): Promise<ExtensionToolResult> {
     if (!this.isExtensionConnected) {
       throw new Error('Chrome extension not connected. Install and connect the Nine1Bot Browser Control extension.')
     }
+    const supportedTools = this.relay!.getTools()
+    if (supportedTools.length > 0 && !supportedTools.includes(toolName)) {
+      throw new Error(`Unknown extension tool: ${toolName}. Available: ${supportedTools.join(', ')}`)
+    }
     const result = await this.relay!.sendCommand(
       'Extension.callTool',
-      { toolName, args },
+      {
+        toolName,
+        args,
+        timeoutMs: options?.timeoutMs,
+        taskLabel: options?.taskLabel,
+      },
       tabId
     )
     return result as ExtensionToolResult
+  }
+
+  async readConsoleMessages(
+    tabId: string,
+    options?: { sampleMs?: number; max?: number; sinceMs?: number; level?: string },
+    browser?: BrowserTarget,
+  ): Promise<unknown[]> {
+    const channel = this.getChannel(browser)
+    if (channel === 'cdp') {
+      throw new Error('console_messages is currently supported only in extension channel. Use browser=\"user\".')
+    }
+    const result = await this.callExtensionTool(tabId, 'console_messages', options ?? {})
+    const text = result.content?.find((c) => c.type === 'text')?.text ?? '[]'
+    return JSON.parse(text)
+  }
+
+  async readNetworkRequests(
+    tabId: string,
+    options?: { sampleMs?: number; max?: number; sinceMs?: number; resourceType?: string },
+    browser?: BrowserTarget,
+  ): Promise<unknown[]> {
+    const channel = this.getChannel(browser)
+    if (channel === 'cdp') {
+      throw new Error('network_requests is currently supported only in extension channel. Use browser=\"user\".')
+    }
+    const result = await this.callExtensionTool(tabId, 'network_requests', options ?? {})
+    const text = result.content?.find((c) => c.type === 'text')?.text ?? '[]'
+    return JSON.parse(text)
   }
 
   // ==================== Internal Helpers ====================
@@ -795,9 +981,16 @@ export class BridgeServer {
       resultJson = String(await evaluateScript(wsUrl, expression) ?? 'null')
     }
 
-    const parsed = JSON.parse(resultJson)
-    if (!parsed) {
-      throw new Error(`Element with ref "${ref}" not found`)
+    const parsed = JSON.parse(resultJson) as {
+      found?: boolean
+      centerX?: number
+      centerY?: number
+      visible?: boolean
+      message?: string
+    } | null
+
+    if (!parsed || parsed.found === false) {
+      throw new Error(parsed?.message || `Element with ref "${ref}" not found`)
     }
 
     if (!parsed.visible) {
@@ -823,8 +1016,22 @@ export class BridgeServer {
         const wsUrl = await this.getTargetWsUrl(tabId)
         newJson = String(await evaluateScript(wsUrl, expression) ?? 'null')
       }
-      const newParsed = JSON.parse(newJson)
-      if (newParsed) return [newParsed.centerX, newParsed.centerY]
+      const newParsed = JSON.parse(newJson) as {
+        found?: boolean
+        centerX?: number
+        centerY?: number
+        message?: string
+      } | null
+      if (!newParsed || newParsed.found === false) {
+        throw new Error(newParsed?.message || `Element with ref "${ref}" could not be resolved after scrolling`)
+      }
+      if (typeof newParsed.centerX === 'number' && typeof newParsed.centerY === 'number') {
+        return [newParsed.centerX, newParsed.centerY]
+      }
+    }
+
+    if (typeof parsed.centerX !== 'number' || typeof parsed.centerY !== 'number') {
+      throw new Error(parsed.message || `Element with ref "${ref}" did not resolve to valid coordinates`)
     }
 
     return [parsed.centerX, parsed.centerY]
@@ -834,6 +1041,15 @@ export class BridgeServer {
 
   private createHttpApp(): Hono {
     const app = new Hono()
+
+    app.get('/bootstrap', (c) => {
+      return c.json({
+        mode: 'embedded',
+        serverOrigin: this.options.serverOrigin,
+        instanceId: this.options.instanceId,
+        extensionProtocolVersion: EXTENSION_PROTOCOL_VERSION,
+      })
+    })
 
     app.get('/', async (c) => {
       try {
@@ -848,6 +1064,15 @@ export class BridgeServer {
       try {
         const status = await this.getStatus()
         return c.json({ ok: true, ...status })
+      } catch (error) {
+        return c.json({ ok: false, error: String(error) }, 500)
+      }
+    })
+
+    app.get('/diagnostics', async (c) => {
+      try {
+        const runtime = await this.getRuntimeStatus()
+        return c.json({ ok: true, runtime })
       } catch (error) {
         return c.json({ ok: false, error: String(error) }, 500)
       }
@@ -873,6 +1098,31 @@ export class BridgeServer {
           title: t.targetInfo.title,
           url: t.targetInfo.url,
         })),
+      })
+    })
+
+    app.get('/extension/health', (c) => {
+      const health = this.relay?.getHealth() ?? null
+      const helloAt = this.relay?.getHelloAt() ?? null
+      const hello = this.relay?.getHello() ?? null
+      const capabilities = this.relay?.getCapabilities() ?? {}
+      const agentStates = this.relay?.getAgentStates() ?? []
+      return c.json({
+        connected: this.isExtensionConnected,
+        helloAt,
+        hello,
+        health,
+        capabilities,
+        agentStates,
+        instanceId: this.options.instanceId,
+        serverOrigin: this.options.serverOrigin,
+      })
+    })
+
+    app.get('/extension/tools', (c) => {
+      return c.json({
+        connected: this.isExtensionConnected,
+        tools: this.relay?.getTools() ?? [],
       })
     })
 
@@ -1023,6 +1273,34 @@ export class BridgeServer {
         if (!expression) return c.json({ ok: false, error: 'expression is required' }, 400)
         const result = await this.evaluate(tabId, expression, browser)
         return c.json({ ok: true, result })
+      } catch (error) {
+        return c.json({ ok: false, error: String(error) }, 500)
+      }
+    })
+
+    app.post('/tabs/:targetId/diagnostics/console', async (c) => {
+      try {
+        const tabId = c.req.param('targetId')
+        const browser = c.req.query('browser') as BrowserTarget | undefined
+        const body = await c.req
+          .json<{ sampleMs?: number; max?: number; sinceMs?: number; level?: string }>()
+          .catch(() => ({}))
+        const entries = await this.readConsoleMessages(tabId, body, browser)
+        return c.json({ ok: true, entries })
+      } catch (error) {
+        return c.json({ ok: false, error: String(error) }, 500)
+      }
+    })
+
+    app.post('/tabs/:targetId/diagnostics/network', async (c) => {
+      try {
+        const tabId = c.req.param('targetId')
+        const browser = c.req.query('browser') as BrowserTarget | undefined
+        const body = await c.req
+          .json<{ sampleMs?: number; max?: number; sinceMs?: number; resourceType?: string }>()
+          .catch(() => ({}))
+        const entries = await this.readNetworkRequests(tabId, body, browser)
+        return c.json({ ok: true, entries })
       } catch (error) {
         return c.json({ ok: false, error: String(error) }, 500)
       }

--- a/packages/browser-mcp-server/src/core/types.ts
+++ b/packages/browser-mcp-server/src/core/types.ts
@@ -59,6 +59,35 @@ export interface BrowserStatus {
     running: boolean
     tabs: Tab[]
   } | null
+  runtime?: BrowserRuntimeStatus
+}
+
+export interface BrowserStatusIssue {
+  code: string
+  severity: 'warning' | 'error'
+  message: string
+}
+
+export interface BrowserRuntimeConflict {
+  host: string
+  port: number
+  message: string
+}
+
+export interface BrowserRuntimeStatus {
+  mode: 'embedded'
+  serverOrigin: string
+  instanceId: string
+  extension: {
+    connected: boolean
+    helloAt: number | null
+    version: string | null
+    protocolVersion: string | null
+    serverOrigin: string | null
+    pairedInstanceId: string | null
+  }
+  conflicts: BrowserRuntimeConflict[]
+  issues: BrowserStatusIssue[]
 }
 
 /** Snapshot (a11y tree) result */

--- a/packages/nine1bot/package.json
+++ b/packages/nine1bot/package.json
@@ -23,6 +23,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "bun-types": "^1.3.9",
     "@types/node": "^22.10.2",
     "@types/ws": "^8.18.1",
     "@types/yargs": "^17.0.33",

--- a/packages/nine1bot/src/browser/index.ts
+++ b/packages/nine1bot/src/browser/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Browser 模块导出
+ */
+
+export * from './cdp'
+export * from './chrome'
+export * from './extension-relay'

--- a/packages/nine1bot/src/browser/index.ts
+++ b/packages/nine1bot/src/browser/index.ts
@@ -1,7 +1,7 @@
 /**
- * Browser 模块导出
+ * Browser runtime wiring currently lives in launcher and browser-mcp-server.
+ * Keep this module as a placeholder so package-wide typecheck does not import
+ * non-existent implementation files.
  */
 
-export * from './cdp'
-export * from './chrome'
-export * from './extension-relay'
+export {}

--- a/packages/nine1bot/src/config/loader.test.ts
+++ b/packages/nine1bot/src/config/loader.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadConfig } from './loader'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function writeConfig(config: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'nine1bot-config-'))
+  tempDirs.push(dir)
+  const configPath = join(dir, 'nine1bot.config.jsonc')
+  await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  return configPath
+}
+
+describe('loadConfig browser migration guards', () => {
+  it('rejects deprecated mcp.browser config', async () => {
+    const configPath = await writeConfig({
+      browser: { enabled: true },
+      mcp: {
+        browser: {
+          type: 'local',
+          enabled: true,
+        },
+      },
+    })
+
+    await expect(loadConfig(configPath)).rejects.toThrow('mcp.browser')
+  })
+
+  it('rejects deprecated browser.bridgePort config', async () => {
+    const configPath = await writeConfig({
+      browser: {
+        enabled: true,
+        bridgePort: 18793,
+      },
+    })
+
+    await expect(loadConfig(configPath)).rejects.toThrow('browser.bridgePort')
+  })
+})

--- a/packages/nine1bot/src/config/loader.ts
+++ b/packages/nine1bot/src/config/loader.ts
@@ -269,6 +269,31 @@ async function loadConfigFile(configPath: string): Promise<Partial<Nine1BotConfi
   }
 }
 
+function validateDeprecatedBrowserConfig(config: Partial<Nine1BotConfig>): void {
+  const issues: Array<{ path: string; message: string }> = []
+
+  const browserConfig = (config as any).browser
+  if (browserConfig && typeof browserConfig === 'object' && 'bridgePort' in browserConfig) {
+    issues.push({
+      path: 'browser.bridgePort',
+      message: 'deprecated. Browser control now uses the built-in /browser/* routes on the main server; remove bridgePort.',
+    })
+  }
+
+  const mcpConfig = (config as any).mcp
+  if (mcpConfig && typeof mcpConfig === 'object' && 'browser' in mcpConfig) {
+    issues.push({
+      path: 'mcp.browser',
+      message: 'deprecated. Browser control no longer supports MCP mode; remove mcp.browser and use browser.enabled instead.',
+    })
+  }
+
+  if (issues.length === 0) return
+
+  const messages = issues.map((issue) => `  - ${issue.path}: ${issue.message}`).join('\n')
+  throw new Error(`Invalid config:\n${messages}`)
+}
+
 /**
  * 加载配置文件
  * 配置优先级（从低到高）：
@@ -312,6 +337,7 @@ export async function loadConfig(customConfigPath?: string): Promise<Nine1BotCon
 
   // 验证并返回最终配置
   try {
+    validateDeprecatedBrowserConfig(result)
     return Nine1BotConfigSchema.parse(result)
   } catch (error) {
     if (error && typeof error === 'object' && 'issues' in error) {

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -51,6 +51,10 @@ export interface StartServerOptions {
   fullConfig: Nine1BotConfig
 }
 
+function generateBrowserInstanceId(): string {
+  return `browser_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
 /**
  * Nine1Bot 特有的配置字段（需要从 opencode 配置中过滤掉）
  */
@@ -242,14 +246,17 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
   const browserConfig = (fullConfig as any).browser
   if (browserConfig?.enabled) {
     try {
+      const serverOrigin = `http://${server.hostname}:${server.port}`
       bridgeServer = new BridgeServer({
         cdpPort: browserConfig.cdpPort ?? 9222,
         autoLaunch: browserConfig.autoLaunch ?? true,
         headless: browserConfig.headless ?? false,
+        serverOrigin,
+        instanceId: generateBrowserInstanceId(),
       })
       await bridgeServer.start()
       setBridgeServer(bridgeServer)
-      console.log('[Nine1Bot] Browser control enabled at /browser/')
+      console.log(`[Nine1Bot] Browser control enabled at ${serverOrigin}/browser/`)
     } catch (error: any) {
       console.warn(`[Nine1Bot] Failed to initialize browser bridge: ${error.message}`)
     }

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -55,6 +55,18 @@ function generateBrowserInstanceId(): string {
   return `browser_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
 }
 
+function getBrowserServerOrigin(hostname: string, port: number): string {
+  const url = new URL('http://127.0.0.1')
+  const normalizedHostname = !hostname || hostname === '0.0.0.0'
+    ? '127.0.0.1'
+    : hostname === '::'
+      ? '::1'
+      : hostname
+  url.hostname = normalizedHostname
+  url.port = String(port)
+  return url.toString().replace(/\/$/, '')
+}
+
 /**
  * Nine1Bot 特有的配置字段（需要从 opencode 配置中过滤掉）
  */
@@ -246,7 +258,7 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
   const browserConfig = (fullConfig as any).browser
   if (browserConfig?.enabled) {
     try {
-      const serverOrigin = `http://${server.hostname}:${server.port}`
+      const serverOrigin = getBrowserServerOrigin(server.hostname, server.port)
       bridgeServer = new BridgeServer({
         cdpPort: browserConfig.cdpPort ?? 9222,
         autoLaunch: browserConfig.autoLaunch ?? true,


### PR DESCRIPTION
# 描述 / Summary

将浏览器控制链路迁移到 Nine1Bot 内建 browser relay，并补齐 extension/server 配对、运行时诊断和旧配置迁移保护，方便排查浏览器接入问题。

## 类型 / Type of change

- [x] 新功能 (feature)
- [ ] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

/暂无/

## 变更点 / What changed

- 浏览器扩展从旧 `relayUrl` / `webUiUrl` 配置迁移到 `serverOrigin`
- 新增 `/browser/bootstrap` 与 `/browser/diagnostics`，用于扩展自举和运行时排障
- 扩展握手增加 `protocolVersion`、`serverOrigin`、`pairedInstanceId`
- 服务端增加 runtime status / conflicts / issues 输出，并检测旧 bridge 端口冲突
- `tabs` 工具支持带初始 URL 创建新标签页
- Nine1Bot 启动内建 bridge 时注入 `serverOrigin` / `instanceId`
- 配置加载阶段拒绝旧配置 `browser.bridgePort` 与 `mcp.browser`
- `browser` 工具输出补充 runtime diagnostics

## 如何测试 / How to test

1. 运行：
   `bun test packages/nine1bot/src/config/loader.test.ts`
2. 启动 Nine1Bot，并连接浏览器扩展
3. 检查：
   - `/browser/bootstrap` 返回 `serverOrigin` 与 `instanceId`
   - `/browser/diagnostics` 返回 runtime 信息
   - 浏览器状态输出中能看到 extension pairing / conflict / issue 信息
4. 预期结果：
   - 扩展可连接到内建 `/browser/extension`
   - 旧配置会被明确拒绝
   - 运行时诊断信息可用于定位接入问题

## 截图（UI 变更时提供）/ Screenshots for UI changed

/无/

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

请重点看：
- extension 与 server 的 pairing 逻辑是否稳妥
- runtime diagnostics 是否足够解释连接失败/错连场景
- 本 PR 不包含 MCP OAuth 接入，只处理 browser relay 迁移与诊断
