### PR TITLE
fix(opencode): stabilize test bootstrap and typecheck

### DIFF
--- a/opencode/packages/opencode/src/browser/bridge.ts
+++ b/opencode/packages/opencode/src/browser/bridge.ts
@@ -5,7 +5,27 @@
  * then AI tools and routes access it via getBridgeServer().
  */
 
-import type { BridgeServer } from '../../../../packages/browser-mcp-server/src/bridge/server'
+import type { Hono } from "hono"
+
+export type BridgeServer = {
+  getRoutes(): Hono
+  getStatus(): Promise<any>
+  launchBotBrowser(options?: any): Promise<any>
+  snapshot(...args: any[]): Promise<any>
+  screenshot(...args: any[]): Promise<any>
+  navigate(...args: any[]): Promise<any>
+  clickElement(...args: any[]): Promise<any>
+  fillForm(...args: any[]): Promise<any>
+  pressKey(...args: any[]): Promise<any>
+  scroll(...args: any[]): Promise<any>
+  waitForText(...args: any[]): Promise<any>
+  handleDialog(...args: any[]): Promise<any>
+  findElements(...args: any[]): Promise<any>
+  uploadFile(...args: any[]): Promise<any>
+  evaluate(...args: any[]): Promise<any>
+  readConsoleMessages(...args: any[]): Promise<any>
+  readNetworkRequests(...args: any[]): Promise<any>
+}
 
 let instance: BridgeServer | null = null
 

--- a/opencode/packages/opencode/src/project/project.ts
+++ b/opencode/packages/opencode/src/project/project.ts
@@ -7,14 +7,13 @@ import { createHash } from "crypto"
 import { Storage } from "../storage/storage"
 import { Log } from "../util/log"
 import { Flag } from "@/flag/flag"
-import { Session } from "../session"
+import type { Session } from "../session"
 import { work } from "../util/queue"
 import { fn } from "@opencode-ai/util/fn"
 import { BusEvent } from "@/bus/bus-event"
 import { iife } from "@/util/iife"
 import { GlobalBus } from "@/bus/global"
 import { existsSync } from "fs"
-import { Bus } from "@/bus"
 
 export namespace Project {
   const log = Log.create({ service: "project" })
@@ -426,6 +425,7 @@ export namespace Project {
     })
     emitProjectUpdated(project)
 
+    const { Bus } = await import("@/bus")
     await Bus.publish(Event.ContextUpdated, {
       projectID,
       revision: next.revision,

--- a/opencode/packages/opencode/src/session/message-v2.ts
+++ b/opencode/packages/opencode/src/session/message-v2.ts
@@ -806,10 +806,4 @@ export namespace MessageV2 {
     }
   }
 
-  function isNetworkLikeError(e: Error): boolean {
-    const code = (e as any).code
-    if (typeof code === "number" && code >= 500 && code < 600) return true
-    const msg = e.message.toLowerCase()
-    return msg.includes("network") || msg.includes("connection lost") || msg.includes("etimedout") || msg.includes("econnrefused") || msg.includes("socket hang up")
-  }
 }

--- a/opencode/packages/opencode/src/tool/browser.ts
+++ b/opencode/packages/opencode/src/tool/browser.ts
@@ -2,7 +2,8 @@ import z from "zod"
 import { Tool } from "./tool"
 import { getBridgeServer } from "../browser/bridge"
 import { Identifier } from "../id/id"
-import type { BrowserTarget } from "browser-mcp-server"
+
+type BrowserTarget = "user" | "bot"
 
 function requireBridge() {
   const bridge = getBridgeServer()

--- a/opencode/packages/opencode/test/preload.ts
+++ b/opencode/packages/opencode/test/preload.ts
@@ -3,13 +3,14 @@
 import os from "os"
 import path from "path"
 import fs from "fs/promises"
-import fsSync from "fs"
 import { afterAll } from "bun:test"
 
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
-afterAll(() => {
-  fsSync.rmSync(dir, { recursive: true, force: true })
+afterAll(async () => {
+  const { Instance } = await import("../src/project/instance")
+  await Instance.disposeAll().catch(() => undefined)
+  await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }).catch(() => undefined)
 })
 // Set test home directory to isolate tests from user's actual home directory
 // This prevents tests from picking up real user configs/skills from ~/.claude/skills
@@ -22,10 +23,18 @@ process.env["XDG_CACHE_HOME"] = path.join(dir, "cache")
 process.env["XDG_CONFIG_HOME"] = path.join(dir, "config")
 process.env["XDG_STATE_HOME"] = path.join(dir, "state")
 
+process.env["OPENCODE_DISABLE_DEFAULT_PLUGINS"] = "true"
+process.env["OPENCODE_DISABLE_OPENCODE_MCP"] = "true"
+process.env["OPENCODE_DISABLE_CLAUDE_CODE_MCP"] = "true"
+process.env["OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER"] = "true"
+process.env["OPENCODE_DISABLE_MODELS_FETCH"] = "true"
+
+await fs.mkdir(path.join(process.env["XDG_CONFIG_HOME"], "opencode", "node_modules"), { recursive: true })
+
 // Write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")
 await fs.mkdir(cacheDir, { recursive: true })
-await fs.writeFile(path.join(cacheDir, "version"), "14")
+await fs.writeFile(path.join(cacheDir, "version"), "19")
 
 // Clear provider env vars to ensure clean test state
 delete process.env["ANTHROPIC_API_KEY"]

--- a/opencode/packages/opencode/test/server/session-list.test.ts
+++ b/opencode/packages/opencode/test/server/session-list.test.ts
@@ -1,39 +1,47 @@
 import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
 import { Log } from "../../src/util/log"
 
-const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
 
 describe("session.list", () => {
   test("filters by directory", async () => {
-    await Instance.provide({
-      directory: projectRoot,
-      fn: async () => {
-        const app = Server.App()
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-session-list-"))
+    const otherDir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-session-list-other-"))
+    try {
+      await Instance.provide({
+        directory: projectRoot,
+        fn: async () => {
+          const app = Server.App()
 
-        const first = await Session.create({})
+          const first = await Session.create({})
 
-        const otherDir = path.join(projectRoot, "..", "__session_list_other")
-        const second = await Instance.provide({
-          directory: otherDir,
-          fn: async () => Session.create({}),
-        })
+          const second = await Instance.provide({
+            directory: otherDir,
+            fn: async () => Session.create({}),
+          })
 
-        const response = await app.request(`/session?directory=${encodeURIComponent(projectRoot)}`)
-        expect(response.status).toBe(200)
+          const response = await app.request(`/session?directory=${encodeURIComponent(projectRoot)}`)
+          expect(response.status).toBe(200)
 
-        const body = (await response.json()) as unknown[]
-        const ids = body
-          .map((s) => (typeof s === "object" && s && "id" in s ? (s as { id: string }).id : undefined))
-          .filter((x): x is string => typeof x === "string")
+          const body = (await response.json()) as unknown[]
+          const ids = body
+            .map((s) => (typeof s === "object" && s && "id" in s ? (s as { id: string }).id : undefined))
+            .filter((x): x is string => typeof x === "string")
 
-        expect(ids).toContain(first.id)
-        expect(ids).not.toContain(second.id)
-      },
-    })
+          expect(ids).toContain(first.id)
+          expect(ids).not.toContain(second.id)
+        },
+      })
+    } finally {
+      await Instance.disposeAll()
+      await fs.rm(projectRoot, { recursive: true, force: true })
+      await fs.rm(otherDir, { recursive: true, force: true })
+    }
   })
 })

--- a/opencode/packages/opencode/test/session/message-v2.test.ts
+++ b/opencode/packages/opencode/test/session/message-v2.test.ts
@@ -51,6 +51,16 @@ const model: Provider.Model = {
   headers: {},
   release_date: "2026-01-01",
 }
+const imageModel: Provider.Model = {
+  ...model,
+  capabilities: {
+    ...model.capabilities,
+    input: {
+      ...model.capabilities.input,
+      image: true,
+    },
+  },
+}
 
 function userInfo(id: string): MessageV2.User {
   return {
@@ -212,7 +222,7 @@ describe("session.message-v2.toModelMessage", () => {
             type: "file",
             mime: "image/png",
             filename: "img.png",
-            url: "https://example.com/img.png",
+            url: "data:image/png;base64,aW1n",
           },
           {
             ...basePart(messageID, "p4"),
@@ -240,11 +250,18 @@ describe("session.message-v2.toModelMessage", () => {
             description: "desc",
             agent: "agent",
           },
+          {
+            ...basePart(messageID, "p8"),
+            type: "file",
+            mime: "image/png",
+            filename: "remote.png",
+            url: "https://example.com/remote.png",
+          },
         ] as MessageV2.Part[],
       },
     ]
 
-    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+    expect(MessageV2.toModelMessages(input, imageModel)).toStrictEqual([
       {
         role: "user",
         content: [
@@ -253,7 +270,7 @@ describe("session.message-v2.toModelMessage", () => {
             type: "file",
             mediaType: "image/png",
             filename: "img.png",
-            data: "https://example.com/img.png",
+            data: "data:image/png;base64,aW1n",
           },
           { type: "text", text: "What did we do so far?" },
           { type: "text", text: "The following tool was executed by the user" },
@@ -314,7 +331,7 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+    expect(MessageV2.toModelMessages(input, imageModel)).toStrictEqual([
       {
         role: "user",
         content: [{ type: "text", text: "run tool" }],
@@ -348,6 +365,90 @@ describe("session.message-v2.toModelMessage", () => {
               ],
             },
             providerOptions: { openai: { tool: "meta" } },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("folds unsupported tool attachments into the tool output text", () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-1"),
+                  type: "file",
+                  mime: "image/png",
+                  filename: "attachment.png",
+                  url: "data:image/png;base64,Zm9v",
+                },
+              ],
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: {
+              type: "content",
+              value: [
+                {
+                  type: "text",
+                  text: "ok\n\n[1 file(s) omitted — current model does not support this input type]",
+                },
+              ],
+            },
           },
         ],
       },


### PR DESCRIPTION
Fix opencode test startup and typecheck blockers by breaking the Project/Bus initialization cycle, isolating test runtime state, and replacing cross-package browser types with local contracts.

Also updates message-v2 tests to cover model attachment capabilities explicitly, including image-capable models preserving media attachments and text-only models folding unsupported attachments into output text.

Validated with:
- bun run --cwd opencode/packages/opencode typecheck
- bun test test/session/session.test.ts test/session/message-v2.test.ts
- bun test test/server/session-list.test.ts test/server/session-select.test.ts