### PR TITLE
fix: correct terminal viewport and truncation handling

### DIFF
--- a/opencode/packages/opencode/src/pty/screen-buffer.ts
+++ b/opencode/packages/opencode/src/pty/screen-buffer.ts
@@ -63,13 +63,23 @@ export namespace ScreenBuffer {
     }
 
     /**
+     * 获取当前可见视口在缓冲区中的起始行号
+     */
+    private getViewportTop() {
+      const buffer = this.term.buffer.active
+      const maxTop = Math.max(0, buffer.length - this.term.rows)
+      return Math.min(Math.max(0, buffer.viewportY), maxTop)
+    }
+
+    /**
      * 获取当前可见屏幕的文本内容
      */
     getScreen(): string[] {
       const lines: string[] = []
       const buffer = this.term.buffer.active
+      const viewportTop = this.getViewportTop()
       for (let i = 0; i < this.term.rows; i++) {
-        const line = buffer.getLine(i)
+        const line = buffer.getLine(viewportTop + i)
         if (line) {
           lines.push(line.translateToString().trimEnd())
         } else {
@@ -94,9 +104,10 @@ export namespace ScreenBuffer {
     getScreenAnsi(): string {
       const lines: string[] = []
       const buffer = this.term.buffer.active
+      const viewportTop = this.getViewportTop()
 
       for (let y = 0; y < this.term.rows; y++) {
-        const line = buffer.getLine(y)
+        const line = buffer.getLine(viewportTop + y)
         if (!line) {
           lines.push("")
           continue
@@ -209,11 +220,11 @@ export namespace ScreenBuffer {
     getScrollback(lines?: number): string[] {
       const result: string[] = []
       const buffer = this.term.buffer.active
-      const scrollbackLength = buffer.baseY
+      const viewportTop = this.getViewportTop()
 
-      const start = lines ? Math.max(0, scrollbackLength - lines) : 0
-      for (let i = start; i < scrollbackLength; i++) {
-        const line = buffer.getLine(i - scrollbackLength)
+      const start = lines ? Math.max(0, viewportTop - lines) : 0
+      for (let i = start; i < viewportTop; i++) {
+        const line = buffer.getLine(i)
         if (line) {
           result.push(line.translateToString().trimEnd())
         }
@@ -250,7 +261,7 @@ export namespace ScreenBuffer {
         rows: this.term.rows,
         cols: this.term.cols,
         cursor: this.getCursor(),
-        scrollbackLength: buffer.baseY,
+        scrollbackLength: this.getViewportTop(),
       }
     }
 

--- a/opencode/packages/opencode/src/tool/terminal/view.ts
+++ b/opencode/packages/opencode/src/tool/terminal/view.ts
@@ -17,7 +17,8 @@ Use this to:
 - Monitor the state of long-running tasks
 - View full-screen applications like vim or htop
 
-The output is formatted to clearly show terminal boundaries.`,
+The output is formatted to clearly show terminal boundaries.
+If the output is too large, the latest terminal content is kept and older history is truncated.`,
 
   parameters: z.object({
     id: z.string().describe("Terminal session ID (from terminal_create or terminal_list)"),
@@ -68,5 +69,9 @@ ${"─".repeat(width)}`,
         cols: screenInfo?.cols,
       },
     }
+  },
+}, {
+  truncation: {
+    direction: "tail",
   },
 })

--- a/opencode/packages/opencode/src/tool/terminal/wait.ts
+++ b/opencode/packages/opencode/src/tool/terminal/wait.ts
@@ -13,6 +13,7 @@ Use this after sending commands to wait for:
 - Process completion indicators
 
 This is more efficient than repeatedly calling terminal_view. The tool will check the terminal screen every 100ms until the pattern is found or timeout occurs.
+If the output is too large, the latest terminal content is kept and older history is truncated.
 
 Pattern tips:
 - Use regex for flexible matching
@@ -95,5 +96,9 @@ The pattern was not found. You can:
         },
       }
     }
+  },
+}, {
+  truncation: {
+    direction: "tail",
   },
 })

--- a/opencode/packages/opencode/src/tool/tool.ts
+++ b/opencode/packages/opencode/src/tool/tool.ts
@@ -46,9 +46,14 @@ export namespace Tool {
   export type InferParameters<T extends Info> = T extends Info<infer P> ? z.infer<P> : never
   export type InferMetadata<T extends Info> = T extends Info<any, infer M> ? M : never
 
+  export interface DefineOptions {
+    truncation?: Truncate.Options
+  }
+
   export function define<Parameters extends z.ZodType, Result extends Metadata>(
     id: string,
     init: Info<Parameters, Result>["init"] | Awaited<ReturnType<Info<Parameters, Result>["init"]>>,
+    options: DefineOptions = {},
   ): Info<Parameters, Result> {
     return {
       id,
@@ -72,7 +77,7 @@ export namespace Tool {
           if (result.metadata.truncated !== undefined) {
             return result
           }
-          const truncated = await Truncate.output(result.output, {}, initCtx?.agent)
+          const truncated = await Truncate.output(result.output, options.truncation ?? {}, initCtx?.agent)
           return {
             ...result,
             output: truncated.content,

--- a/opencode/packages/opencode/test/tool/screen-buffer.test.ts
+++ b/opencode/packages/opencode/test/tool/screen-buffer.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ScreenBuffer } from "../../src/pty/screen-buffer"
+
+const disposables: ScreenBuffer.Buffer[] = []
+
+function createBuffer(config: Partial<ScreenBuffer.Config>) {
+  const buffer = new ScreenBuffer.Buffer(config)
+  disposables.push(buffer)
+  return buffer
+}
+
+afterEach(() => {
+  while (disposables.length > 0) {
+    disposables.pop()?.dispose()
+  }
+})
+
+describe("ScreenBuffer", () => {
+  test("getScreen returns the current viewport lines", async () => {
+    const buffer = createBuffer({ rows: 4, cols: 40, scrollback: 100 })
+    const data = ["l1", "l2", "l3", "l4", "l5", "l6"].join("\r\n")
+
+    await buffer.write(data)
+
+    expect(buffer.getScreen()).toEqual(["l3", "l4", "l5", "l6"])
+    expect(buffer.getInfo().scrollbackLength).toBe(2)
+  })
+
+  test("getScrollback returns lines above the current viewport", async () => {
+    const buffer = createBuffer({ rows: 3, cols: 40, scrollback: 100 })
+    const data = ["l1", "l2", "l3", "l4", "l5", "l6", "l7"].join("\r\n")
+
+    await buffer.write(data)
+
+    expect(buffer.getScrollback()).toEqual(["l1", "l2", "l3", "l4"])
+    expect(buffer.getScrollback(2)).toEqual(["l3", "l4"])
+  })
+
+  test("getFullView appends screen after requested history slice", async () => {
+    const buffer = createBuffer({ rows: 3, cols: 40, scrollback: 100 })
+    const data = ["l1", "l2", "l3", "l4", "l5", "l6", "l7"].join("\r\n")
+
+    await buffer.write(data)
+
+    expect(buffer.getFullView(2).split("\n")).toEqual(["l3", "l4", "l5", "l6", "l7"])
+  })
+
+  test("getScreenAnsi also reads from current viewport", async () => {
+    const buffer = createBuffer({ rows: 3, cols: 40, scrollback: 100 })
+    const data = ["old1", "old2", "new1", "new2", "new3"].join("\r\n")
+
+    await buffer.write(data)
+
+    const ansi = buffer.getScreenAnsi()
+    expect(ansi).toContain("new3")
+    expect(ansi).not.toContain("old1")
+  })
+})

--- a/opencode/packages/opencode/test/tool/tool-define-truncation.test.ts
+++ b/opencode/packages/opencode/test/tool/tool-define-truncation.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import z from "zod"
+import fs from "fs/promises"
+import { Tool } from "../../src/tool/tool"
+
+const createdOutputPaths: string[] = []
+
+const baseContext: Tool.Context = {
+  sessionID: "session_test",
+  messageID: "message_test",
+  agent: "agent_test",
+  abort: new AbortController().signal,
+  cwd: process.cwd(),
+  extra: {},
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+afterEach(async () => {
+  while (createdOutputPaths.length > 0) {
+    const outputPath = createdOutputPaths.pop()
+    if (!outputPath) continue
+    await fs.unlink(outputPath).catch(() => {})
+  }
+})
+
+describe("Tool.define truncation options", () => {
+  test("uses head truncation when direction is not specified", async () => {
+    const output = Array.from({ length: 10 }, (_, i) => `line${i}`).join("\n")
+    const tool = Tool.define(
+      "test_head_truncation",
+      {
+        description: "test",
+        parameters: z.object({}),
+        execute: async () => ({
+          title: "head",
+          output,
+          metadata: {},
+        }),
+      },
+      {
+        truncation: { maxLines: 3 },
+      },
+    )
+
+    const initialized = await tool.init()
+    const result = await initialized.execute({}, baseContext)
+    const metadata = result.metadata as { truncated?: boolean; outputPath?: string }
+    const outputPath = metadata.outputPath
+    if (outputPath) createdOutputPaths.push(outputPath)
+
+    expect(metadata.truncated).toBe(true)
+    expect(result.output).toContain("line0")
+    expect(result.output).toContain("line1")
+    expect(result.output).toContain("line2")
+    expect(result.output).not.toContain("line9")
+  })
+
+  test("uses tail truncation when direction is tail", async () => {
+    const output = Array.from({ length: 10 }, (_, i) => `line${i}`).join("\n")
+    const tool = Tool.define(
+      "test_tail_truncation",
+      {
+        description: "test",
+        parameters: z.object({}),
+        execute: async () => ({
+          title: "tail",
+          output,
+          metadata: {},
+        }),
+      },
+      {
+        truncation: { maxLines: 3, direction: "tail" },
+      },
+    )
+
+    const initialized = await tool.init()
+    const result = await initialized.execute({}, baseContext)
+    const metadata = result.metadata as { truncated?: boolean; outputPath?: string }
+    const outputPath = metadata.outputPath
+    if (outputPath) createdOutputPaths.push(outputPath)
+
+    expect(metadata.truncated).toBe(true)
+    expect(result.output).toContain("line7")
+    expect(result.output).toContain("line8")
+    expect(result.output).toContain("line9")
+    expect(result.output).not.toContain("line0")
+  })
+})


### PR DESCRIPTION
# 描述 / Summary

修复终端屏幕读取与输出截断行为，避免 `terminal_view` / `terminal_wait` 在有滚动历史或大输出场景下读取错误位置的内容。

## 类型 / Type of change

- [ ] 新功能 (feature)
- [x] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

/暂无/

## 变更点 / What changed

- 修复 `screen-buffer` 读取逻辑，按当前 viewport 位置读取可见内容，而不是固定从缓冲区顶部读取
- 修正 scrollback 计算逻辑，使其和当前 viewport 对齐
- 为 `Tool.define` 增加可配置的 truncation 方向
- 让 `terminal_view` / `terminal_wait` 在大输出场景下优先保留最新内容（tail truncation）
- 补充 `screen-buffer` 与 truncation 的回归测试

## 如何测试 / How to test

1. 运行：
   `bun test opencode/packages/opencode/test/tool/screen-buffer.test.ts opencode/packages/opencode/test/tool/tool-define-truncation.test.ts`
2. 确认所有测试通过
3. 预期结果：
   - viewport 读取返回当前屏幕内容
   - scrollback 返回屏幕上方历史
   - truncation 为 `tail` 时保留最新输出

## 截图（UI 变更时提供）/ Screenshots for UI changed

/无/

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

请重点看：
- `screen-buffer` 的 viewport / scrollback 计算是否和终端实际行为一致
- `tail truncation` 是否只影响目标工具，不改变默认截断语义
