### PR TITLE
feat: add end-to-end remote MCP OAuth flow

### DIFF
--- a/docs/mcp-integration-analysis.md
+++ b/docs/mcp-integration-analysis.md
@@ -1,0 +1,698 @@
+# Nine1Bot MCP 接入与 OAuth 机制分析
+
+## 1. 这套 MCP 到底是怎么分层的
+
+先说结论：
+
+- `nine1bot` 负责用户配置、配置持久化、Web UI、运行时注入环境变量。
+- `opencode` 负责真正的 MCP 客户端实现，包括：
+  - local stdio MCP 连接
+  - remote Streamable HTTP / SSE 连接
+  - OAuth 状态机
+  - token 刷新
+  - 将 MCP tools 包装成模型可调用工具
+- 所以它不是“配置存储在 nine1bot 还是 opencode”二选一，而是：
+  - 持久化配置主要在 `nine1bot`
+  - 运行时执行主要在 `opencode`
+
+```mermaid
+flowchart LR
+    A["Web UI / CLI"] --> B["Nine1Bot 配置层"]
+    B --> C["Nine1Bot Launcher"]
+    C --> D["生成临时 OPENCODE_CONFIG"]
+    C --> E["注入环境变量"]
+    D --> F["OpenCode Server"]
+    E --> F
+    F --> G["MCP 模块"]
+    G --> H["Local MCP (stdio)"]
+    G --> I["Remote MCP (HTTP / SSE)"]
+    I --> J["OAuth Provider / Token Refresh"]
+    J --> K["mcp-auth.json"]
+```
+
+## 2. 配置文件和认证文件到底用的是哪个
+
+### 2.1 Nine1Bot 自己的主配置
+
+Nine1Bot 自己定义了两层配置：
+
+- 全局配置：`~/.config/nine1bot/config.jsonc`
+- 项目配置：项目根目录向上查找的 `nine1bot.config.jsonc` 或 `nine1bot.config.json`
+
+优先级从低到高：
+
+1. `~/.config/nine1bot/config.jsonc`
+2. `nine1bot.config.jsonc`
+
+也就是说，当你在 Nine1Bot 中“正式配置一个 MCP server”时，默认应该认为配置来源是 Nine1Bot 的配置体系，而不是 `opencode/` 子目录。
+
+对应实现：
+
+- `packages/nine1bot/src/config/loader.ts`
+- `packages/nine1bot/src/config/schema.ts`
+
+### 2.2 运行时真正给 opencode 读的配置
+
+Nine1Bot 启动 server 时，会把自己的配置裁剪、转换成 opencode 能识别的格式，然后写入一个临时文件：
+
+- `/tmp/nine1bot/opencode.config.json`
+
+然后通过环境变量传给 opencode：
+
+- `OPENCODE_CONFIG=/tmp/nine1bot/opencode.config.json`
+
+这个临时文件是运行时配置源，不是用户长期维护的配置源。
+
+所以这里要区分：
+
+- 你平时编辑的是 `nine1bot.config.jsonc`
+- opencode 启动后实际读到的是转换后的临时 `opencode.config.json`
+
+### 2.3 OAuth / token 存储文件
+
+Nine1Bot 在启动 opencode 时，会显式覆盖认证存储路径：
+
+- Provider auth：`~/.local/share/nine1bot/auth.json`
+- MCP OAuth auth：`~/.local/share/nine1bot/mcp-auth.json`
+- 项目环境变量目录：`~/.local/share/nine1bot/project-env`
+
+因此在 Nine1Bot 环境下，MCP OAuth 凭证主写入：
+
+- `~/.local/share/nine1bot/mcp-auth.json`
+
+不是默认的 opencode 数据目录。
+
+不过 `opencode/src/mcp/auth.ts` 仍然保留了向后兼容逻辑：
+
+- 如果存在旧的 opencode `mcp-auth.json`，读取时会合并旧文件和新文件
+- 但新的主写入目标优先走 `NINE1BOT_MCP_AUTH_PATH`
+
+### 2.4 opencode 自己还会读哪些配置
+
+如果没被 Nine1Bot 禁掉继承，opencode 还会继续加载这些来源：
+
+1. 远程 `/.well-known/opencode`
+2. `~/.config/opencode/*`
+3. 项目里的 `opencode.jsonc` / `opencode.json`
+4. 项目里的 `.opencode/opencode.jsonc` / `.opencode/opencode.json`
+5. `OPENCODE_CONFIG`
+6. `OPENCODE_CONFIG_CONTENT`
+
+所以最终生效配置并不只来自 Nine1Bot。
+
+## 3. Nine1Bot 对 MCP 的配置格式
+
+Nine1Bot 对 MCP 配置的 schema 在：
+
+- `packages/nine1bot/src/config/schema.ts`
+
+支持三类内容：
+
+### 3.1 local MCP
+
+```jsonc
+{
+  "mcp": {
+    "my-local-server": {
+      "type": "local",
+      "command": ["npx", "-y", "@some/mcp-server"],
+      "environment": {
+        "FOO": "bar"
+      },
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}
+```
+
+### 3.2 remote MCP
+
+```jsonc
+{
+  "mcp": {
+    "my-remote-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/http",
+      "headers": {
+        "X-API-Key": "xxx"
+      },
+      "oauth": {
+        "clientId": "optional-static-client-id",
+        "clientSecret": "optional-secret",
+        "scope": "read write"
+      },
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}
+```
+
+### 3.3 只改 enabled
+
+```jsonc
+{
+  "mcp": {
+    "some-server": {
+      "enabled": false
+    }
+  }
+}
+```
+
+这种写法更多用于覆盖已有继承配置的开关状态。
+
+## 4. MCP 的各种“继承”是怎么设计的
+
+Nine1Bot 在 MCP 这块做了两层继承控制：
+
+### 4.1 Nine1Bot 配置层的继承标志
+
+在 `mcp` 下定义：
+
+```jsonc
+{
+  "mcp": {
+    "inheritOpencode": true,
+    "inheritClaudeCode": true
+  }
+}
+```
+
+含义：
+
+- `inheritOpencode`
+  - 是否继承 opencode 自己的 MCP 配置来源
+  - 包括 `~/.config/opencode`、项目 `opencode.json[c]`、`.opencode/*`
+- `inheritClaudeCode`
+  - 是否继承 Claude Desktop 配置中的 `mcpServers`
+
+### 4.2 启动时如何生效
+
+Nine1Bot Launcher 会把这些继承控制转成环境变量：
+
+- `OPENCODE_DISABLE_OPENCODE_MCP=true`
+- `OPENCODE_DISABLE_CLAUDE_CODE_MCP=true`
+
+也就是说，Nine1Bot 不会自己重新实现一套 MCP 继承器，而是通过 env flag 控制 opencode 的加载行为。
+
+### 4.3 Claude Desktop MCP 的继承来源
+
+如果没禁用，opencode 会去读 Claude Desktop 配置：
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%/Claude/claude_desktop_config.json`
+
+然后把：
+
+```json
+{
+  "mcpServers": {
+    "foo": {
+      "command": "xxx",
+      "args": ["a", "b"],
+      "env": {}
+    }
+  }
+}
+```
+
+转换成 opencode/Nine1Bot 可用的 local MCP：
+
+```json
+{
+  "foo": {
+    "type": "local",
+    "command": ["xxx", "a", "b"],
+    "environment": {},
+    "enabled": true
+  }
+}
+```
+
+### 4.4 最终生效 MCP 配置的心智模型
+
+可以把最终配置理解成：
+
+```text
+远程 well-known
+  -> opencode global config
+  -> Claude Desktop MCP
+  -> Nine1Bot 生成的 OPENCODE_CONFIG
+  -> project opencode config（若未禁用）
+  -> OPENCODE_CONFIG_CONTENT（若有）
+```
+
+但注意一点：
+
+- Nine1Bot 在启动时把自己的 MCP 配置写进 `OPENCODE_CONFIG`
+- Nine1Bot 的 hot reload 又会直接监听 `~/.config/nine1bot/config.jsonc` 和项目 `nine1bot.config.jsonc`
+- 所以从用户视角，真正应该维护的是 Nine1Bot 配置
+
+## 5. 整个请求是怎么包装的
+
+### 5.1 Web 请求到项目上下文
+
+前端会把当前目录作为：
+
+- query 参数 `directory`
+- request header `x-opencode-directory`
+
+一起发给后端。
+
+后端收到请求后，会把这个目录塞进 `Instance.provide({ directory })`，后续：
+
+- 配置解析
+- local MCP 启动 cwd
+- session prompt
+- tool 调用
+
+都会运行在这个目录上下文里。
+
+```mermaid
+sequenceDiagram
+    participant UI as Web UI
+    participant API as OpenCode Server
+    participant Inst as Instance Context
+    participant MCP as MCP Module
+
+    UI->>API: /mcp?directory=/project + x-opencode-directory
+    API->>Inst: Instance.provide(directory)
+    Inst->>MCP: MCP.overview() / connect() / add()
+    MCP-->>API: status/tools/resources/health
+    API-->>UI: JSON
+```
+
+### 5.2 前端对 `/mcp` 的调用
+
+Nine1Bot Web 主要使用这些接口：
+
+- `GET /mcp`：列状态
+- `POST /mcp`：动态添加
+- `DELETE /mcp/:name`：删除
+- `POST /mcp/:name/connect`：连接
+- `POST /mcp/:name/disconnect`：断开
+- `POST /mcp/:name/auth`：启动 OAuth
+- `DELETE /mcp/:name/auth`：清理 OAuth
+- `POST /mcp/:name/health`：健康检查
+
+这些接口本身只是薄薄一层，真正逻辑全部下沉到 `opencode/src/mcp/index.ts`。
+
+## 6. Local MCP 是怎么运作的
+
+这一部分最重要的结论是：
+
+- local MCP 不走 OAuth
+- local MCP 的本质是“当前项目目录下启动一个 stdio 子进程，然后通过 MCP SDK 连上去”
+
+### 6.1 local MCP 建连流程
+
+```mermaid
+sequenceDiagram
+    participant User as 用户/配置
+    participant UI as Web UI
+    participant Server as OpenCode Server
+    participant MCP as MCP.create()
+    participant Proc as Local MCP Process
+
+    User->>UI: 添加 local MCP 配置
+    UI->>Server: POST /mcp
+    Server->>MCP: MCP.add(name, config)
+    MCP->>Proc: StdioClientTransport(command,args,cwd,env)
+    Proc-->>MCP: initialize / tools / resources
+    MCP-->>Server: connected + tools
+    Server-->>UI: status=connected
+```
+
+### 6.2 local MCP 的关键细节
+
+- transport 使用 `StdioClientTransport`
+- `cwd` 不是固定目录，而是当前请求对应的 `Instance.directory`
+- `environment` 会把当前 `process.env` 和 MCP 自己的 `environment` 合并
+- 如果命令本身启动失败，会直接进入 `status=failed`
+
+### 6.3 local MCP 的运行时状态
+
+连接成功后，MCP 模块会拉取：
+
+- `listTools()`
+- `listResources()`
+
+并把这些东西缓存到内存状态中。之后模型能直接把这些 tools 当作普通 tool 调用。
+
+## 7. Remote MCP 是怎么运作的
+
+remote MCP 的本质是：
+
+- 通过 MCP SDK 对远端 MCP endpoint 建 client
+- transport 会依次尝试：
+  - `StreamableHTTPClientTransport`
+  - `SSEClientTransport`
+
+### 7.1 remote MCP 不一定需要 OAuth
+
+remote MCP 有三种典型模式：
+
+1. 纯 headers 鉴权
+2. OAuth
+3. headers + OAuth 混合
+
+如果你配置了：
+
+```jsonc
+{
+  "oauth": false
+}
+```
+
+则显式关闭 OAuth，只按普通 remote 连接处理。
+
+如果没写 `oauth: false`，remote MCP 默认认为“支持 OAuth 能力”。
+
+### 7.2 remote MCP 建连流程
+
+```mermaid
+sequenceDiagram
+    participant UI as Web UI / Agent
+    participant Server as OpenCode Server
+    participant MCP as MCP.create()
+    participant Transport as HTTP/SSE Transport
+    participant Remote as Remote MCP Server
+
+    UI->>Server: connect / add / first use
+    Server->>MCP: create(name, remoteConfig)
+    MCP->>Transport: build authProvider + headers
+    MCP->>Remote: connect via StreamableHTTP
+    alt HTTP 成功
+        Remote-->>MCP: connected
+    else HTTP 失败
+        MCP->>Remote: connect via SSE
+        Remote-->>MCP: connected or auth error
+    end
+    MCP-->>Server: connected / needs_auth / needs_client_registration / failed
+```
+
+### 7.3 建连后的工具包装
+
+一旦 remote MCP 连接成功，系统会：
+
+1. `listTools()`
+2. 把每个 MCP tool 包装成 AI SDK 的 `dynamicTool`
+3. 以 `serverName_toolName` 形式暴露给模型
+
+所以从模型视角看：
+
+- 它不是直接“懂 MCP”
+- 而是通过 opencode 把 MCP tool 再封成模型可调用 tool
+
+## 8. MCP OAuth 是怎么运作的
+
+这是你最关心的部分，可以分成四层理解：
+
+1. 什么时候认为需要 OAuth
+2. OAuth client 是静态注册还是动态注册
+3. 回调走哪里
+4. token 存哪里、什么时候刷新
+
+### 8.1 什么时候触发 OAuth
+
+remote MCP 在建连时，如果 transport 返回认证错误，会进入：
+
+- `needs_auth`
+- 或 `needs_client_registration`
+
+然后系统决定是否启动 OAuth 流程。
+
+另外，如果模型在真正 `callTool()` 时撞到鉴权错误，也会触发重新连接和交互认证。
+
+### 8.2 OAuth client 的两种模式
+
+#### 模式 A：静态 client registration
+
+你手动在配置里提供：
+
+```jsonc
+{
+  "oauth": {
+    "clientId": "...",
+    "clientSecret": "...",
+    "scope": "..."
+  }
+}
+```
+
+这意味着：
+
+- `clientId/clientSecret` 来自配置文件
+- 系统不会依赖动态注册
+- 比较适合企业平台、固定 app 注册场景
+
+#### 模式 B：动态 client registration
+
+如果你没有写 `clientId`，`McpOAuthProvider.clientInformation()` 会先尝试读取本地保存的动态注册信息：
+
+- 如果本地没有，就让 MCP/OAuth SDK 去做动态 client registration
+- 如果远端服务不支持动态注册，就进入 `needs_client_registration`
+
+所以这里的本质判断是：
+
+- 有 `clientId`：走静态注册
+- 没 `clientId`：优先走动态注册
+
+### 8.3 OAuth 的两种回调模式
+
+#### 模式 A：loopback 模式
+
+用于本机交互，例如 CLI 或服务端直接弹浏览器。
+
+回调地址：
+
+- `http://127.0.0.1:19876/mcp/oauth/callback`
+
+流程：
+
+1. 本地起一个临时 callback server
+2. 打开浏览器到授权页
+3. 浏览器授权完成后回调到本机端口
+4. 本地进程拿到 `code`
+5. 完成 token 交换
+
+#### 模式 B：server 模式
+
+用于 Nine1Bot Web UI。
+
+回调地址：
+
+- `http(s)://你的-nine1bot-server/mcp/oauth/callback`
+
+流程：
+
+1. Web UI 调 `POST /mcp/:name/auth`
+2. 后端 `startAuth(mode="server")`
+3. 返回授权 URL
+4. 前端 `window.open(url)`
+5. 浏览器授权完成后重定向回 Nine1Bot 的 `/mcp/oauth/callback`
+6. 后端处理 callback，完成 token 交换
+7. 前端轮询 `/mcp` 状态直到 `connected`
+
+### 8.4 Web UI 下的 OAuth 时序
+
+```mermaid
+sequenceDiagram
+    participant User as 用户
+    participant UI as Web UI
+    participant API as OpenCode /mcp
+    participant OAuth as Remote OAuth Server
+    participant MCP as MCP 模块
+    participant Store as mcp-auth.json
+
+    User->>UI: 点击 Authenticate
+    UI->>API: POST /mcp/:name/auth
+    API->>MCP: startAuth(mode=server)
+    MCP-->>API: authorizationUrl
+    API-->>UI: authorizationUrl
+    UI->>OAuth: 打开 popup 跳转授权页
+    OAuth->>API: GET /mcp/oauth/callback?code=...&state=...
+    API->>MCP: handleOAuthCallback()
+    MCP->>Store: 保存 clientInfo / token / metadata
+    MCP-->>API: success html
+    UI->>API: 轮询 GET /mcp
+    API-->>UI: status=connected
+```
+
+### 8.5 OAuth 的内部关键状态
+
+在 OAuth 流程中，系统会维护：
+
+- `oauthState`
+- `codeVerifier`
+- `clientInfo`
+- `tokens`
+- `issuer`
+- `authorizationEndpoint`
+- `tokenEndpoint`
+- `registrationEndpoint`
+- `lastAuthError`
+
+它们都保存在 `mcp-auth.json` 的对应 server 条目里。
+
+### 8.6 token 刷新机制
+
+`McpOAuthProvider.tokens()` 会先检查：
+
+- token 是否过期
+- token 是否接近过期
+
+如果接近过期并且有 `refreshToken`，就会：
+
+1. 去 `/.well-known/oauth-authorization-server` 拉 metadata
+2. 找到 `token_endpoint`
+3. 发起 refresh token 请求
+4. 成功后写回新 token
+
+如果刷新失败：
+
+- `invalid_client`：清理 token 和 clientInfo
+- `invalid_grant / reauth_required / insufficient_scope`：清理 token
+
+这样下次连接时会重新进入认证流程。
+
+### 8.7 state 校验与安全设计
+
+回调时系统强制校验：
+
+- 必须带 `state`
+- `state` 必须存在于待处理会话里
+
+否则直接判为：
+
+- 缺失 state
+- 非法或过期 state
+- 潜在 CSRF
+
+这是这套 OAuth 流程里最核心的安全边界之一。
+
+## 9. “添加一个 MCP 服务”时，你应该怎么判断走哪条链路
+
+### 9.1 如果你添加的是 local MCP
+
+你应该关注：
+
+1. `type` 是否是 `local`
+2. `command` 能否在当前机器执行
+3. 当前 session/project 的 `directory` 是什么
+4. 是否需要通过 `environment` 注入密钥
+5. 这个 server 本身是否正确走 stdio MCP 协议
+
+你不需要关注：
+
+- OAuth
+- `mcp-auth.json`
+- callback 路由
+
+### 9.2 如果你添加的是 remote MCP，但只是 API key / headers
+
+你应该关注：
+
+1. `type` 是否是 `remote`
+2. `url` 是否正确
+3. `headers` 是否足够
+4. 是否要显式写 `oauth: false`
+
+如果你的远端服务只支持 header/token，不需要 OAuth，建议明确写：
+
+```jsonc
+{
+  "oauth": false
+}
+```
+
+这样可以避免系统误判成 OAuth capable remote server。
+
+### 9.3 如果你添加的是 remote MCP，并且要 OAuth
+
+你应该关注：
+
+1. 服务端是否支持动态 client registration
+2. 如果不支持，是否需要手动配置 `clientId`
+3. 回调场景是 Web UI 还是本机 loopback
+4. token 会保存在 `~/.local/share/nine1bot/mcp-auth.json`
+5. 如果服务端 URL 改了，旧 token 会被视为无效
+
+### 9.4 推荐判断表
+
+| 场景 | type | 是否走 OAuth | 关注点 |
+| --- | --- | --- | --- |
+| 本地命令型 MCP | `local` | 否 | `command`、`cwd`、`environment` |
+| 远端 + API Key | `remote` | 否或应显式禁用 | `url`、`headers`、`oauth: false` |
+| 远端 + 浏览器授权 | `remote` | 是 | `oauth`、回调地址、token 存储 |
+| 企业远端 + 预注册 client | `remote` | 是 | `clientId/clientSecret/scope` |
+
+## 10. 配置修改后如何生效
+
+Nine1Bot 在 MCP 这块不只是“重启后生效”，它还实现了热更新：
+
+- 监听 `~/.config/nine1bot/config.jsonc`
+- 监听项目 `nine1bot.config.jsonc`
+- 每 30 秒检查一次
+
+如果检测到 MCP 配置变化，就会：
+
+1. 新增新 server
+2. 重新连接配置已变的 server
+3. 移除被删除的 server
+
+所以从维护体验上说：
+
+- 正式配置写 Nine1Bot 配置文件
+- opencode 临时 config 负责当前进程运行时读取
+- hot reload 负责把文件变化同步到已运行的 MCP 状态
+
+## 11. 一句话总结整套设计
+
+这套设计的核心不是“把 MCP 重新实现一遍”，而是：
+
+- Nine1Bot 作为外层产品壳，统一管理自己的配置体系、UI、目录上下文和认证存储
+- opencode 作为内层执行引擎，负责真正的 MCP transport、OAuth、tool 包装和连接管理
+- 二者通过：
+  - `OPENCODE_CONFIG`
+  - `NINE1BOT_*` 环境变量
+  - `/mcp` HTTP 路由
+  - `Instance.provide(directory)`
+
+连接在一起
+
+因此在理解和排查问题时，最有效的方式是分三层看：
+
+1. Nine1Bot 配置层：你到底配了什么、写到哪了
+2. opencode 运行层：它最终读到了什么配置
+3. MCP/OAuth 执行层：它到底是 local 建连失败、remote 认证失败，还是 token 刷新失败
+
+## 12. 关键源码索引
+
+### Nine1Bot 配置与启动
+
+- `packages/nine1bot/src/config/loader.ts`
+- `packages/nine1bot/src/config/schema.ts`
+- `packages/nine1bot/src/launcher/server.ts`
+
+### Web UI MCP 交互
+
+- `web/src/api/client.ts`
+- `web/src/components/McpProjectPanel.vue`
+- `web/src/composables/useSettings.ts`
+
+### OpenCode MCP 核心
+
+- `opencode/packages/opencode/src/server/server.ts`
+- `opencode/packages/opencode/src/server/routes/mcp.ts`
+- `opencode/packages/opencode/src/mcp/index.ts`
+- `opencode/packages/opencode/src/mcp/auth.ts`
+- `opencode/packages/opencode/src/mcp/oauth-provider.ts`
+- `opencode/packages/opencode/src/mcp/oauth-callback.ts`
+- `opencode/packages/opencode/src/mcp/hot-reload.ts`
+- `opencode/packages/opencode/src/config/config.ts`
+- `opencode/packages/opencode/src/config/claude-mcp.ts`
+

--- a/nine1bot.config.jsonc.example
+++ b/nine1bot.config.jsonc.example
@@ -24,7 +24,17 @@
     "disableProjectConfig": false
   },
   "provider": {},
-  "mcp": {},
+  "mcp": {
+    // "remote-docs": {
+    //   "type": "remote",
+    //   "url": "https://mcp.example.com/http",
+    //   "oauth": {
+    //     "clientId": "your-client-id",
+    //     "clientSecret": "your-client-secret",
+    //     "scope": "read write"
+    //   }
+    // }
+  },
   "browser": {
     "enabled": false,
     "cdpPort": 9222,

--- a/opencode/packages/opencode/src/cli/cmd/mcp.ts
+++ b/opencode/packages/opencode/src/cli/cmd/mcp.ts
@@ -112,6 +112,9 @@ export const McpListCommand = cmd({
           } else if (status.status === "needs_auth") {
             statusIcon = "⚠"
             statusText = "needs authentication"
+          } else if (status.status === "auth_in_progress") {
+            statusIcon = "◐"
+            statusText = "authentication in progress"
           } else if (status.status === "needs_client_registration") {
             statusIcon = "✗"
             statusText = "needs client registration"
@@ -243,6 +246,12 @@ export const McpAuthCommand = cmd({
 
           if (status.status === "connected") {
             spinner.stop("Authentication successful!")
+          } else if (status.status === "auth_in_progress") {
+            spinner.stop("Authentication in progress")
+            prompts.log.info("Browser authorization is still in progress. Complete it, then retry your request.")
+          } else if (status.status === "needs_auth") {
+            spinner.stop("Authentication requires browser approval")
+            prompts.log.info("Complete the browser authorization to continue.")
           } else if (status.status === "needs_client_registration") {
             spinner.stop("Authentication failed", 1)
             prompts.log.error(status.error)
@@ -690,6 +699,7 @@ export const McpDebugCommand = cmd({
                 clientSecret: oauthConfig?.clientSecret,
                 scope: oauthConfig?.scope,
               },
+              "http://127.0.0.1:19876/mcp/oauth/callback",
               {
                 onRedirect: async () => {},
               },

--- a/opencode/packages/opencode/src/cli/error.ts
+++ b/opencode/packages/opencode/src/cli/error.ts
@@ -6,7 +6,7 @@ import { UI } from "./ui"
 
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
-    return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
+    return `MCP server "${input.data.name}" failed. Check the MCP configuration, connectivity, and authentication state.`
   if (Provider.ModelNotFoundError.isInstance(input)) {
     const { providerID, modelID, suggestions } = input.data
     return [

--- a/opencode/packages/opencode/src/mcp/auth.ts
+++ b/opencode/packages/opencode/src/mcp/auth.ts
@@ -4,11 +4,15 @@ import z from "zod"
 import { Global } from "../global"
 
 export namespace McpAuth {
+  const OAUTH_EXPIRY_SAFETY_WINDOW_SECONDS = 300
+
   export const Tokens = z.object({
     accessToken: z.string(),
     refreshToken: z.string().optional(),
     expiresAt: z.number().optional(),
     scope: z.string().optional(),
+    issuedAt: z.number().optional(),
+    lastRefreshedAt: z.number().optional(),
   })
   export type Tokens = z.infer<typeof Tokens>
 
@@ -23,13 +27,40 @@ export namespace McpAuth {
   export const Entry = z.object({
     tokens: Tokens.optional(),
     clientInfo: ClientInfo.optional(),
+    registrationMode: z.enum(["dynamic", "static"]).optional(),
     codeVerifier: z.string().optional(),
     oauthState: z.string().optional(),
+    authStartedAt: z.number().optional(),
     serverUrl: z.string().optional(), // Track the URL these credentials are for
+    issuer: z.string().optional(),
+    authorizationEndpoint: z.string().optional(),
+    tokenEndpoint: z.string().optional(),
+    registrationEndpoint: z.string().optional(),
+    redirectUrl: z.string().optional(),
+    lastAuthError: z.string().optional(),
+    lastAuthErrorAt: z.number().optional(),
+    lastSuccessAt: z.number().optional(),
   })
   export type Entry = z.infer<typeof Entry>
 
-  const filepath = path.join(Global.Path.data, "mcp-auth.json")
+  const legacyFilepath = path.join(Global.Path.data, "mcp-auth.json")
+
+  function getPrimaryFilePath() {
+    return process.env.NINE1BOT_MCP_AUTH_PATH || legacyFilepath
+  }
+
+  async function loadFile(filePath: string): Promise<Record<string, Entry>> {
+    const data = await Bun.file(filePath).json().catch(() => ({}))
+    return z.record(z.string(), Entry).catch({}).parse(data)
+  }
+
+  async function writeFileAtomically(filePath: string, data: Record<string, Entry>): Promise<void> {
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await Bun.write(tempPath, JSON.stringify(data, null, 2))
+    await fs.chmod(tempPath, 0o600)
+    await fs.rename(tempPath, filePath)
+  }
 
   export async function get(mcpName: string): Promise<Entry | undefined> {
     const data = await all()
@@ -54,38 +85,76 @@ export namespace McpAuth {
   }
 
   export async function all(): Promise<Record<string, Entry>> {
-    const file = Bun.file(filepath)
-    return file.json().catch(() => ({}))
+    const primaryFilepath = getPrimaryFilePath()
+    if (primaryFilepath === legacyFilepath) {
+      return loadFile(primaryFilepath)
+    }
+
+    const [legacy, primary] = await Promise.all([loadFile(legacyFilepath), loadFile(primaryFilepath)])
+    return {
+      ...legacy,
+      ...primary,
+    }
   }
 
   export async function set(mcpName: string, entry: Entry, serverUrl?: string): Promise<void> {
-    const file = Bun.file(filepath)
-    const data = await all()
+    const filepath = getPrimaryFilePath()
+    const data = await loadFile(filepath)
     // Always update serverUrl if provided
     if (serverUrl) {
       entry.serverUrl = serverUrl
     }
-    await Bun.write(file, JSON.stringify({ ...data, [mcpName]: entry }, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    await writeFileAtomically(filepath, { ...data, [mcpName]: entry })
   }
 
   export async function remove(mcpName: string): Promise<void> {
-    const file = Bun.file(filepath)
-    const data = await all()
-    delete data[mcpName]
-    await Bun.write(file, JSON.stringify(data, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    const primaryFilepath = getPrimaryFilePath()
+    const targets = primaryFilepath === legacyFilepath ? [primaryFilepath] : [primaryFilepath, legacyFilepath]
+
+    await Promise.all(
+      targets.map(async (filepath) => {
+        const data = await loadFile(filepath)
+        delete data[mcpName]
+        await writeFileAtomically(filepath, data).catch(() => undefined)
+      }),
+    )
   }
 
   export async function updateTokens(mcpName: string, tokens: Tokens, serverUrl?: string): Promise<void> {
     const entry = (await get(mcpName)) ?? {}
-    entry.tokens = tokens
+    entry.tokens = {
+      ...tokens,
+      issuedAt: tokens.issuedAt ?? Math.floor(Date.now() / 1000),
+      lastRefreshedAt: Math.floor(Date.now() / 1000),
+    }
+    entry.lastSuccessAt = Math.floor(Date.now() / 1000)
+    delete entry.lastAuthError
+    delete entry.lastAuthErrorAt
     await set(mcpName, entry, serverUrl)
   }
 
-  export async function updateClientInfo(mcpName: string, clientInfo: ClientInfo, serverUrl?: string): Promise<void> {
+  export async function updateClientInfo(
+    mcpName: string,
+    clientInfo: ClientInfo,
+    serverUrl?: string,
+    redirectUrl?: string,
+  ): Promise<void> {
     const entry = (await get(mcpName)) ?? {}
     entry.clientInfo = clientInfo
+    entry.registrationMode = "dynamic"
+    if (redirectUrl) {
+      entry.redirectUrl = redirectUrl
+    }
+    await set(mcpName, entry, serverUrl)
+  }
+
+  export async function setRegistrationMode(
+    mcpName: string,
+    registrationMode: "dynamic" | "static",
+    serverUrl?: string,
+  ): Promise<void> {
+    const entry = (await get(mcpName)) ?? {}
+    entry.registrationMode = registrationMode
     await set(mcpName, entry, serverUrl)
   }
 
@@ -106,6 +175,7 @@ export namespace McpAuth {
   export async function updateOAuthState(mcpName: string, oauthState: string): Promise<void> {
     const entry = (await get(mcpName)) ?? {}
     entry.oauthState = oauthState
+    entry.authStartedAt = Math.floor(Date.now() / 1000)
     await set(mcpName, entry)
   }
 
@@ -118,8 +188,54 @@ export namespace McpAuth {
     const entry = await get(mcpName)
     if (entry) {
       delete entry.oauthState
+      delete entry.authStartedAt
       await set(mcpName, entry)
     }
+  }
+
+  export async function clearTokens(mcpName: string): Promise<void> {
+    const entry = await get(mcpName)
+    if (!entry) return
+    delete entry.tokens
+    await set(mcpName, entry)
+  }
+
+  export async function clearClientInfo(mcpName: string): Promise<void> {
+    const entry = await get(mcpName)
+    if (!entry) return
+    delete entry.clientInfo
+    await set(mcpName, entry)
+  }
+
+  export async function updateOAuthMetadata(
+    mcpName: string,
+    metadata: {
+      issuer?: string
+      authorizationEndpoint?: string
+      tokenEndpoint?: string
+      registrationEndpoint?: string
+      redirectUrl?: string
+    },
+    serverUrl?: string,
+  ): Promise<void> {
+    const entry = (await get(mcpName)) ?? {}
+    Object.assign(entry, metadata)
+    await set(mcpName, entry, serverUrl)
+  }
+
+  export async function setLastAuthError(mcpName: string, message: string, serverUrl?: string): Promise<void> {
+    const entry = (await get(mcpName)) ?? {}
+    entry.lastAuthError = message
+    entry.lastAuthErrorAt = Math.floor(Date.now() / 1000)
+    await set(mcpName, entry, serverUrl)
+  }
+
+  export async function clearLastAuthError(mcpName: string): Promise<void> {
+    const entry = await get(mcpName)
+    if (!entry) return
+    delete entry.lastAuthError
+    delete entry.lastAuthErrorAt
+    await set(mcpName, entry)
   }
 
   /**
@@ -130,6 +246,13 @@ export namespace McpAuth {
     const entry = await get(mcpName)
     if (!entry?.tokens) return null
     if (!entry.tokens.expiresAt) return false
-    return entry.tokens.expiresAt < Date.now() / 1000
+    return entry.tokens.expiresAt <= Date.now() / 1000
+  }
+
+  export async function isTokenStale(mcpName: string): Promise<boolean | null> {
+    const entry = await get(mcpName)
+    if (!entry?.tokens) return null
+    if (!entry.tokens.expiresAt) return false
+    return entry.tokens.expiresAt <= Date.now() / 1000 + OAUTH_EXPIRY_SAFETY_WINDOW_SECONDS
   }
 }

--- a/opencode/packages/opencode/src/mcp/index.ts
+++ b/opencode/packages/opencode/src/mcp/index.ts
@@ -444,6 +444,11 @@ export namespace MCP {
     ])
   }
 
+  async function setStatusAfterAuthInterruption(mcpName: string, status: Status) {
+    const nextState = await state()
+    nextState.status[mcpName] = status
+  }
+
   async function retryAfterInvalidClient(session: PendingOAuthSession) {
     return Instance.provide({
       directory: session.directory,
@@ -1836,6 +1841,9 @@ export namespace MCP {
             }
           }
         }
+        await setStatusAfterAuthInterruption(session.mcpName, {
+          status: "needs_auth",
+        })
         await cleanupPendingOAuthSession(session)
       }
       return {
@@ -1845,6 +1853,13 @@ export namespace MCP {
     }
 
     if (!input.code) {
+      const session = pendingOAuthSessions.get(state)
+      if (session) {
+        await setStatusAfterAuthInterruption(session.mcpName, {
+          status: "needs_auth",
+        })
+        await cleanupPendingOAuthSession(session)
+      }
       return {
         html: McpOAuthCallback.renderError("No authorization code provided"),
         status: 400,
@@ -1858,12 +1873,17 @@ export namespace MCP {
       }
     }
 
+    const session = pendingOAuthSessions.get(state)
     const status = await finishAuthByState(state, input.code)
     if (status.status === "connected") {
       return {
         html: McpOAuthCallback.renderSuccess(),
         status: 200,
       }
+    }
+
+    if (session) {
+      await setStatusAfterAuthInterruption(session.mcpName, status)
     }
 
     return {

--- a/opencode/packages/opencode/src/mcp/index.ts
+++ b/opencode/packages/opencode/src/mcp/index.ts
@@ -16,7 +16,7 @@ import z from "zod/v4"
 import { Instance } from "../project/instance"
 import { Installation } from "../installation"
 import { withTimeout } from "@/util/timeout"
-import { McpOAuthProvider } from "./oauth-provider"
+import { McpOAuthProvider, OAUTH_CALLBACK_PATH, OAUTH_CALLBACK_PORT } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
 import { BusEvent } from "../bus/bus-event"
@@ -132,6 +132,13 @@ export namespace MCP {
         }),
       z
         .object({
+          status: z.literal("auth_in_progress"),
+        })
+        .meta({
+          ref: "MCPStatusAuthInProgress",
+        }),
+      z
+        .object({
           status: z.literal("needs_client_registration"),
           error: z.string(),
         })
@@ -170,7 +177,46 @@ export namespace MCP {
   }
 
   // Convert MCP tool definition to AI SDK Tool type
-  async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
+  function isAuthenticationError(error: unknown) {
+    return (
+      error instanceof UnauthorizedError ||
+      (error instanceof Error &&
+        /unauthorized|invalid[_ ]token|reauth|authentication required|invalid_client|invalid_grant/i.test(
+          error.message,
+        ))
+    )
+  }
+
+  type AuthFailureReason = "needs_auth" | "invalid_client" | "invalid_grant" | "registration_required"
+
+  function classifyAuthenticationError(error: unknown): AuthFailureReason | undefined {
+    if (!isAuthenticationError(error)) {
+      return undefined
+    }
+
+    const message = error instanceof Error ? error.message : String(error)
+
+    if (/dynamic client registration|pre-registered client|required clientId|needs_client_registration/i.test(message)) {
+      return "registration_required"
+    }
+
+    if (/invalid_client/i.test(message)) {
+      return "invalid_client"
+    }
+
+    if (/invalid_grant|reauth_required|insufficient_scope/i.test(message)) {
+      return "invalid_grant"
+    }
+
+    return "needs_auth"
+  }
+
+  async function convertMcpTool(
+    serverName: string,
+    mcpTool: MCPToolDef,
+    client: MCPClient,
+    timeout?: number,
+  ): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
     // Spread first, then override type to ensure it's always "object"
@@ -185,17 +231,54 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
-        return client.callTool(
-          {
-            name: mcpTool.name,
-            arguments: args as Record<string, unknown>,
-          },
-          CallToolResultSchema,
-          {
-            resetTimeoutOnProgress: true,
-            timeout,
-          },
-        )
+        try {
+          return await client.callTool(
+            {
+              name: mcpTool.name,
+              arguments: args as Record<string, unknown>,
+            },
+            CallToolResultSchema,
+            {
+              resetTimeoutOnProgress: true,
+              timeout,
+            },
+          )
+        } catch (error) {
+          if (!isAuthenticationError(error)) {
+            throw error
+          }
+
+          const message = error instanceof Error ? error.message : String(error)
+          await markFailed(serverName, message)
+
+          const cfg = await Config.get()
+          const entry = cfg.mcp?.[serverName]
+          if (!entry || !isMcpConfigured(entry)) {
+            throw error
+          }
+
+          const recovered = await ensureServerConnected(serverName, entry, { interactiveAuth: true })
+          if (!recovered) {
+            throw error
+          }
+
+          const refreshedClient = (await clients())[serverName]
+          if (!refreshedClient) {
+            throw error
+          }
+
+          return refreshedClient.callTool(
+            {
+              name: mcpTool.name,
+              arguments: args as Record<string, unknown>,
+            },
+            CallToolResultSchema,
+            {
+              resetTimeoutOnProgress: true,
+              timeout,
+            },
+          )
+        }
       },
     })
   }
@@ -218,9 +301,28 @@ export namespace MCP {
     s.resources[serverName] = resourcesResult.resources.map(toResourceInfo)
   }
 
-  // Store transports for OAuth servers to allow finishing auth
   type TransportWithAuth = StreamableHTTPClientTransport | SSEClientTransport
-  const pendingOAuthTransports = new Map<string, TransportWithAuth>()
+  type StartAuthMode = "loopback" | "server"
+
+  type StartAuthOptions = {
+    mode?: StartAuthMode
+    serverOrigin?: string
+    attempt?: number
+  }
+
+  type PendingOAuthSession = {
+    directory: string
+    mcpName: string
+    state: string
+    transport: TransportWithAuth
+    mode: StartAuthMode
+    serverOrigin?: string
+    attempt: number
+  }
+
+  const pendingOAuthSessions = new Map<string, PendingOAuthSession>()
+  const connectionFlights = new Map<string, Promise<boolean>>()
+  const authLaunchFlights = new Map<string, Promise<Status>>()
 
   // Prompt cache types
   type PromptInfo = Awaited<ReturnType<MCPClient["listPrompts"]>>["prompts"][number]
@@ -231,9 +333,237 @@ export namespace MCP {
     return typeof entry === "object" && entry !== null && "type" in entry
   }
 
+  type McpRemote = Extract<Config.Mcp, { type: "remote" }>
+
   type ReconnectState = {
     attempts: number
     nextAt: number
+  }
+
+  function createOAuthState() {
+    return Array.from(crypto.getRandomValues(new Uint8Array(32)))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  }
+
+  function getLoopbackRedirectUrl() {
+    return `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
+  }
+
+  function getServerRedirectUrl(serverOrigin: string) {
+    if (!serverOrigin) {
+      throw new Error("Server origin is required for MCP OAuth server callback mode")
+    }
+    return `${serverOrigin.replace(/\/$/, "")}/mcp/oauth/callback`
+  }
+
+  function createRemoteTransports(mcp: McpRemote, authProvider?: McpOAuthProvider) {
+    return [
+      {
+        name: "StreamableHTTP",
+        transport: new StreamableHTTPClientTransport(new URL(mcp.url), {
+          authProvider,
+          requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
+        }),
+      },
+      {
+        name: "SSE",
+        transport: new SSEClientTransport(new URL(mcp.url), {
+          authProvider,
+          requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
+        }),
+      },
+    ] satisfies Array<{ name: string; transport: TransportWithAuth }>
+  }
+
+  function buildOAuthProvider(
+    mcpName: string,
+    mcp: McpRemote,
+    redirectUrl: string,
+    onRedirect: (url: URL) => void | Promise<void>,
+  ) {
+    const oauthConfig = typeof mcp.oauth === "object" ? mcp.oauth : undefined
+    return new McpOAuthProvider(
+      mcpName,
+      mcp.url,
+      {
+        clientId: oauthConfig?.clientId,
+        clientSecret: oauthConfig?.clientSecret,
+        scope: oauthConfig?.scope,
+      },
+      redirectUrl,
+      {
+        onRedirect,
+      },
+    )
+  }
+
+  function hasStaticClientRegistration(mcp: McpRemote) {
+    return typeof mcp.oauth === "object" && Boolean(mcp.oauth.clientId)
+  }
+
+  async function clearDynamicOAuthState(mcpName: string) {
+    await Promise.all([
+      McpAuth.clearTokens(mcpName),
+      McpAuth.clearClientInfo(mcpName),
+      McpAuth.clearLastAuthError(mcpName),
+    ]).catch(() => undefined)
+  }
+
+  function isFeishuLikeServer(serverName: string, mcp: McpRemote) {
+    return /lark|feishu/i.test(serverName) || /lark|feishu/i.test(mcp.url)
+  }
+
+  function shouldPreflightFeishuIntent(userText: string) {
+    return /飞书|feishu|lark|知识库|文档|wiki|docs|群聊|群|chat|消息/i.test(userText)
+  }
+
+  function getPendingSessionByName(mcpName: string) {
+    for (const session of pendingOAuthSessions.values()) {
+      if (session.mcpName === mcpName) {
+        return session
+      }
+    }
+  }
+
+  function clearPendingSessionsForName(mcpName: string) {
+    for (const [state, session] of pendingOAuthSessions.entries()) {
+      if (session.mcpName === mcpName) {
+        pendingOAuthSessions.delete(state)
+        McpOAuthCallback.cancelPending(state)
+      }
+    }
+  }
+
+  async function cleanupPendingOAuthSession(session: PendingOAuthSession) {
+    pendingOAuthSessions.delete(session.state)
+    McpOAuthCallback.cancelPending(session.state)
+    await Promise.all([
+      McpAuth.clearOAuthState(session.mcpName).catch(() => undefined),
+      McpAuth.clearCodeVerifier(session.mcpName).catch(() => undefined),
+    ])
+  }
+
+  async function retryAfterInvalidClient(session: PendingOAuthSession) {
+    return Instance.provide({
+      directory: session.directory,
+      fn: async () => {
+        const cfg = await Config.get()
+        const mcpConfig = cfg.mcp?.[session.mcpName]
+        if (!mcpConfig || !isMcpConfigured(mcpConfig) || mcpConfig.type !== "remote") {
+          return undefined
+        }
+
+        await clearDynamicOAuthState(session.mcpName)
+
+        if (session.attempt >= 1 || hasStaticClientRegistration(mcpConfig)) {
+          return undefined
+        }
+
+        await cleanupPendingOAuthSession(session)
+
+        const { authorizationUrl } = await startAuth(session.mcpName, {
+          mode: session.mode,
+          serverOrigin: session.serverOrigin,
+          attempt: session.attempt + 1,
+        })
+        const oauthState = await McpAuth.getOAuthState(session.mcpName)
+        if (!authorizationUrl || !oauthState) {
+          return undefined
+        }
+
+        return {
+          authorizationUrl,
+          oauthState,
+        }
+      },
+    })
+  }
+
+  async function runBrowserAuthorization(
+    mcpName: string,
+    authorizationUrl: string,
+    oauthState: string,
+  ): Promise<Status> {
+    log.info("launching background oauth flow", { mcpName, authorizationUrl, oauthState })
+    const s = await state()
+    s.status[mcpName] = {
+      status: "auth_in_progress",
+    }
+
+    const callbackPromise = McpOAuthCallback.waitForCallback(oauthState)
+
+    try {
+      const subprocess = await open(authorizationUrl)
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => resolve(), 500)
+        subprocess.on("error", (error) => {
+          clearTimeout(timeout)
+          reject(error)
+        })
+        subprocess.on("exit", (code) => {
+          if (code !== null && code !== 0) {
+            clearTimeout(timeout)
+            reject(new Error(`Browser open failed with exit code ${code}`))
+          }
+        })
+      })
+    } catch (error) {
+      log.warn("failed to open browser, user must open URL manually", { mcpName, error })
+      await Bus.publish(BrowserOpenFailed, { mcpName, url: authorizationUrl }).catch(() => undefined)
+    }
+
+    try {
+      const code = await callbackPromise
+      const status = await finishAuthByState(oauthState, code)
+      const nextState = await state()
+      nextState.status[mcpName] = status
+      return status
+    } catch (error) {
+      const oauthError =
+        error && typeof error === "object" && "oauthError" in error && typeof error.oauthError === "string"
+          ? error.oauthError
+          : undefined
+      const session = pendingOAuthSessions.get(oauthState)
+      if (oauthError === "invalid_client" && session) {
+        log.warn("received invalid_client during browser authorization, retrying with fresh registration", {
+          mcpName,
+          attempt: session.attempt,
+        })
+        const recovered = await retryAfterInvalidClient(session)
+        if (recovered) {
+          return runBrowserAuthorization(mcpName, recovered.authorizationUrl, recovered.oauthState)
+        }
+      }
+      if (session) {
+        await cleanupPendingOAuthSession(session)
+      }
+      log.error("background oauth flow failed", { mcpName, error })
+      const nextState = await state()
+      const status: Status = {
+        status: "needs_auth",
+      }
+      nextState.status[mcpName] = status
+      return status
+    }
+  }
+
+  async function launchBrowserAuthorization(
+    mcpName: string,
+    authorizationUrl: string,
+    oauthState: string,
+  ): Promise<Status> {
+    const existing = authLaunchFlights.get(mcpName)
+    if (existing) {
+      return existing
+    }
+
+    const flight = runBrowserAuthorization(mcpName, authorizationUrl, oauthState).finally(() => {
+      authLaunchFlights.delete(mcpName)
+    })
+
+    authLaunchFlights.set(mcpName, flight)
+    return flight
   }
 
   function toToolInfo(tool: MCPToolDef): ToolInfo {
@@ -287,6 +617,133 @@ export namespace MCP {
       attempts,
       nextAt: computeNextReconnect(attempts),
     }
+  }
+
+  async function syncCreateResult(serverName: string, result: Awaited<ReturnType<typeof create>>) {
+    const s = await state()
+    const existingClient = s.clients[serverName]
+
+    s.status[serverName] = result.status
+
+    if (result.mcpClient) {
+      if (existingClient && existingClient !== result.mcpClient) {
+        await existingClient.close().catch((error) => {
+          log.error("Failed to close existing MCP client", { serverName, error })
+        })
+      }
+      s.clients[serverName] = result.mcpClient
+    } else if (existingClient) {
+      await existingClient.close().catch((error) => {
+        log.error("Failed to close existing MCP client", { serverName, error })
+      })
+      delete s.clients[serverName]
+    }
+
+    if (result.tools) {
+      s.tools[serverName] = result.tools
+    } else {
+      delete s.tools[serverName]
+    }
+
+    if (result.resources) {
+      s.resources[serverName] = result.resources
+    } else {
+      delete s.resources[serverName]
+    }
+
+    if (result.health) {
+      s.health[serverName] = result.health
+    } else {
+      delete s.health[serverName]
+    }
+  }
+
+  type EnsureServerConnectedOptions = {
+    interactiveAuth?: boolean
+    waitForAuthMs?: number
+  }
+
+  async function ensureServerConnected(
+    serverName: string,
+    entry: Config.Mcp,
+    options: EnsureServerConnectedOptions = {},
+  ): Promise<boolean> {
+    const existing = connectionFlights.get(serverName)
+    if (existing) {
+      return existing
+    }
+
+    const flight = (async () => {
+      const interactiveAuth = options.interactiveAuth ?? true
+      const waitForAuthMs = options.waitForAuthMs ?? 0
+      const s = await state()
+      if (s.status[serverName]?.status === "connected" && s.clients[serverName]) {
+        return true
+      }
+
+      const result = await create(serverName, entry)
+      await syncCreateResult(serverName, result)
+
+      if (result.status.status === "connected" && result.mcpClient) {
+        return true
+      }
+
+      if (!interactiveAuth || entry.type !== "remote" || entry.oauth === false) {
+        return false
+      }
+
+      const authStatus = await getAuthStatus(serverName)
+      const shouldAuthenticate =
+        result.status.status === "needs_auth" ||
+        result.status.status === "needs_client_registration" ||
+        authStatus === "not_authenticated" ||
+        authStatus === "expired"
+
+      if (!shouldAuthenticate) {
+        return false
+      }
+
+      const { authorizationUrl } = await startAuth(serverName, { mode: "loopback" })
+      if (!authorizationUrl) {
+        const nextState = await state()
+        return nextState.status[serverName]?.status === "connected"
+      }
+
+      const oauthState = await McpAuth.getOAuthState(serverName)
+      if (!oauthState) {
+        return false
+      }
+
+      const launch = launchBrowserAuthorization(serverName, authorizationUrl, oauthState)
+      if (waitForAuthMs <= 0) {
+        void launch
+        return false
+      }
+
+      const outcome = await Promise.race([
+        launch.then(() => "completed" as const),
+        new Promise<"timeout">((resolve) => {
+          const timer = setTimeout(() => resolve("timeout"), waitForAuthMs)
+          timer.unref?.()
+        }),
+      ])
+
+      if (outcome === "completed") {
+        const nextState = await state()
+        return nextState.status[serverName]?.status === "connected"
+      }
+
+      const nextState = await state()
+      nextState.status[serverName] = {
+        status: "auth_in_progress",
+      }
+      return false
+    })().finally(() => {
+      connectionFlights.delete(serverName)
+    })
+
+    connectionFlights.set(serverName, flight)
+    return flight
   }
 
   const state = Instance.state(
@@ -360,7 +817,7 @@ export namespace MCP {
           }),
         ),
       )
-      pendingOAuthTransports.clear()
+      pendingOAuthSessions.clear()
     },
   )
 
@@ -473,43 +930,21 @@ export namespace MCP {
     if (mcp.type === "remote") {
       // OAuth is enabled by default for remote servers unless explicitly disabled with oauth: false
       const oauthDisabled = mcp.oauth === false
-      const oauthConfig = typeof mcp.oauth === "object" ? mcp.oauth : undefined
       let authProvider: McpOAuthProvider | undefined
 
       if (!oauthDisabled) {
-        authProvider = new McpOAuthProvider(
+        authProvider = buildOAuthProvider(
           key,
-          mcp.url,
-          {
-            clientId: oauthConfig?.clientId,
-            clientSecret: oauthConfig?.clientSecret,
-            scope: oauthConfig?.scope,
-          },
-          {
-            onRedirect: async (url) => {
-              log.info("oauth redirect requested", { key, url: url.toString() })
-              // Store the URL - actual browser opening is handled by startAuth
-            },
+          mcp,
+          getLoopbackRedirectUrl(),
+          async (url) => {
+            log.info("oauth redirect requested", { key, url: url.toString() })
+            // Store the URL - actual browser opening is handled by startAuth
           },
         )
       }
 
-      const transports: Array<{ name: string; transport: TransportWithAuth }> = [
-        {
-          name: "StreamableHTTP",
-          transport: new StreamableHTTPClientTransport(new URL(mcp.url), {
-            authProvider,
-            requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
-          }),
-        },
-        {
-          name: "SSE",
-          transport: new SSEClientTransport(new URL(mcp.url), {
-            authProvider,
-            requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
-          }),
-        },
-      ]
+      const transports = createRemoteTransports(mcp, authProvider)
 
       let lastError: Error | undefined
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
@@ -529,16 +964,14 @@ export namespace MCP {
           lastError = error instanceof Error ? error : new Error(String(error))
 
           // Handle OAuth-specific errors
-          if (error instanceof UnauthorizedError) {
+          if (isAuthenticationError(error)) {
             log.info("mcp server requires authentication", { key, transport: name })
-
-            // Check if this is a "needs registration" error
-            if (lastError.message.includes("registration") || lastError.message.includes("client_id")) {
+            const reason = classifyAuthenticationError(lastError)
+            if (reason === "registration_required" && !hasStaticClientRegistration(mcp)) {
               status = {
                 status: "needs_client_registration" as const,
                 error: "Server does not support dynamic client registration. Please provide clientId in config.",
               }
-              // Show toast for needs_client_registration
               Bus.publish(TuiEvent.ToastShow, {
                 title: "MCP Authentication Required",
                 message: `Server "${key}" requires a pre-registered client ID. Add clientId to your config.`,
@@ -546,13 +979,14 @@ export namespace MCP {
                 duration: 8000,
               }).catch((e) => log.debug("failed to show toast", { error: e }))
             } else {
-              // Store transport for later finishAuth call
-              pendingOAuthTransports.set(key, transport)
+              if (reason === "invalid_client" && !hasStaticClientRegistration(mcp)) {
+                await clearDynamicOAuthState(key)
+              }
+
               status = { status: "needs_auth" as const }
-              // Show toast for needs_auth
               Bus.publish(TuiEvent.ToastShow, {
                 title: "MCP Authentication Required",
-                message: `Server "${key}" requires authentication. Run: opencode mcp auth ${key}`,
+                message: `Server "${key}" requires browser authorization.`,
                 variant: "warning",
                 duration: 8000,
               }).catch((e) => log.debug("failed to show toast", { error: e }))
@@ -667,11 +1101,17 @@ export namespace MCP {
     }
 
     const tools = result.tools.map(toToolInfo)
+    const resourcesResult = await withTimeout(mcpClient.listResources(), mcp.timeout ?? DEFAULT_TIMEOUT).catch((err) => {
+      log.debug("failed to get resources from client", { key, error: err })
+      return undefined
+    })
+    const resources = resourcesResult?.resources.map(toResourceInfo)
     const health: Health = {
       ok: true,
       checkedAt: new Date().toISOString(),
       latencyMs: Date.now() - toolStart,
       tools: tools.length,
+      resources: resources?.length,
     }
 
     log.info("create() successfully created client", { key, toolCount: result.tools.length })
@@ -679,6 +1119,7 @@ export namespace MCP {
       mcpClient,
       status,
       tools,
+      resources,
       health,
     }
   }
@@ -722,6 +1163,8 @@ export namespace MCP {
 
     return result
   }
+
+  const healthInFlight = new Map<string, Promise<Health>>()
 
   async function pingServer(
     serverName: string,
@@ -1003,12 +1446,13 @@ export namespace MCP {
   }
 
   export async function tools() {
-    const result: Record<string, Tool> = {}
-    const s = await state()
     const cfg = await Config.get()
     const config = cfg.mcp ?? {}
-    const clientsSnapshot = await clients()
+    const s = await state()
     const defaultTimeout = cfg.experimental?.mcp_timeout
+    const result: Record<string, Tool> = {}
+
+    const clientsSnapshot = await clients()
 
     for (const [clientName, client] of Object.entries(clientsSnapshot)) {
       // Only include tools from connected MCPs (skip disabled ones)
@@ -1037,7 +1481,12 @@ export namespace MCP {
       for (const mcpTool of toolsResult.tools) {
         const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = mcpTool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(mcpTool, client, timeout)
+        result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(
+          clientName,
+          mcpTool,
+          client,
+          timeout,
+        )
       }
     }
     return result
@@ -1086,8 +1535,16 @@ export namespace MCP {
   }
 
   export async function getPrompt(clientName: string, name: string, args?: Record<string, string>) {
-    const clientsSnapshot = await clients()
-    const client = clientsSnapshot[clientName]
+    let client = (await clients())[clientName]
+
+    if (!client) {
+      const cfg = await Config.get()
+      const entry = cfg.mcp?.[clientName]
+      if (entry && isMcpConfigured(entry)) {
+        await ensureServerConnected(clientName, entry, { interactiveAuth: true })
+        client = (await clients())[clientName]
+      }
+    }
 
     if (!client) {
       log.warn("client not found for prompt", {
@@ -1114,8 +1571,16 @@ export namespace MCP {
   }
 
   export async function readResource(clientName: string, resourceUri: string) {
-    const clientsSnapshot = await clients()
-    const client = clientsSnapshot[clientName]
+    let client = (await clients())[clientName]
+
+    if (!client) {
+      const cfg = await Config.get()
+      const entry = cfg.mcp?.[clientName]
+      if (entry && isMcpConfigured(entry)) {
+        await ensureServerConnected(clientName, entry, { interactiveAuth: true })
+        client = (await clients())[clientName]
+      }
+    }
 
     if (!client) {
       log.warn("client not found for prompt", {
@@ -1140,11 +1605,62 @@ export namespace MCP {
     return result
   }
 
+  async function finishAuthByState(oauthState: string, authorizationCode: string): Promise<Status> {
+    const session = pendingOAuthSessions.get(oauthState)
+
+    if (!session) {
+      throw new Error("No pending OAuth flow for the provided state")
+    }
+
+    try {
+      return await Instance.provide({
+        directory: session.directory,
+        fn: async () => {
+          const storedState = await McpAuth.getOAuthState(session.mcpName)
+          if (storedState !== oauthState) {
+            throw new Error("OAuth state mismatch - potential CSRF attack")
+          }
+
+          await session.transport.finishAuth(authorizationCode)
+          await McpAuth.clearCodeVerifier(session.mcpName)
+
+          const cfg = await Config.get()
+          const mcpConfig = cfg.mcp?.[session.mcpName]
+
+          if (!mcpConfig) {
+            throw new Error(`MCP server not found: ${session.mcpName}`)
+          }
+
+          if (!isMcpConfigured(mcpConfig)) {
+            throw new Error(`MCP server ${session.mcpName} is disabled or missing configuration`)
+          }
+
+          const result = await add(session.mcpName, mcpConfig)
+          const statusRecord = result.status as Record<string, Status>
+          return statusRecord[session.mcpName] ?? { status: "failed", error: "Unknown error after auth" }
+        },
+      })
+    } catch (error) {
+      log.error("failed to finish oauth", { mcpName: session.mcpName, error })
+      return {
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      }
+    } finally {
+      pendingOAuthSessions.delete(oauthState)
+      await McpAuth.clearCodeVerifier(session.mcpName).catch(() => undefined)
+      await McpAuth.clearOAuthState(session.mcpName).catch(() => undefined)
+    }
+  }
+
   /**
    * Start OAuth authentication flow for an MCP server.
    * Returns the authorization URL that should be opened in a browser.
    */
-  export async function startAuth(mcpName: string): Promise<{ authorizationUrl: string }> {
+  export async function startAuth(
+    mcpName: string,
+    options: StartAuthOptions = {},
+  ): Promise<{ authorizationUrl: string }> {
     const cfg = await Config.get()
     const mcpConfig = cfg.mcp?.[mcpName]
 
@@ -1164,57 +1680,96 @@ export namespace MCP {
       throw new Error(`MCP server ${mcpName} has OAuth explicitly disabled`)
     }
 
-    // Start the callback server
-    await McpOAuthCallback.ensureRunning()
+    const mode = options.mode ?? "loopback"
+    if (mode === "loopback") {
+      await McpOAuthCallback.ensureRunning()
+    }
 
-    // Generate and store a cryptographically secure state parameter BEFORE creating the provider
-    // The SDK will call provider.state() to read this value
-    const oauthState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("")
+    const oauthState = createOAuthState()
     await McpAuth.updateOAuthState(mcpName, oauthState)
 
-    // Create a new auth provider for this flow
-    // OAuth config is optional - if not provided, we'll use auto-discovery
-    const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
-    let capturedUrl: URL | undefined
-    const authProvider = new McpOAuthProvider(
-      mcpName,
-      mcpConfig.url,
-      {
-        clientId: oauthConfig?.clientId,
-        clientSecret: oauthConfig?.clientSecret,
-        scope: oauthConfig?.scope,
-      },
-      {
-        onRedirect: async (url) => {
-          capturedUrl = url
-        },
-      },
-    )
+    const redirectUrl =
+      mode === "server"
+        ? getServerRedirectUrl(options.serverOrigin ?? "")
+        : getLoopbackRedirectUrl()
 
-    // Create transport with auth provider
-    const transport = new StreamableHTTPClientTransport(new URL(mcpConfig.url), {
-      authProvider,
-    })
+    const connectTimeout = mcpConfig.timeout ?? DEFAULT_TIMEOUT
 
-    // Try to connect - this will trigger the OAuth flow
     try {
-      const client = new Client({
-        name: "opencode",
-        version: Installation.VERSION,
-      })
-      await client.connect(transport)
-      // If we get here, we're already authenticated
-      return { authorizationUrl: "" }
-    } catch (error) {
-      if (error instanceof UnauthorizedError && capturedUrl) {
-        // Store transport for finishAuth
-        pendingOAuthTransports.set(mcpName, transport)
-        return { authorizationUrl: capturedUrl.toString() }
+      for (let attempt = 0; attempt < 2; attempt++) {
+        let capturedUrl: URL | undefined
+        const authProvider = buildOAuthProvider(
+          mcpName,
+          mcpConfig,
+          redirectUrl,
+          async (url) => {
+            capturedUrl = url
+          },
+        )
+        const transports = createRemoteTransports(mcpConfig, authProvider)
+        let retryAfterInvalidClient = false
+
+        for (const { name, transport } of transports) {
+          try {
+            const client = new Client({
+              name: "opencode",
+              version: Installation.VERSION,
+            })
+            await withTimeout(client.connect(transport), connectTimeout)
+            await client.close().catch(() => undefined)
+            return { authorizationUrl: "" }
+          } catch (error) {
+            const reason = classifyAuthenticationError(error)
+            if (isAuthenticationError(error) && capturedUrl) {
+              pendingOAuthSessions.set(oauthState, {
+                directory: Instance.directory,
+                mcpName,
+                state: oauthState,
+                transport,
+                mode,
+                serverOrigin: options.serverOrigin,
+                attempt: options.attempt ?? 0,
+              })
+              const s = await state()
+              s.status[mcpName] = {
+                status: "auth_in_progress",
+              }
+              return { authorizationUrl: capturedUrl.toString() }
+            }
+
+            if (reason === "invalid_client" && !hasStaticClientRegistration(mcpConfig) && attempt === 0) {
+              await clearDynamicOAuthState(mcpName)
+              retryAfterInvalidClient = true
+              break
+            }
+
+            if (reason === "registration_required" && !hasStaticClientRegistration(mcpConfig)) {
+              throw new Error("Server does not support dynamic client registration. Please provide clientId in config.")
+            }
+
+            log.debug("oauth start transport failed", {
+              mcpName,
+              transport: name,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+
+        if (retryAfterInvalidClient) {
+          continue
+        }
+
+        break
       }
+    } catch (error) {
+      await McpAuth.clearOAuthState(mcpName).catch(() => undefined)
+      await McpAuth.clearCodeVerifier(mcpName).catch(() => undefined)
       throw error
     }
+
+    await McpAuth.clearOAuthState(mcpName).catch(() => undefined)
+    await McpAuth.clearCodeVerifier(mcpName).catch(() => undefined)
+    throw new Error(`Failed to start OAuth flow for MCP server: ${mcpName}`)
   }
 
   /**
@@ -1222,112 +1777,98 @@ export namespace MCP {
    * Opens the browser and waits for callback.
    */
   export async function authenticate(mcpName: string): Promise<Status> {
-    const { authorizationUrl } = await startAuth(mcpName)
+    const { authorizationUrl } = await startAuth(mcpName, { mode: "loopback" })
 
     if (!authorizationUrl) {
-      // Already authenticated
       const s = await state()
       return s.status[mcpName] ?? { status: "connected" }
     }
 
-    // Get the state that was already generated and stored in startAuth()
     const oauthState = await McpAuth.getOAuthState(mcpName)
     if (!oauthState) {
       throw new Error("OAuth state not found - this should not happen")
     }
 
-    // The SDK has already added the state parameter to the authorization URL
-    // We just need to open the browser
     log.info("opening browser for oauth", { mcpName, url: authorizationUrl, state: oauthState })
-
-    // Register the callback BEFORE opening the browser to avoid race condition
-    // when the IdP has an active SSO session and redirects immediately
-    const callbackPromise = McpOAuthCallback.waitForCallback(oauthState)
-
-    try {
-      const subprocess = await open(authorizationUrl)
-      // The open package spawns a detached process and returns immediately.
-      // We need to listen for errors which fire asynchronously:
-      // - "error" event: command not found (ENOENT)
-      // - "exit" with non-zero code: command exists but failed (e.g., no display)
-      await new Promise<void>((resolve, reject) => {
-        // Give the process a moment to fail if it's going to
-        const timeout = setTimeout(() => resolve(), 500)
-        subprocess.on("error", (error) => {
-          clearTimeout(timeout)
-          reject(error)
-        })
-        subprocess.on("exit", (code) => {
-          if (code !== null && code !== 0) {
-            clearTimeout(timeout)
-            reject(new Error(`Browser open failed with exit code ${code}`))
-          }
-        })
-      })
-    } catch (error) {
-      // Browser opening failed (e.g., in remote/headless sessions like SSH, devcontainers)
-      // Emit event so CLI can display the URL for manual opening
-      log.warn("failed to open browser, user must open URL manually", { mcpName, error })
-      Bus.publish(BrowserOpenFailed, { mcpName, url: authorizationUrl })
-    }
-
-    // Wait for callback using the already-registered promise
-    const code = await callbackPromise
-
-    // Validate and clear the state
-    const storedState = await McpAuth.getOAuthState(mcpName)
-    if (storedState !== oauthState) {
-      await McpAuth.clearOAuthState(mcpName)
-      throw new Error("OAuth state mismatch - potential CSRF attack")
-    }
-
-    await McpAuth.clearOAuthState(mcpName)
-
-    // Finish auth
-    return finishAuth(mcpName, code)
+    return launchBrowserAuthorization(mcpName, authorizationUrl, oauthState)
   }
 
   /**
    * Complete OAuth authentication with the authorization code.
    */
   export async function finishAuth(mcpName: string, authorizationCode: string): Promise<Status> {
-    const transport = pendingOAuthTransports.get(mcpName)
+    const storedState = await McpAuth.getOAuthState(mcpName)
+    const sessionState = storedState ?? getPendingSessionByName(mcpName)?.state
 
-    if (!transport) {
+    if (!sessionState) {
       throw new Error(`No pending OAuth flow for MCP server: ${mcpName}`)
     }
 
-    try {
-      // Call finishAuth on the transport
-      await transport.finishAuth(authorizationCode)
+    return finishAuthByState(sessionState, authorizationCode)
+  }
 
-      // Clear the code verifier after successful auth
-      await McpAuth.clearCodeVerifier(mcpName)
+  export async function handleOAuthCallback(input: {
+    code?: string | null
+    state?: string | null
+    error?: string | null
+    errorDescription?: string | null
+    oauthError?: string | null
+  }): Promise<{ html: string; status: number } | { redirectUrl: string; status: number }> {
+    const state = input.state ?? undefined
 
-      // Now try to reconnect
-      const cfg = await Config.get()
-      const mcpConfig = cfg.mcp?.[mcpName]
-
-      if (!mcpConfig) {
-        throw new Error(`MCP server not found: ${mcpName}`)
-      }
-
-      if (!isMcpConfigured(mcpConfig)) {
-        throw new Error(`MCP server ${mcpName} is disabled or missing configuration`)
-      }
-
-      // Re-add the MCP server to establish connection
-      pendingOAuthTransports.delete(mcpName)
-      const result = await add(mcpName, mcpConfig)
-
-      const statusRecord = result.status as Record<string, Status>
-      return statusRecord[mcpName] ?? { status: "failed", error: "Unknown error after auth" }
-    } catch (error) {
-      log.error("failed to finish oauth", { mcpName, error })
+    if (!state) {
       return {
-        status: "failed",
-        error: error instanceof Error ? error.message : String(error),
+        html: McpOAuthCallback.renderError("Missing required state parameter - potential CSRF attack"),
+        status: 400,
       }
+    }
+
+    if (input.error) {
+      const errorMessage = input.errorDescription || input.error
+      const session = pendingOAuthSessions.get(state)
+      if (session) {
+        if (input.oauthError === "invalid_client") {
+          const recovered = await retryAfterInvalidClient(session)
+          if (recovered) {
+            return {
+              redirectUrl: recovered.authorizationUrl,
+              status: 302,
+            }
+          }
+        }
+        await cleanupPendingOAuthSession(session)
+      }
+      return {
+        html: McpOAuthCallback.renderError(errorMessage),
+        status: 400,
+      }
+    }
+
+    if (!input.code) {
+      return {
+        html: McpOAuthCallback.renderError("No authorization code provided"),
+        status: 400,
+      }
+    }
+
+    if (!pendingOAuthSessions.has(state)) {
+      return {
+        html: McpOAuthCallback.renderError("Invalid or expired state parameter - potential CSRF attack"),
+        status: 400,
+      }
+    }
+
+    const status = await finishAuthByState(state, input.code)
+    if (status.status === "connected") {
+      return {
+        html: McpOAuthCallback.renderSuccess(),
+        status: 200,
+      }
+    }
+
+    return {
+      html: McpOAuthCallback.renderError(status.status === "failed" ? status.error : "OAuth authentication failed"),
+      status: 400,
     }
   }
 
@@ -1335,9 +1876,8 @@ export namespace MCP {
    * Remove OAuth credentials for an MCP server.
    */
   export async function removeAuth(mcpName: string): Promise<void> {
+    clearPendingSessionsForName(mcpName)
     await McpAuth.remove(mcpName)
-    McpOAuthCallback.cancelPending(mcpName)
-    pendingOAuthTransports.delete(mcpName)
     await McpAuth.clearOAuthState(mcpName)
     log.info("removed oauth credentials", { mcpName })
   }
@@ -1361,6 +1901,44 @@ export namespace MCP {
     return !!entry?.tokens
   }
 
+  export async function prepareServersForTurn(
+    userText: string,
+    options: { waitForAuthMs?: number } = {},
+  ): Promise<{ authInProgressServers: string[] }> {
+    if (!shouldPreflightFeishuIntent(userText)) {
+      return { authInProgressServers: [] }
+    }
+
+    const cfg = await Config.get()
+    const config = cfg.mcp ?? {}
+    const authInProgressServers: string[] = []
+    const waitForAuthMs = options.waitForAuthMs ?? 120_000
+
+    for (const [serverName, entry] of Object.entries(config)) {
+      if (!isMcpConfigured(entry) || entry.type !== "remote" || entry.oauth === false || entry.enabled === false) {
+        continue
+      }
+
+      if (!isFeishuLikeServer(serverName, entry)) {
+        continue
+      }
+
+      const connected = await ensureServerConnected(serverName, entry, {
+        interactiveAuth: true,
+        waitForAuthMs,
+      })
+
+      if (!connected) {
+        const nextState = await state()
+        if (nextState.status[serverName]?.status === "auth_in_progress") {
+          authInProgressServers.push(serverName)
+        }
+      }
+    }
+
+    return { authInProgressServers }
+  }
+
   export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 
   /**
@@ -1369,8 +1947,7 @@ export namespace MCP {
   export async function getAuthStatus(mcpName: string): Promise<AuthStatus> {
     const hasTokens = await hasStoredTokens(mcpName)
     if (!hasTokens) return "not_authenticated"
-    const expired = await McpAuth.isTokenExpired(mcpName)
+    const expired = await McpAuth.isTokenStale(mcpName)
     return expired ? "expired" : "authenticated"
   }
 }
-  const healthInFlight = new Map<string, Promise<Health>>()

--- a/opencode/packages/opencode/src/mcp/oauth-callback.ts
+++ b/opencode/packages/opencode/src/mcp/oauth-callback.ts
@@ -78,6 +78,7 @@ export namespace McpOAuthCallback {
         const state = url.searchParams.get("state")
         const error = url.searchParams.get("error")
         const errorDescription = url.searchParams.get("error_description")
+        const larkMcpError = url.searchParams.get("lark_mcp_error")
 
         log.info("received oauth callback", { hasCode: !!code, state, error })
 
@@ -85,7 +86,7 @@ export namespace McpOAuthCallback {
         if (!state) {
           const errorMsg = "Missing required state parameter - potential CSRF attack"
           log.error("oauth callback missing state parameter", { url: url.toString() })
-          return new Response(HTML_ERROR(errorMsg), {
+          return new Response(renderError(errorMsg), {
             status: 400,
             headers: { "Content-Type": "text/html" },
           })
@@ -97,15 +98,17 @@ export namespace McpOAuthCallback {
             const pending = pendingAuths.get(state)!
             clearTimeout(pending.timeout)
             pendingAuths.delete(state)
-            pending.reject(new Error(errorMsg))
+            const authError = new Error(errorMsg) as Error & { oauthError?: string }
+            authError.oauthError = larkMcpError || error
+            pending.reject(authError)
           }
-          return new Response(HTML_ERROR(errorMsg), {
+          return new Response(renderError(errorMsg), {
             headers: { "Content-Type": "text/html" },
           })
         }
 
         if (!code) {
-          return new Response(HTML_ERROR("No authorization code provided"), {
+          return new Response(renderError("No authorization code provided"), {
             status: 400,
             headers: { "Content-Type": "text/html" },
           })
@@ -115,7 +118,7 @@ export namespace McpOAuthCallback {
         if (!pendingAuths.has(state)) {
           const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
           log.error("oauth callback with invalid state", { state, pendingStates: Array.from(pendingAuths.keys()) })
-          return new Response(HTML_ERROR(errorMsg), {
+          return new Response(renderError(errorMsg), {
             status: 400,
             headers: { "Content-Type": "text/html" },
           })
@@ -127,7 +130,7 @@ export namespace McpOAuthCallback {
         pendingAuths.delete(state)
         pending.resolve(code)
 
-        return new Response(HTML_SUCCESS, {
+        return new Response(renderSuccess(), {
           headers: { "Content-Type": "text/html" },
         })
       },
@@ -149,11 +152,11 @@ export namespace McpOAuthCallback {
     })
   }
 
-  export function cancelPending(mcpName: string): void {
-    const pending = pendingAuths.get(mcpName)
+  export function cancelPending(oauthState: string): void {
+    const pending = pendingAuths.get(oauthState)
     if (pending) {
       clearTimeout(pending.timeout)
-      pendingAuths.delete(mcpName)
+      pendingAuths.delete(oauthState)
       pending.reject(new Error("Authorization cancelled"))
     }
   }
@@ -196,5 +199,13 @@ export namespace McpOAuthCallback {
 
   export function isRunning(): boolean {
     return server !== undefined
+  }
+
+  export function renderSuccess() {
+    return HTML_SUCCESS
+  }
+
+  export function renderError(error: string) {
+    return HTML_ERROR(error)
   }
 }

--- a/opencode/packages/opencode/src/mcp/oauth-provider.ts
+++ b/opencode/packages/opencode/src/mcp/oauth-provider.ts
@@ -1,10 +1,12 @@
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type {
   OAuthClientMetadata,
+  OAuthMetadata,
   OAuthTokens,
   OAuthClientInformation,
   OAuthClientInformationFull,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
+import { OAuthTokensSchema } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { McpAuth } from "./auth"
 import { Log } from "../util/log"
 
@@ -12,6 +14,26 @@ const log = Log.create({ service: "mcp.oauth" })
 
 const OAUTH_CALLBACK_PORT = 19876
 const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+const OAUTH_EXPIRY_SAFETY_WINDOW_SECONDS = 300
+const refreshFlights = new Map<string, Promise<OAuthTokens | undefined>>()
+
+export type McpOAuthErrorCode =
+  | "invalid_client"
+  | "invalid_grant"
+  | "insufficient_scope"
+  | "reauth_required"
+  | "registration_required"
+  | "needs_auth"
+
+export class McpOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly oauthError: McpOAuthErrorCode,
+  ) {
+    super(message)
+    this.name = "McpOAuthError"
+  }
+}
 
 export interface McpOAuthConfig {
   clientId?: string
@@ -28,11 +50,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private mcpName: string,
     private serverUrl: string,
     private config: McpOAuthConfig,
+    private redirectTarget: string,
     private callbacks: McpOAuthCallbacks,
   ) {}
 
   get redirectUrl(): string {
-    return `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
+    return this.redirectTarget
   }
 
   get clientMetadata(): OAuthClientMetadata {
@@ -46,9 +69,160 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
   }
 
+  private get oauthMetadataUrl(): string {
+    return new URL("/.well-known/oauth-authorization-server", this.serverUrl).toString()
+  }
+
+  private buildStoredTokens(tokens: McpAuth.Tokens): OAuthTokens {
+    return {
+      access_token: tokens.accessToken,
+      token_type: "Bearer",
+      refresh_token: tokens.refreshToken,
+      expires_in: tokens.expiresAt ? Math.max(0, Math.floor(tokens.expiresAt - Date.now() / 1000)) : undefined,
+      scope: tokens.scope,
+    }
+  }
+
+  private async loadOAuthMetadata(): Promise<OAuthMetadata> {
+    const response = await fetch(this.oauthMetadataUrl, {
+      headers: {
+        Accept: "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OAuth metadata: ${response.status} ${response.statusText}`)
+    }
+
+    const metadata = (await response.json()) as OAuthMetadata
+    await McpAuth.updateOAuthMetadata(
+      this.mcpName,
+      {
+        issuer: metadata.issuer,
+        authorizationEndpoint: metadata.authorization_endpoint,
+        tokenEndpoint: metadata.token_endpoint,
+        registrationEndpoint: metadata.registration_endpoint,
+        redirectUrl: this.redirectUrl,
+      },
+      this.serverUrl,
+    )
+    return metadata
+  }
+
+  private parseOAuthError(
+    raw: unknown,
+    response: Response,
+    fallback: McpOAuthErrorCode,
+  ): McpOAuthError {
+    const payload = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined
+    const message =
+      (typeof payload?.error_description === "string" && payload.error_description) ||
+      (typeof payload?.error === "string" && payload.error) ||
+      `Token refresh failed with status ${response.status}`
+
+    const oauthError =
+      (typeof payload?.lark_mcp_error === "string" && payload.lark_mcp_error) ||
+      (typeof payload?.error === "string" && payload.error) ||
+      fallback
+
+    return new McpOAuthError(message, oauthError as McpOAuthErrorCode)
+  }
+
+  private async handleRefreshFailure(error: Error & { oauthError?: string }) {
+    const oauthError = error.oauthError
+    await McpAuth.setLastAuthError(this.mcpName, error.message, this.serverUrl)
+
+    if (oauthError === "invalid_client") {
+      await Promise.all([McpAuth.clearTokens(this.mcpName), McpAuth.clearClientInfo(this.mcpName)])
+      return
+    }
+
+    if (
+      oauthError === "invalid_grant" ||
+      oauthError === "reauth_required" ||
+      oauthError === "insufficient_scope"
+    ) {
+      await McpAuth.clearTokens(this.mcpName)
+    }
+  }
+
+  private async performTokenRefresh(entry: McpAuth.Entry): Promise<OAuthTokens | undefined> {
+    if (!entry.tokens?.refreshToken) {
+      return undefined
+    }
+
+    const client = await this.clientInformation()
+    if (!client?.client_id) {
+      const error = new Error("No client information available for MCP token refresh") as Error & {
+        oauthError?: string
+      }
+      error.oauthError = "invalid_client"
+      await this.handleRefreshFailure(error)
+      return undefined
+    }
+
+    const metadata = await this.loadOAuthMetadata()
+    if (!metadata.token_endpoint) {
+      throw new Error("OAuth metadata did not include a token endpoint")
+    }
+
+    const payload: Record<string, string> = {
+      grant_type: "refresh_token",
+      client_id: client.client_id,
+      refresh_token: entry.tokens.refreshToken,
+    }
+
+    if (client.client_secret) {
+      payload.client_secret = client.client_secret
+    }
+
+    if (this.config.scope) {
+      payload.scope = this.config.scope
+    }
+
+    const response = await fetch(metadata.token_endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+
+    const raw = await response.json().catch(() => undefined)
+    if (!response.ok) {
+      const error = this.parseOAuthError(raw, response, "invalid_grant")
+      await this.handleRefreshFailure(error)
+      return undefined
+    }
+
+    const parsed = OAuthTokensSchema.safeParse(raw)
+    if (!parsed.success) {
+      throw new Error("MCP token refresh returned an invalid token payload")
+    }
+
+    await this.saveTokens(parsed.data)
+    await McpAuth.clearLastAuthError(this.mcpName)
+    return parsed.data
+  }
+
+  private async refreshTokensSingleFlight(entry: McpAuth.Entry): Promise<OAuthTokens | undefined> {
+    const existing = refreshFlights.get(this.mcpName)
+    if (existing) {
+      return existing
+    }
+
+    const flight = this.performTokenRefresh(entry).finally(() => {
+      refreshFlights.delete(this.mcpName)
+    })
+    refreshFlights.set(this.mcpName, flight)
+    return flight
+  }
+
   async clientInformation(): Promise<OAuthClientInformation | undefined> {
     // Check config first (pre-registered client)
     if (this.config.clientId) {
+      await McpAuth.setRegistrationMode(this.mcpName, "static", this.serverUrl)
       return {
         client_id: this.config.clientId,
         client_secret: this.config.clientSecret,
@@ -59,9 +233,20 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Use getForUrl to validate credentials are for the current server URL
     const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
     if (entry?.clientInfo) {
+      if (entry.registrationMode === "dynamic" && entry.redirectUrl !== this.redirectUrl) {
+        log.info("stored dynamic client redirect URL changed, re-registering", {
+          mcpName: this.mcpName,
+          previousRedirectUrl: entry.redirectUrl,
+          redirectUrl: this.redirectUrl,
+        })
+        await McpAuth.clearClientInfo(this.mcpName)
+        return undefined
+      }
+
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
         log.info("client secret expired, need to re-register", { mcpName: this.mcpName })
+        await McpAuth.clearClientInfo(this.mcpName)
         return undefined
       }
       return {
@@ -84,11 +269,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
         clientSecretExpiresAt: info.client_secret_expires_at,
       },
       this.serverUrl,
+      this.redirectUrl,
     )
     log.info("saved dynamically registered client", {
       mcpName: this.mcpName,
       clientId: info.client_id,
     })
+    await McpAuth.clearLastAuthError(this.mcpName)
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
@@ -96,15 +283,29 @@ export class McpOAuthProvider implements OAuthClientProvider {
     const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
     if (!entry?.tokens) return undefined
 
-    return {
-      access_token: entry.tokens.accessToken,
-      token_type: "Bearer",
-      refresh_token: entry.tokens.refreshToken,
-      expires_in: entry.tokens.expiresAt
-        ? Math.max(0, Math.floor(entry.tokens.expiresAt - Date.now() / 1000))
-        : undefined,
-      scope: entry.tokens.scope,
+    const expiresAt = entry.tokens.expiresAt
+    if (!expiresAt || expiresAt > Date.now() / 1000 + OAUTH_EXPIRY_SAFETY_WINDOW_SECONDS) {
+      return this.buildStoredTokens(entry.tokens)
     }
+
+    if (!entry.tokens.refreshToken) {
+      await McpAuth.clearTokens(this.mcpName)
+      return undefined
+    }
+
+    const refreshed = await this.refreshTokensSingleFlight(entry)
+    if (refreshed) {
+      return refreshed
+    }
+
+    if (expiresAt > Date.now() / 1000) {
+      log.warn("token refresh failed but current token is still usable for a short period", {
+        mcpName: this.mcpName,
+      })
+      return this.buildStoredTokens(entry.tokens)
+    }
+
+    return undefined
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
@@ -113,7 +314,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
       {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token,
-        expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+        expiresAt: tokens.expires_in ? Math.floor(Date.now() / 1000 + tokens.expires_in) : undefined,
         scope: tokens.scope,
       },
       this.serverUrl,

--- a/opencode/packages/opencode/src/server/routes/mcp.ts
+++ b/opencode/packages/opencode/src/server/routes/mcp.ts
@@ -88,8 +88,54 @@ export const McpRoutes = lazy(() =>
         if (!supportsOAuth) {
           return c.json({ error: `MCP server ${name} does not support OAuth` }, 400)
         }
-        const result = await MCP.startAuth(name)
+        const result = await MCP.startAuth(name, {
+          mode: "server",
+          serverOrigin: new URL(c.req.url).origin,
+        })
         return c.json(result)
+      },
+    )
+    .get(
+      "/oauth/callback",
+      describeRoute({
+        summary: "MCP OAuth browser callback",
+        description: "Handle the browser redirect for MCP OAuth authentication.",
+        operationId: "mcp.auth.browserCallback",
+        responses: {
+          200: {
+            description: "OAuth callback page",
+            content: {
+              "text/html": {
+                schema: resolver(z.string()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          code: z.string().optional(),
+          state: z.string().optional(),
+          error: z.string().optional(),
+          error_description: z.string().optional(),
+          lark_mcp_error: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const query = c.req.valid("query")
+        const result = await MCP.handleOAuthCallback({
+          code: query.code,
+          state: query.state,
+          error: query.error,
+          errorDescription: query.error_description,
+          oauthError: query.lark_mcp_error,
+        })
+        if ("redirectUrl" in result) {
+          return c.redirect(result.redirectUrl, 302)
+        }
+        return c.html(result.html, result.status as 200 | 400)
       },
     )
     .post(

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -603,7 +603,7 @@ export namespace SessionPrompt {
       const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
       const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
-      const tools = await resolveTools({
+      const { tools, systemHints } = await resolveTools({
         agent,
         session,
         model,
@@ -648,7 +648,11 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [...(await SystemPrompt.environment(model, session.directory)), ...(await InstructionPrompt.system())],
+        system: [
+          ...(await SystemPrompt.environment(model, session.directory)),
+          ...(await InstructionPrompt.system()),
+          ...systemHints,
+        ],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),
           ...(isLastStep
@@ -702,6 +706,7 @@ export namespace SessionPrompt {
     bypassAgentCheck: boolean
     messages: MessageV2.WithParts[]
   }) {
+    const systemHints: string[] = []
     using _ = log.time("resolveTools")
     const tools: Record<string, AITool> = {}
 
@@ -776,6 +781,26 @@ export namespace SessionPrompt {
           return result
         },
       })
+    }
+
+    const lastUserMessage = [...input.messages].reverse().find((message) => message.info.role === "user")
+    const lastUserText = lastUserMessage?.parts
+      .filter((part): part is MessageV2.TextPart => part.type === "text" && !part.ignored)
+      .map((part) => part.text)
+      .join("\n")
+      .trim()
+
+    if (lastUserText) {
+      const preflight = await Instance.provide({
+        directory: input.session.directory,
+        fn: () => MCP.prepareServersForTurn(lastUserText),
+      })
+
+      if (preflight.authInProgressServers.length > 0) {
+        systemHints.push(
+          "Feishu MCP authentication is in progress; do not ask the user to edit JSON or provide clientId manually.",
+        )
+      }
     }
 
     // Get MCP tools within session directory's Instance context
@@ -876,7 +901,7 @@ export namespace SessionPrompt {
       tools[key] = item
     }
 
-    return tools
+    return { tools, systemHints }
   }
 
   async function createUserMessage(input: PromptInput, session: Session.Info) {

--- a/opencode/packages/opencode/test/mcp/auth.test.ts
+++ b/opencode/packages/opencode/test/mcp/auth.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { rm } from "fs/promises"
+
+const { McpAuth } = await import("../../src/mcp/auth")
+
+const tempFile = "/tmp/opencode-mcp-auth-test.json"
+
+beforeEach(async () => {
+  process.env.NINE1BOT_MCP_AUTH_PATH = tempFile
+  await rm(tempFile, { force: true }).catch(() => undefined)
+})
+
+afterEach(async () => {
+  await rm(tempFile, { force: true }).catch(() => undefined)
+  delete process.env.NINE1BOT_MCP_AUTH_PATH
+})
+
+test("marks tokens within the safety window as stale", async () => {
+  await McpAuth.updateTokens("lark", {
+    accessToken: "token",
+    refreshToken: "refresh",
+    expiresAt: Math.floor(Date.now() / 1000) + 240,
+    scope: "scope1",
+  })
+
+  expect(await McpAuth.isTokenStale("lark")).toBe(true)
+})
+
+test("keeps tokens outside the safety window as valid", async () => {
+  await McpAuth.updateTokens("lark", {
+    accessToken: "token",
+    refreshToken: "refresh",
+    expiresAt: Math.floor(Date.now() / 1000) + 900,
+    scope: "scope1",
+  })
+
+  expect(await McpAuth.isTokenStale("lark")).toBe(false)
+})
+
+test("tracks dynamic and static registration state in persisted oauth entries", async () => {
+  await McpAuth.updateClientInfo("lark", {
+    clientId: "dynamic-client",
+    clientSecret: "dynamic-secret",
+  })
+
+  let entry = await McpAuth.get("lark")
+  expect(entry?.registrationMode).toBe("dynamic")
+
+  await McpAuth.setRegistrationMode("lark", "static")
+  entry = await McpAuth.get("lark")
+  expect(entry?.registrationMode).toBe("static")
+})
+
+test("records auth start timestamp while oauth is in progress", async () => {
+  await McpAuth.updateOAuthState("lark", "oauth-state")
+  const entry = await McpAuth.get("lark")
+
+  expect(entry?.oauthState).toBe("oauth-state")
+  expect(typeof entry?.authStartedAt).toBe("number")
+})

--- a/opencode/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/opencode/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -535,3 +535,53 @@ test("server callback redirects to a fresh authorization URL after invalid_clien
     },
   })
 })
+
+test("server callback error resets auth_in_progress back to needs_auth", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-server-cancelled": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const started = await MCP.startAuth("test-oauth-server-cancelled", {
+        mode: "server",
+        serverOrigin: "https://bot.example.com",
+      })
+
+      expect(started.authorizationUrl).toContain(
+        encodeURIComponent("https://bot.example.com/mcp/oauth/callback"),
+      )
+
+      const oauthState = await waitFor(() => McpAuth.getOAuthState("test-oauth-server-cancelled"))
+
+      const response = await MCP.handleOAuthCallback({
+        state: oauthState,
+        error: "access_denied",
+        errorDescription: "User denied access",
+      })
+
+      expect("html" in response).toBe(true)
+      if (!("html" in response)) {
+        throw new Error("Expected HTML error response")
+      }
+      expect(response.status).toBe(400)
+
+      const statuses = await MCP.status()
+      expect(statuses["test-oauth-server-cancelled"]?.status).toBe("needs_auth")
+    },
+  })
+})

--- a/opencode/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/opencode/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -1,13 +1,24 @@
-import { test, expect, mock, beforeEach } from "bun:test"
+import { test, expect, mock, beforeEach, afterEach } from "bun:test"
 import { EventEmitter } from "events"
 
 // Track open() calls and control failure behavior
 let openShouldFail = false
 let openCalledWith: string | undefined
+let openCalls: string[] = []
+let connectShouldSucceed = false
+const busSubscriptions = new Map<string, Array<(event: any) => void>>()
+const callbackWaiters = new Map<
+  string,
+  {
+    resolve: (code: string) => void
+    reject: (error: Error) => void
+  }
+>()
 
 mock.module("open", () => ({
   default: async (url: string) => {
     openCalledWith = url
+    openCalls.push(url)
     // Return a mock subprocess that emits an error if openShouldFail is true
     const subprocess = new EventEmitter()
     if (openShouldFail) {
@@ -32,15 +43,26 @@ class MockUnauthorizedError extends Error {
 const transportCalls: Array<{
   type: "streamable" | "sse"
   url: string
-  options: { authProvider?: unknown }
+  options: { authProvider?: unknown; requestInit?: RequestInit }
 }> = []
 
 // Mock the transport constructors
 mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: class MockStreamableHTTP {
     url: string
-    authProvider: { redirectToAuthorization?: (url: URL) => Promise<void> } | undefined
-    constructor(url: URL, options?: { authProvider?: { redirectToAuthorization?: (url: URL) => Promise<void> } }) {
+    authProvider:
+      | {
+          redirectToAuthorization?: (url: URL) => Promise<void>
+          redirectUrl?: string
+        }
+      | undefined
+    constructor(
+      url: URL,
+      options?: {
+        authProvider?: { redirectToAuthorization?: (url: URL) => Promise<void>; redirectUrl?: string }
+        requestInit?: RequestInit
+      },
+    ) {
       this.url = url.toString()
       this.authProvider = options?.authProvider
       transportCalls.push({
@@ -50,25 +72,31 @@ mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
       })
     }
     async start() {
+      if (connectShouldSucceed) {
+        return
+      }
       // Simulate OAuth redirect by calling the authProvider's redirectToAuthorization
       if (this.authProvider?.redirectToAuthorization) {
-        await this.authProvider.redirectToAuthorization(new URL("https://auth.example.com/authorize?client_id=test"))
+        const redirectUri = encodeURIComponent(this.authProvider.redirectUrl || "")
+        await this.authProvider.redirectToAuthorization(
+          new URL(`https://auth.example.com/authorize?client_id=test&redirect_uri=${redirectUri}`),
+        )
       }
       throw new MockUnauthorizedError()
     }
     async finishAuth(_code: string) {
-      // Mock successful auth completion
+      connectShouldSucceed = true
     }
   },
 }))
 
 mock.module("@modelcontextprotocol/sdk/client/sse.js", () => ({
   SSEClientTransport: class MockSSE {
-    constructor(url: URL) {
+    constructor(url: URL, options?: { authProvider?: unknown; requestInit?: RequestInit }) {
       transportCalls.push({
         type: "sse",
         url: url.toString(),
-        options: {},
+        options: options ?? {},
       })
     }
     async start() {
@@ -83,6 +111,14 @@ mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async connect(transport: { start: () => Promise<void> }) {
       await transport.start()
     }
+    async close() {}
+    async listTools() {
+      return { tools: [] }
+    }
+    async listResources() {
+      return { resources: [] }
+    }
+    setNotificationHandler() {}
   },
 }))
 
@@ -91,18 +127,120 @@ mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
   UnauthorizedError: MockUnauthorizedError,
 }))
 
+mock.module("@/bus", () => ({
+  Bus: {
+    async publish(def: { type: string }, properties: Record<string, unknown>) {
+      const event = {
+        type: def.type,
+        properties,
+      }
+      for (const callback of busSubscriptions.get(def.type) ?? []) {
+        callback(event)
+      }
+      for (const callback of busSubscriptions.get("*") ?? []) {
+        callback(event)
+      }
+      return []
+    },
+    subscribe(def: { type: string }, callback: (event: any) => void) {
+      const current = busSubscriptions.get(def.type) ?? []
+      current.push(callback)
+      busSubscriptions.set(def.type, current)
+      return () => {
+        const next = busSubscriptions.get(def.type) ?? []
+        const index = next.indexOf(callback)
+        if (index >= 0) {
+          next.splice(index, 1)
+        }
+      }
+    },
+  },
+}))
+
 beforeEach(() => {
   openShouldFail = false
   openCalledWith = undefined
+  openCalls = []
+  connectShouldSucceed = false
   transportCalls.length = 0
+  busSubscriptions.clear()
+  callbackWaiters.clear()
 })
 
 // Import modules after mocking
-const { MCP } = await import("../../src/mcp/index")
-const { Bus } = await import("../../src/bus")
-const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
 const { Instance } = await import("../../src/project/instance")
+const { MCP } = await import("../../src/mcp/index")
+const { Bus } = await import("@/bus")
+const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
+const { McpAuth } = await import("../../src/mcp/auth")
 const { tmpdir } = await import("../fixture/fixture")
+
+const mockedOAuthCallback = McpOAuthCallback as typeof McpOAuthCallback & {
+  ensureRunning: () => Promise<void>
+  waitForCallback: (oauthState: string) => Promise<string>
+  cancelPending: (oauthState: string) => void
+  stop: () => Promise<void>
+}
+
+mockedOAuthCallback.ensureRunning = async () => {}
+mockedOAuthCallback.waitForCallback = (oauthState: string) =>
+  {
+    const promise = new Promise<string>((resolve, reject) => {
+      callbackWaiters.set(oauthState, { resolve, reject })
+    })
+    promise.catch(() => undefined)
+    return promise
+  }
+mockedOAuthCallback.cancelPending = (oauthState: string) => {
+  const pending = callbackWaiters.get(oauthState)
+  if (!pending) {
+    return
+  }
+  callbackWaiters.delete(oauthState)
+  pending.reject(new Error("Authorization cancelled"))
+}
+mockedOAuthCallback.stop = async () => {
+  for (const [oauthState, pending] of callbackWaiters.entries()) {
+    callbackWaiters.delete(oauthState)
+    pending.reject(new Error("OAuth callback server stopped"))
+  }
+}
+
+afterEach(async () => {
+  await McpOAuthCallback.stop().catch(() => undefined)
+})
+
+async function waitFor<T>(fn: () => Promise<T | undefined> | T | undefined, timeoutMs = 2000): Promise<T> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = await fn()
+    if (value !== undefined) {
+      return value
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error("Timed out waiting for condition")
+}
+
+function rejectCallback(state: string, message: string, oauthError?: string) {
+  const pending = callbackWaiters.get(state)
+  if (!pending) {
+    throw new Error(`Missing pending callback for state: ${state}`)
+  }
+  callbackWaiters.delete(state)
+  const error = new Error(message) as Error & { oauthError?: string }
+  error.oauthError = oauthError
+  pending.reject(error)
+}
+
+function resolveCallback(state: string, code: string) {
+  const pending = callbackWaiters.get(state)
+  if (!pending) {
+    throw new Error(`Missing pending callback for state: ${state}`)
+  }
+  callbackWaiters.delete(state)
+  pending.resolve(code)
+}
 
 test("BrowserOpenFailed event is published when open() throws", async () => {
   await using tmp = await tmpdir({
@@ -141,12 +279,7 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
       // Stop the callback server and cancel any pending auth
       await McpOAuthCallback.stop()
 
-      // Wait for authenticate to reject (due to server stopping)
-      try {
-        await authPromise
-      } catch {
-        // Expected to fail
-      }
+      const status = await authPromise
 
       unsubscribe()
 
@@ -154,6 +287,7 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
       expect(events.length).toBe(1)
       expect(events[0].mcpName).toBe("test-oauth-server")
       expect(events[0].url).toContain("https://")
+      expect(status.status).toBe("needs_auth")
     },
   })
 })
@@ -195,12 +329,7 @@ test("BrowserOpenFailed event is NOT published when open() succeeds", async () =
       // Stop the callback server and cancel any pending auth
       await McpOAuthCallback.stop()
 
-      // Wait for authenticate to reject (due to server stopping)
-      try {
-        await authPromise
-      } catch {
-        // Expected to fail
-      }
+      const status = await authPromise
 
       unsubscribe()
 
@@ -208,6 +337,7 @@ test("BrowserOpenFailed event is NOT published when open() succeeds", async () =
       expect(events.length).toBe(0)
       // Verify open() was still called
       expect(openCalledWith).toBeDefined()
+      expect(status.status).toBe("needs_auth")
     },
   })
 })
@@ -245,17 +375,163 @@ test("open() is called with the authorization URL", async () => {
       // Stop the callback server and cancel any pending auth
       await McpOAuthCallback.stop()
 
-      // Wait for authenticate to reject (due to server stopping)
-      try {
-        await authPromise
-      } catch {
-        // Expected to fail
-      }
+      const status = await authPromise
 
       // Verify open was called with a URL
       expect(openCalledWith).toBeDefined()
       expect(typeof openCalledWith).toBe("string")
       expect(openCalledWith!).toContain("https://")
+      expect(status.status).toBe("needs_auth")
+    },
+  })
+})
+
+test("startAuth reuses remote headers and server callback redirect", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-server-headers": {
+              type: "remote",
+              url: "https://example.com/mcp",
+              headers: {
+                Authorization: "Bearer test-token",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      transportCalls.length = 0
+
+      const result = await MCP.startAuth("test-oauth-server-headers", {
+        mode: "server",
+        serverOrigin: "https://bot.example.com",
+      })
+
+      expect(result.authorizationUrl).toContain(
+        encodeURIComponent("https://bot.example.com/mcp/oauth/callback"),
+      )
+      expect(transportCalls[0]?.options.requestInit?.headers).toEqual({
+        Authorization: "Bearer test-token",
+      })
+    },
+  })
+})
+
+test("authenticate retries invalid_client once before surfacing failure", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-server-retry": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const authPromise = MCP.authenticate("test-oauth-server-retry")
+      authPromise.catch(() => undefined)
+
+      await waitFor(() => (openCalls.length >= 1 ? openCalls[0] : undefined))
+      const firstState = await waitFor(() => McpAuth.getOAuthState("test-oauth-server-retry"))
+
+      rejectCallback(firstState, "invalid_client", "invalid_client")
+
+      await waitFor(() => (openCalls.length >= 2 ? openCalls[1] : undefined))
+      const secondState = await waitFor(async () => {
+        const value = await McpAuth.getOAuthState("test-oauth-server-retry")
+        return value && value !== firstState ? value : undefined
+      })
+
+      expect(secondState).not.toBe(firstState)
+
+      resolveCallback(secondState, "test-code")
+
+      const status = await authPromise
+      expect(status.status).toBe("connected")
+      expect(openCalls.length).toBe(2)
+    },
+  })
+})
+
+test("server callback redirects to a fresh authorization URL after invalid_client once", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-oauth-server-server-retry": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const started = await MCP.startAuth("test-oauth-server-server-retry", {
+        mode: "server",
+        serverOrigin: "https://bot.example.com",
+      })
+
+      expect(started.authorizationUrl).toContain(
+        encodeURIComponent("https://bot.example.com/mcp/oauth/callback"),
+      )
+
+      const firstState = await waitFor(() => McpAuth.getOAuthState("test-oauth-server-server-retry"))
+      const retry = await MCP.handleOAuthCallback({
+        state: firstState,
+        error: "access_denied",
+        errorDescription: "invalid_client",
+        oauthError: "invalid_client",
+      })
+
+      expect("redirectUrl" in retry).toBe(true)
+      if (!("redirectUrl" in retry)) {
+        throw new Error("Expected retry redirect response")
+      }
+      expect(retry.redirectUrl).toContain(encodeURIComponent("https://bot.example.com/mcp/oauth/callback"))
+
+      const secondState = await waitFor(async () => {
+        const value = await McpAuth.getOAuthState("test-oauth-server-server-retry")
+        return value && value !== firstState ? value : undefined
+      })
+
+      const success = await MCP.handleOAuthCallback({
+        state: secondState,
+        code: "server-code",
+      })
+
+      expect("html" in success).toBe(true)
+      if (!("html" in success)) {
+        throw new Error("Expected HTML success response")
+      }
+      expect(success.status).toBe(200)
     },
   })
 })

--- a/opencode/packages/opencode/test/mcp/oauth-provider.test.ts
+++ b/opencode/packages/opencode/test/mcp/oauth-provider.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { rm } from "fs/promises"
+
+const tempFile = "/tmp/opencode-mcp-oauth-provider-test.json"
+
+const { McpAuth } = await import("../../src/mcp/auth")
+const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
+
+beforeEach(async () => {
+  process.env.NINE1BOT_MCP_AUTH_PATH = tempFile
+  await rm(tempFile, { force: true }).catch(() => undefined)
+})
+
+afterEach(async () => {
+  await rm(tempFile, { force: true }).catch(() => undefined)
+  delete process.env.NINE1BOT_MCP_AUTH_PATH
+})
+
+test("re-registers a dynamic client when redirect URL changes", async () => {
+  await McpAuth.updateClientInfo(
+    "lark",
+    {
+      clientId: "dynamic-client",
+      clientSecret: "dynamic-secret",
+    },
+    "http://127.0.0.1:3000/mcp",
+    "http://127.0.0.1:19876/mcp/oauth/callback",
+  )
+
+  const provider = new McpOAuthProvider(
+    "lark",
+    "http://127.0.0.1:3000/mcp",
+    {},
+    "http://127.0.0.1:4096/mcp/oauth/callback",
+    {
+      onRedirect: async () => {},
+    },
+  )
+
+  expect(await provider.clientInformation()).toBeUndefined()
+
+  const entry = await McpAuth.get("lark")
+  expect(entry?.clientInfo).toBeUndefined()
+})
+
+test("persists redirect URL when saving a dynamic client", async () => {
+  const provider = new McpOAuthProvider(
+    "lark",
+    "http://127.0.0.1:3000/mcp",
+    {},
+    "http://127.0.0.1:4096/mcp/oauth/callback",
+    {
+      onRedirect: async () => {},
+    },
+  )
+
+  await provider.saveClientInformation({
+    client_id: "dynamic-client",
+    client_secret: "dynamic-secret",
+    client_id_issued_at: 123,
+    client_secret_expires_at: 456,
+    redirect_uris: ["http://127.0.0.1:4096/mcp/oauth/callback"],
+  })
+
+  const entry = await McpAuth.get("lark")
+  expect(entry?.redirectUrl).toBe("http://127.0.0.1:4096/mcp/oauth/callback")
+  expect(entry?.clientInfo?.clientId).toBe("dynamic-client")
+})

--- a/opencode/packages/sdk/js/src/gen/types.gen.ts
+++ b/opencode/packages/sdk/js/src/gen/types.gen.ts
@@ -1630,6 +1630,10 @@ export type McpStatusNeedsAuth = {
   status: "needs_auth"
 }
 
+export type McpStatusAuthInProgress = {
+  status: "auth_in_progress"
+}
+
 export type McpStatusNeedsClientRegistration = {
   status: "needs_client_registration"
   error: string
@@ -1640,6 +1644,7 @@ export type McpStatus =
   | McpStatusDisabled
   | McpStatusFailed
   | McpStatusNeedsAuth
+  | McpStatusAuthInProgress
   | McpStatusNeedsClientRegistration
 
 export type LspStatus = {

--- a/opencode/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/opencode/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2073,6 +2073,10 @@ export type McpStatusNeedsAuth = {
   status: "needs_auth"
 }
 
+export type McpStatusAuthInProgress = {
+  status: "auth_in_progress"
+}
+
 export type McpStatusNeedsClientRegistration = {
   status: "needs_client_registration"
   error: string
@@ -2083,6 +2087,7 @@ export type McpStatus =
   | McpStatusDisabled
   | McpStatusFailed
   | McpStatusNeedsAuth
+  | McpStatusAuthInProgress
   | McpStatusNeedsClientRegistration
 
 export type Path = {

--- a/opencode/packages/sdk/openapi.json
+++ b/opencode/packages/sdk/openapi.json
@@ -10617,6 +10617,16 @@
         },
         "required": ["status"]
       },
+      "MCPStatusAuthInProgress": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "auth_in_progress"
+          }
+        },
+        "required": ["status"]
+      },
       "MCPStatusNeedsClientRegistration": {
         "type": "object",
         "properties": {
@@ -10643,6 +10653,9 @@
           },
           {
             "$ref": "#/components/schemas/MCPStatusNeedsAuth"
+          },
+          {
+            "$ref": "#/components/schemas/MCPStatusAuthInProgress"
           },
           {
             "$ref": "#/components/schemas/MCPStatusNeedsClientRegistration"

--- a/packages/nine1bot/src/config/loader.test.ts
+++ b/packages/nine1bot/src/config/loader.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadConfig } from './loader'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function writeConfig(config: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'nine1bot-config-'))
+  tempDirs.push(dir)
+  const configPath = join(dir, 'nine1bot.config.jsonc')
+  await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  return configPath
+}
+
+describe('loadConfig remote MCP oauth support', () => {
+  it('preserves remote MCP oauth config', async () => {
+    const configPath = await writeConfig({
+      mcp: {
+        remote_docs: {
+          type: 'remote',
+          url: 'https://mcp.example.com/http',
+          oauth: {
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            scope: 'read write',
+          },
+        },
+      },
+    })
+
+    const config = await loadConfig(configPath)
+    expect(config.mcp?.remote_docs).toEqual({
+      type: 'remote',
+      url: 'https://mcp.example.com/http',
+      oauth: {
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        scope: 'read write',
+      },
+    })
+  })
+})

--- a/packages/nine1bot/src/config/loader.ts
+++ b/packages/nine1bot/src/config/loader.ts
@@ -159,6 +159,15 @@ export function getAuthPath(): string {
 }
 
 /**
+ * 获取 MCP OAuth 认证文件路径
+ * - Windows: %LOCALAPPDATA%\nine1bot\mcp-auth.json
+ * - Unix: ~/.local/share/nine1bot/mcp-auth.json
+ */
+export function getMcpAuthPath(): string {
+  return join(getDataDir(), 'mcp-auth.json')
+}
+
+/**
  * 获取项目环境变量目录路径
  * 与 auth.json 同级目录，便于统一管理 Nine1Bot 私有数据
  * - Windows: %LOCALAPPDATA%\nine1bot\project-env
@@ -279,10 +288,30 @@ async function loadConfigFile(configPath: string): Promise<Partial<Nine1BotConfi
  */
 export async function loadConfig(customConfigPath?: string): Promise<Nine1BotConfig> {
   let result: Partial<Nine1BotConfig> = {}
+  const projectConfigPath = customConfigPath || await findConfigPath()
+  let projectConfig: Partial<Nine1BotConfig> = {}
+
+  if (projectConfigPath && await fileExists(projectConfigPath)) {
+    try {
+      projectConfig = await loadConfigFile(projectConfigPath)
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(`Invalid JSON in config file: ${projectConfigPath}`)
+      }
+      if (error && typeof error === 'object' && 'issues' in error) {
+        const zodError = error as { issues: Array<{ path: (string | number)[]; message: string }> }
+        const messages = zodError.issues.map(i => `  - ${i.path.join('.')}: ${i.message}`).join('\n')
+        throw new Error(`Invalid config in ${projectConfigPath}:\n${messages}`)
+      }
+      throw error
+    }
+  }
+
+  const skipGlobalConfig = Boolean(projectConfig.isolation?.disableGlobalConfig)
 
   // 1. 加载全局配置
   const globalConfigPath = getGlobalConfigPath()
-  if (await fileExists(globalConfigPath)) {
+  if (!skipGlobalConfig && await fileExists(globalConfigPath)) {
     try {
       const globalConfig = await loadConfigFile(globalConfigPath)
       result = deepMerge(result, globalConfig)
@@ -292,10 +321,8 @@ export async function loadConfig(customConfigPath?: string): Promise<Nine1BotCon
   }
 
   // 2. 加载项目配置
-  const projectConfigPath = customConfigPath || await findConfigPath()
   if (projectConfigPath && await fileExists(projectConfigPath)) {
     try {
-      const projectConfig = await loadConfigFile(projectConfigPath)
       result = deepMerge(result, projectConfig)
     } catch (error) {
       if (error instanceof SyntaxError) {

--- a/packages/nine1bot/src/config/loader.ts
+++ b/packages/nine1bot/src/config/loader.ts
@@ -321,20 +321,8 @@ export async function loadConfig(customConfigPath?: string): Promise<Nine1BotCon
   }
 
   // 2. 加载项目配置
-  if (projectConfigPath && await fileExists(projectConfigPath)) {
-    try {
-      result = deepMerge(result, projectConfig)
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        throw new Error(`Invalid JSON in config file: ${projectConfigPath}`)
-      }
-      if (error && typeof error === 'object' && 'issues' in error) {
-        const zodError = error as { issues: Array<{ path: (string | number)[]; message: string }> }
-        const messages = zodError.issues.map(i => `  - ${i.path.join('.')}: ${i.message}`).join('\n')
-        throw new Error(`Invalid config in ${projectConfigPath}:\n${messages}`)
-      }
-      throw error
-    }
+  if (projectConfigPath) {
+    result = deepMerge(result, projectConfig)
   }
 
   // 验证并返回最终配置

--- a/packages/nine1bot/src/config/schema.ts
+++ b/packages/nine1bot/src/config/schema.ts
@@ -128,11 +128,18 @@ const McpLocalSchema = z.object({
   timeout: z.number().optional(),
 })
 
+const McpOAuthSchema = z.object({
+  clientId: z.string().optional(),
+  clientSecret: z.string().optional(),
+  scope: z.string().optional(),
+})
+
 const McpRemoteSchema = z.object({
   type: z.literal('remote'),
   url: z.string(),
   enabled: z.boolean().optional(),
   headers: z.record(z.string()).optional(),
+  oauth: z.union([McpOAuthSchema, z.literal(false)]).optional(),
   timeout: z.number().optional(),
 })
 
@@ -210,6 +217,7 @@ export const Nine1BotConfigSchema = z.object({
   skills: SkillsConfigSchema.default({}),
   browser: BrowserConfigSchema.default({}),
   feishu: FeishuConfigSchema.default({}),
+
 
   // OpenCode 兼容配置
   model: z.string().optional(),

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -2,7 +2,7 @@ import { resolve, dirname, basename } from 'path'
 import { writeFile, mkdir } from 'fs/promises'
 import { tmpdir } from 'os'
 import type { ServerConfig, AuthConfig, Nine1BotConfig, CustomProvider } from '../config/schema'
-import { getInstallDir, getGlobalSkillsDir, getAuthPath, getGlobalConfigDir, getProjectEnvDir } from '../config/loader'
+import { getInstallDir, getGlobalSkillsDir, getAuthPath, getGlobalConfigDir, getMcpAuthPath, getProjectEnvDir } from '../config/loader'
 import { getGlobalPreferencesPath } from '../preferences'
 // 静态导入 OpenCode 服务器（编译时打包）
 import { Server as OpencodeServer } from '../../../../opencode/packages/opencode/src/server/server'
@@ -209,6 +209,7 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
   // 设置 Nine1Bot 独立的认证存储路径
   await mkdir(getGlobalConfigDir(), { recursive: true })
   process.env.NINE1BOT_AUTH_PATH = getAuthPath()
+  process.env.NINE1BOT_MCP_AUTH_PATH = getMcpAuthPath()
   await mkdir(getProjectEnvDir(), { recursive: true })
   process.env.NINE1BOT_PROJECT_ENV_DIR = getProjectEnvDir()
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -815,8 +815,15 @@ export interface PermissionRequest {
 // === MCP Types ===
 export interface McpServer {
   name: string
-  // 后端状态: connected, disabled, failed, needs_auth, needs_client_registration
-  status: 'connected' | 'disabled' | 'failed' | 'needs_auth' | 'needs_client_registration' | 'connecting'
+  // 后端状态: connected, disabled, failed, needs_auth, auth_in_progress, needs_client_registration
+  status:
+    | 'connected'
+    | 'disabled'
+    | 'failed'
+    | 'needs_auth'
+    | 'auth_in_progress'
+    | 'needs_client_registration'
+    | 'connecting'
   error?: string
   tools?: McpTool[]
   resources?: McpResource[]
@@ -854,10 +861,17 @@ export interface McpLocalConfig {
   timeout?: number
 }
 
+export interface McpOAuthConfig {
+  clientId?: string
+  clientSecret?: string
+  scope?: string
+}
+
 export interface McpRemoteConfig {
   type: 'remote'
   url: string
   headers?: Record<string, string>
+  oauth?: McpOAuthConfig | false
   enabled?: boolean
   timeout?: number
 }
@@ -931,7 +945,7 @@ export const mcpApi = {
   // 获取所有 MCP 服务器状态
   // 后端返回 Record<string, MCP.StatusInfo>，转换为数组
   async list(): Promise<McpServer[]> {
-    const res = await fetch(`${BASE_URL}/mcp`)
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp`)
     const data = await res.json()
     // 后端返回 { serverName: { status, tools, ... }, ... }
     if (typeof data === 'object' && !Array.isArray(data)) {
@@ -949,7 +963,7 @@ export const mcpApi = {
 
   // 添加新 MCP 服务器
   async add(name: string, config: McpConfig): Promise<void> {
-    const res = await fetch(`${BASE_URL}/mcp`, {
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, config })
@@ -962,7 +976,7 @@ export const mcpApi = {
 
   // 删除 MCP 服务器
   async remove(name: string): Promise<void> {
-    const res = await fetch(`${BASE_URL}/mcp/${encodeURIComponent(name)}`, {
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}`, {
       method: 'DELETE'
     })
     if (!res.ok) {
@@ -973,29 +987,43 @@ export const mcpApi = {
 
   // 连接 MCP 服务器
   async connect(name: string): Promise<void> {
-    await fetch(`${BASE_URL}/mcp/${encodeURIComponent(name)}/connect`, {
+    await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}/connect`, {
       method: 'POST'
     })
   },
 
   // 断开 MCP 服务器
   async disconnect(name: string): Promise<void> {
-    await fetch(`${BASE_URL}/mcp/${encodeURIComponent(name)}/disconnect`, {
+    await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}/disconnect`, {
       method: 'POST'
     })
   },
 
   // 启动 OAuth 认证
   async startAuth(name: string): Promise<{ url: string }> {
-    const res = await fetch(`${BASE_URL}/mcp/${encodeURIComponent(name)}/auth`, {
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}/auth`, {
       method: 'POST'
     })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to start MCP auth: ${res.status}`)
+    }
     const data = await res.json()
     return { url: data.authorizationUrl || data.url }
   },
 
+  async removeAuth(name: string): Promise<void> {
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}/auth`, {
+      method: 'DELETE'
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to remove MCP auth: ${res.status}`)
+    }
+  },
+
   async health(name: string): Promise<McpHealth> {
-    const res = await fetch(`${BASE_URL}/mcp/${encodeURIComponent(name)}/health`, {
+    const res = await fetchWithTimeout(`${BASE_URL}/mcp/${encodeURIComponent(name)}/health`, {
       method: 'POST'
     })
     const data = await res.json()

--- a/web/src/components/McpManager.vue
+++ b/web/src/components/McpManager.vue
@@ -9,6 +9,7 @@ defineProps<{
 
 const emit = defineEmits<{
   connect: [name: string]
+  authenticate: [name: string]
   disconnect: [name: string]
   add: [name: string, config: McpConfig]
   remove: [name: string]
@@ -32,6 +33,7 @@ function getStatusBadge(status: string) {
   switch (status) {
     case 'connected': return 'badge-success'
     case 'connecting': return 'badge-warning'
+    case 'auth_in_progress': return 'badge-warning'
     case 'failed': return 'badge-error'
     case 'needs_auth': return 'badge-warning'
     case 'needs_client_registration': return 'badge-warning'
@@ -44,10 +46,11 @@ function getStatusText(status: string) {
   switch (status) {
     case 'connected': return '已连接'
     case 'connecting': return '连接中'
+    case 'auth_in_progress': return '认证中'
     case 'disabled': return '已禁用'
     case 'failed': return '连接失败'
     case 'needs_auth': return '需要认证'
-    case 'needs_client_registration': return '需要注册'
+    case 'needs_client_registration': return '需要静态注册'
     default: return status
   }
 }
@@ -508,7 +511,7 @@ function confirmRemove(name: string) {
           <button
             v-else-if="server.status === 'needs_auth'"
             class="btn btn-secondary btn-sm"
-            @click="emit('connect', server.name)"
+            @click="emit('authenticate', server.name)"
           >
             认证
           </button>

--- a/web/src/components/McpProjectPanel.vue
+++ b/web/src/components/McpProjectPanel.vue
@@ -44,6 +44,48 @@ async function connectServer(name: string) {
   }
 }
 
+async function authenticateServer(name: string) {
+  try {
+    const { url } = await mcpApi.startAuth(name)
+    const popup = window.open(url, '_blank', 'width=700,height=780')
+
+    if (!popup) {
+      window.location.href = url
+      return
+    }
+
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 120000) {
+      const next = await mcpApi.list()
+      servers.value = next
+      const match = next.find(server => server.name === name)
+
+      if (!match) {
+        throw new Error(`MCP server not found after auth: ${name}`)
+      }
+
+      if (match.status === 'connected') {
+        return
+      }
+
+      if (match.status === 'auth_in_progress') {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        continue
+      }
+
+      if (match.status === 'failed' || match.status === 'needs_client_registration') {
+        throw new Error(match.error || `MCP auth failed for ${name}`)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
+
+    throw new Error(`Timed out waiting for MCP auth: ${name}`)
+  } catch (e) {
+    console.error('Failed to authenticate MCP server:', e)
+  }
+}
+
 async function disconnectServer(name: string) {
   try {
     await mcpApi.disconnect(name)
@@ -66,9 +108,11 @@ function getStatusText(status: string): string {
   switch (status) {
     case 'connected': return 'Connected'
     case 'connecting': return 'Connecting...'
+    case 'auth_in_progress': return 'Authorizing...'
     case 'disabled': return 'Disconnected'
     case 'failed': return 'Failed'
     case 'needs_auth': return 'Auth Required'
+    case 'needs_client_registration': return 'Static Client Required'
     default: return status
   }
 }
@@ -253,6 +297,14 @@ onMounted(loadServers)
               title="Disconnect"
             >
               <Unplug :size="14" />
+            </button>
+            <button
+              v-else-if="server.status === 'needs_auth'"
+              class="mcp-action-btn connect"
+              @click="authenticateServer(server.name)"
+              title="Authenticate"
+            >
+              <Plug :size="14" />
             </button>
             <Loader2 v-else-if="server.status === 'connecting'" :size="14" class="spin" />
           </div>

--- a/web/src/components/McpProjectPanel.vue
+++ b/web/src/components/McpProjectPanel.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue'
 import { X, Server, Loader2, Plug, Unplug, Plus } from 'lucide-vue-next'
 import { mcpApi } from '../api/client'
 import type { McpServer, McpConfig } from '../api/client'
+import { authenticateMcpWithPopup } from '../utils/mcp-auth'
 
 defineProps<{
   currentDirectory?: string
@@ -46,41 +47,11 @@ async function connectServer(name: string) {
 
 async function authenticateServer(name: string) {
   try {
-    const { url } = await mcpApi.startAuth(name)
-    const popup = window.open(url, '_blank', 'width=700,height=780')
-
-    if (!popup) {
-      window.location.href = url
-      return
-    }
-
-    const startedAt = Date.now()
-    while (Date.now() - startedAt < 120000) {
-      const next = await mcpApi.list()
-      servers.value = next
-      const match = next.find(server => server.name === name)
-
-      if (!match) {
-        throw new Error(`MCP server not found after auth: ${name}`)
-      }
-
-      if (match.status === 'connected') {
-        return
-      }
-
-      if (match.status === 'auth_in_progress') {
-        await new Promise(resolve => setTimeout(resolve, 1000))
-        continue
-      }
-
-      if (match.status === 'failed' || match.status === 'needs_client_registration') {
-        throw new Error(match.error || `MCP auth failed for ${name}`)
-      }
-
-      await new Promise(resolve => setTimeout(resolve, 1000))
-    }
-
-    throw new Error(`Timed out waiting for MCP auth: ${name}`)
+    await authenticateMcpWithPopup(name, {
+      onUpdate: (next) => {
+        servers.value = next
+      },
+    })
   } catch (e) {
     console.error('Failed to authenticate MCP server:', e)
   }

--- a/web/src/components/SettingsPanel.vue
+++ b/web/src/components/SettingsPanel.vue
@@ -325,7 +325,6 @@ function handleOverlayClick(e: MouseEvent) {
 .settings-tabs {
   padding: 0 var(--space-lg);
   border-bottom: 0.5px solid var(--border-subtle);
-  border-bottom: 0.5px solid var(--border-subtle);
 }
 
 .settings-tabs .tabs {
@@ -334,13 +333,11 @@ function handleOverlayClick(e: MouseEvent) {
   gap: 4px;
   border-radius: var(--radius-md);
   border-bottom: none;
-  border-bottom: none;
 }
 
 .settings-tabs .tab {
   flex: 1;
   background: transparent;
-  padding: 6px 16px;
   padding: 6px 16px;
   border-radius: var(--radius-sm);
   border: none;
@@ -349,13 +346,10 @@ function handleOverlayClick(e: MouseEvent) {
   color: var(--text-secondary);
   font-weight: var(--font-weight-normal);
   transition: all var(--transition-fast);
-  font-weight: var(--font-weight-normal);
-  transition: all var(--transition-fast);
 }
 
 .settings-tabs .tab:hover {
   color: var(--text-primary);
-  background: rgba(0, 0, 0, 0.04);
   background: rgba(0, 0, 0, 0.04);
 }
 

--- a/web/src/components/SettingsPanel.vue
+++ b/web/src/components/SettingsPanel.vue
@@ -31,6 +31,7 @@ const {
   selectModel,
   setDefaultModel,
   connectMcp,
+  authenticateMcp,
   disconnectMcp,
   addMcp,
   removeMcp,
@@ -174,6 +175,7 @@ function handleOverlayClick(e: MouseEvent) {
           :servers="mcpServers"
           :loading="loadingMcp"
           @connect="connectMcp"
+          @authenticate="authenticateMcp"
           @disconnect="disconnectMcp"
           @add="addMcp"
           @remove="removeMcp"
@@ -323,6 +325,7 @@ function handleOverlayClick(e: MouseEvent) {
 .settings-tabs {
   padding: 0 var(--space-lg);
   border-bottom: 0.5px solid var(--border-subtle);
+  border-bottom: 0.5px solid var(--border-subtle);
 }
 
 .settings-tabs .tabs {
@@ -331,11 +334,13 @@ function handleOverlayClick(e: MouseEvent) {
   gap: 4px;
   border-radius: var(--radius-md);
   border-bottom: none;
+  border-bottom: none;
 }
 
 .settings-tabs .tab {
   flex: 1;
   background: transparent;
+  padding: 6px 16px;
   padding: 6px 16px;
   border-radius: var(--radius-sm);
   border: none;
@@ -344,10 +349,13 @@ function handleOverlayClick(e: MouseEvent) {
   color: var(--text-secondary);
   font-weight: var(--font-weight-normal);
   transition: all var(--transition-fast);
+  font-weight: var(--font-weight-normal);
+  transition: all var(--transition-fast);
 }
 
 .settings-tabs .tab:hover {
   color: var(--text-primary);
+  background: rgba(0, 0, 0, 0.04);
   background: rgba(0, 0, 0, 0.04);
 }
 

--- a/web/src/composables/useSettings.ts
+++ b/web/src/composables/useSettings.ts
@@ -168,6 +168,41 @@ export function useSettings() {
     }
   }
 
+  async function waitForMcpAuth(name: string, timeoutMs = 120000) {
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < timeoutMs) {
+      const servers = await mcpApi.list()
+      const match = servers.find(server => server.name === name)
+
+      if (!match) {
+        throw new Error(`MCP server not found after auth: ${name}`)
+      }
+
+      if (match.status === 'connected') {
+        mcpServers.value = servers
+        return
+      }
+
+      if (match.status === 'auth_in_progress') {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        continue
+      }
+
+      if (match.status === 'failed') {
+        throw new Error(match.error || `MCP auth failed for ${name}`)
+      }
+
+      if (match.status === 'needs_client_registration') {
+        throw new Error(match.error || `MCP server ${name} requires a pre-registered clientId`)
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
+
+    throw new Error(`Timed out waiting for MCP auth: ${name}`)
+  }
+
   async function disconnectMcp(name: string) {
     try {
       await mcpApi.disconnect(name)
@@ -193,6 +228,24 @@ export function useSettings() {
       await loadMcpServers()
     } catch (e) {
       console.error('Failed to remove MCP:', e)
+      throw e
+    }
+  }
+
+  async function authenticateMcp(name: string) {
+    try {
+      const { url } = await mcpApi.startAuth(name)
+      const popup = window.open(url, '_blank', 'width=700,height=780')
+
+      if (!popup) {
+        window.location.href = url
+        return
+      }
+
+      await waitForMcpAuth(name)
+      await loadMcpServers()
+    } catch (e) {
+      console.error('Failed to authenticate MCP:', e)
       throw e
     }
   }
@@ -367,10 +420,12 @@ export function useSettings() {
     selectModel,
     setDefaultModel,
     connectMcp,
+    authenticateMcp,
     disconnectMcp,
     addMcp,
     removeMcp,
     healthMcp,
+
     startOAuth,
     setApiKey,
     removeAuth,

--- a/web/src/composables/useSettings.ts
+++ b/web/src/composables/useSettings.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { providerApi, configApi, mcpApi, skillApi, authApi, nine1botConfigApi, customProviderApi, importAuthFromOpencode as importAuthFromOpencodeApi } from '../api/client'
 import type { Provider, McpServer, Skill, Config, McpConfig, CustomProvider, AuthImportResult } from '../api/client'
+import { authenticateMcpWithPopup } from '../utils/mcp-auth'
 
 const showSettings = ref(false)
 const activeTab = ref<'models' | 'mcp' | 'skills' | 'auth' | 'preferences' | 'profile'>('models')
@@ -168,41 +169,6 @@ export function useSettings() {
     }
   }
 
-  async function waitForMcpAuth(name: string, timeoutMs = 120000) {
-    const startedAt = Date.now()
-
-    while (Date.now() - startedAt < timeoutMs) {
-      const servers = await mcpApi.list()
-      const match = servers.find(server => server.name === name)
-
-      if (!match) {
-        throw new Error(`MCP server not found after auth: ${name}`)
-      }
-
-      if (match.status === 'connected') {
-        mcpServers.value = servers
-        return
-      }
-
-      if (match.status === 'auth_in_progress') {
-        await new Promise(resolve => setTimeout(resolve, 1000))
-        continue
-      }
-
-      if (match.status === 'failed') {
-        throw new Error(match.error || `MCP auth failed for ${name}`)
-      }
-
-      if (match.status === 'needs_client_registration') {
-        throw new Error(match.error || `MCP server ${name} requires a pre-registered clientId`)
-      }
-
-      await new Promise(resolve => setTimeout(resolve, 1000))
-    }
-
-    throw new Error(`Timed out waiting for MCP auth: ${name}`)
-  }
-
   async function disconnectMcp(name: string) {
     try {
       await mcpApi.disconnect(name)
@@ -234,15 +200,11 @@ export function useSettings() {
 
   async function authenticateMcp(name: string) {
     try {
-      const { url } = await mcpApi.startAuth(name)
-      const popup = window.open(url, '_blank', 'width=700,height=780')
-
-      if (!popup) {
-        window.location.href = url
-        return
-      }
-
-      await waitForMcpAuth(name)
+      await authenticateMcpWithPopup(name, {
+        onUpdate: (servers) => {
+          mcpServers.value = servers
+        },
+      })
       await loadMcpServers()
     } catch (e) {
       console.error('Failed to authenticate MCP:', e)

--- a/web/src/utils/mcp-auth.ts
+++ b/web/src/utils/mcp-auth.ts
@@ -1,0 +1,63 @@
+import { mcpApi } from '../api/client'
+import type { McpServer } from '../api/client'
+
+type WaitForMcpAuthOptions = {
+  timeoutMs?: number
+  onUpdate?: (servers: McpServer[]) => void
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function waitForMcpAuth(name: string, options: WaitForMcpAuthOptions = {}) {
+  const { timeoutMs = 120000, onUpdate } = options
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const servers = await mcpApi.list()
+    onUpdate?.(servers)
+
+    const match = servers.find(server => server.name === name)
+    if (!match) {
+      throw new Error(`MCP server not found after auth: ${name}`)
+    }
+
+    if (match.status === 'connected') {
+      return servers
+    }
+
+    if (match.status === 'auth_in_progress') {
+      await sleep(1000)
+      continue
+    }
+
+    if (match.status === 'failed') {
+      throw new Error(match.error || `MCP auth failed for ${name}`)
+    }
+
+    if (match.status === 'needs_auth') {
+      throw new Error(`MCP auth was cancelled or denied for ${name}`)
+    }
+
+    if (match.status === 'needs_client_registration') {
+      throw new Error(match.error || `MCP server ${name} requires a pre-registered clientId`)
+    }
+
+    await sleep(1000)
+  }
+
+  throw new Error(`Timed out waiting for MCP auth: ${name}`)
+}
+
+export async function authenticateMcpWithPopup(name: string, options: WaitForMcpAuthOptions = {}) {
+  const { url } = await mcpApi.startAuth(name)
+  const popup = window.open(url, '_blank', 'width=700,height=780')
+
+  if (!popup) {
+    window.location.href = url
+    return
+  }
+
+  return waitForMcpAuth(name, options)
+}


### PR DESCRIPTION
# 描述 / Summary

为远程 MCP 增加端到端 OAuth 支持，覆盖 token 持久化、刷新、server callback、CLI/Web UI 状态流转，以及 Nine1Bot 侧的配置与存储接入。

## 类型 / Type of change

- [x] 新功能 (feature)
- [ ] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

/暂无/

## 变更点 / What changed

- `opencode` MCP OAuth 持久化增强：
  - 保存 client / token / redirect / error / metadata 等状态
  - 增加 token stale 判定和 refresh 逻辑
  - 区分 dynamic / static registration
- OAuth 流程增强：
  - `startAuth(mode=loopback|server)`
  - 新增服务端 `/mcp/oauth/callback`
  - 增加 `auth_in_progress` 状态
  - 认证失败时支持更细粒度分类与恢复
- 工具调用时遇到认证错误可尝试自动恢复连接
- 会话开始前可对 Feishu/Lark 类 MCP 做预热准备
- CLI / SDK / OpenAPI / Web UI 全链路支持 `auth_in_progress`
- Nine1Bot 配置 schema 支持 remote MCP `oauth`
- Nine1Bot 支持独立的 `NINE1BOT_MCP_AUTH_PATH`
- 补充文档与测试，示例配置只保留通用、脱敏内容

## 如何测试 / How to test

1. 运行：
   `bun test opencode/packages/opencode/test/mcp/oauth-browser.test.ts opencode/packages/opencode/test/mcp/auth.test.ts opencode/packages/opencode/test/mcp/oauth-provider.test.ts packages/nine1bot/src/config/loader.test.ts`
2. 配置一个启用 OAuth 的 remote MCP
3. 在 Web UI 或 CLI 中触发认证流程
4. 预期结果：
   - 状态可从 `needs_auth` 进入 `auth_in_progress`
   - 浏览器完成授权后进入 `connected`
   - token 接近过期时可刷新
   - SDK / API / Web UI 均能识别新的状态类型

## 截图（UI 变更时提供）/ Screenshots for UI changed

/如需要可补充 MCP 管理面板的认证状态截图/

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

请重点看：
- `mcp/index.ts` 中认证状态机和恢复逻辑
- `oauth-provider` 中 refresh / registration / redirect 处理
- Nine1Bot 侧 `mcp-auth.json` 存储接入是否与 browser relay 变更解耦
- 本 PR 不包含私有 MCP 地址或真实环境配置
