### PR TITLE
fix(opencode): enforce strict session busy rejection

### DIFF
--- a/opencode/packages/opencode/src/server/error.ts
+++ b/opencode/packages/opencode/src/server/error.ts
@@ -29,6 +29,26 @@ export const ERRORS = {
       },
     },
   },
+  409: {
+    description: "Conflict",
+    content: {
+      "application/json": {
+        schema: resolver(
+          z
+            .object({
+              name: z.literal("BusyError"),
+              message: z.string(),
+              data: z.object({
+                sessionID: z.string(),
+              }),
+            })
+            .meta({
+              ref: "BusyError",
+            }),
+        ),
+      },
+    },
+  },
 } as const
 
 export function errors(...codes: number[]) {

--- a/opencode/packages/opencode/src/server/routes/session.ts
+++ b/opencode/packages/opencode/src/server/routes/session.ts
@@ -978,7 +978,7 @@ export const SessionRoutes = lazy(() =>
               },
             },
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1010,7 +1010,7 @@ export const SessionRoutes = lazy(() =>
           204: {
             description: "Prompt accepted",
           },
-          ...errors(400, 404),
+          ...errors(400, 404, 409),
         },
       }),
       validator(
@@ -1021,13 +1021,10 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
-        })
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await SessionPrompt.promptAsync({ ...body, sessionID })
+        return new Response(null, { status: 204 })
       },
     )
     .post(

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -183,24 +183,12 @@ export namespace SessionPrompt {
 
   const state = Instance.state(
     () => {
-      const data: Record<
-        string,
-        {
-          abort: AbortController
-          callbacks: {
-            resolve(input: MessageV2.WithParts): void
-            reject(): void
-          }[]
-        }
-      > = {}
+      const data: Record<string, { abort: AbortController }> = {}
       return data
     },
     async (current) => {
       for (const item of Object.values(current)) {
         item.abort.abort()
-        for (const callback of item.callbacks) {
-          callback.reject()
-        }
       }
     },
   )
@@ -276,35 +264,92 @@ export namespace SessionPrompt {
   })
   export type PromptInput = z.infer<typeof PromptInput>
 
-  export const prompt = fn(PromptInput, async (input) => {
+  function reserve(sessionID: string) {
+    const s = state()
+    if (s[sessionID]) {
+      throw new Session.BusyError(sessionID)
+    }
+    const controller = new AbortController()
+    s[sessionID] = {
+      abort: controller,
+    }
+    SessionStatus.set(sessionID, { type: "busy" })
+    return controller.signal
+  }
+
+  function release(sessionID: string, options?: { abort?: boolean }) {
+    const s = state()
+    const match = s[sessionID]
+    if (!match) return
+    if (options?.abort) {
+      match.abort.abort()
+    }
+    delete s[sessionID]
+    SessionStatus.set(sessionID, { type: "idle" })
+    SessionProcessor.resetDoomLoopCount(sessionID)
+  }
+
+  export const _testing = {
+    reserve,
+    release,
+  }
+
+  async function acceptPrompt(input: PromptInput) {
+    const abort = reserve(input.sessionID)
     const session = await Session.get(input.sessionID)
-    await SessionRevert.cleanup(session)
+    try {
+      await SessionRevert.cleanup(session)
 
-    const message = await createUserMessage(input, session)
-    await Session.touch(input.sessionID)
+      const message = await createUserMessage(input, session)
+      await Session.touch(input.sessionID)
 
-    // this is backwards compatibility for allowing `tools` to be specified when
-    // prompting
-    const permissions: PermissionNext.Ruleset = []
-    for (const [tool, enabled] of Object.entries(input.tools ?? {})) {
-      permissions.push({
-        permission: tool,
-        action: enabled ? "allow" : "deny",
-        pattern: "*",
-      })
+      // this is backwards compatibility for allowing `tools` to be specified when
+      // prompting
+      const permissions: PermissionNext.Ruleset = []
+      for (const [tool, enabled] of Object.entries(input.tools ?? {})) {
+        permissions.push({
+          permission: tool,
+          action: enabled ? "allow" : "deny",
+          pattern: "*",
+        })
+      }
+      if (permissions.length > 0) {
+        session.permission = permissions
+        await Session.update(session.id, (draft) => {
+          draft.permission = permissions
+        })
+      }
+
+      return {
+        abort,
+        message,
+      }
+    } catch (error) {
+      release(input.sessionID)
+      throw error
     }
-    if (permissions.length > 0) {
-      session.permission = permissions
-      await Session.update(session.id, (draft) => {
-        draft.permission = permissions
-      })
-    }
+  }
 
+  export const prompt = fn(PromptInput, async (input) => {
+    const accepted = await acceptPrompt(input)
     if (input.noReply === true) {
-      return message
+      release(input.sessionID)
+      return accepted.message
     }
 
-    return loop(input.sessionID)
+    return loopWithAbort(input.sessionID, accepted.abort)
+  })
+
+  export const promptAsync = fn(PromptInput, async (input) => {
+    const accepted = await acceptPrompt(input)
+    if (input.noReply === true) {
+      release(input.sessionID)
+      return
+    }
+
+    void loopWithAbort(input.sessionID, accepted.abort).catch((error) =>
+      log.error("prompt_async failed", { sessionID: input.sessionID, error }),
+    )
   })
 
   export async function resolvePromptParts(template: string): Promise<PromptInput["parts"]> {
@@ -358,46 +403,17 @@ export namespace SessionPrompt {
     return parts
   }
 
-  function start(sessionID: string) {
-    const s = state()
-    if (s[sessionID]) return
-    const controller = new AbortController()
-    s[sessionID] = {
-      abort: controller,
-      callbacks: [],
-    }
-    return controller.signal
-  }
-
   export function cancel(sessionID: string) {
     log.info("cancel", { sessionID })
-    const s = state()
-    const match = s[sessionID]
-    if (!match) return
-    match.abort.abort()
-    for (const item of match.callbacks) {
-      item.reject()
-    }
-    delete s[sessionID]
-    SessionStatus.set(sessionID, { type: "idle" })
-    // Reset doom loop counter when session ends
-    SessionProcessor.resetDoomLoopCount(sessionID)
-    return
+    release(sessionID, { abort: true })
   }
 
-  export const loop = fn(Identifier.schema("session"), async (sessionID) => {
-    const abort = start(sessionID)
-    if (!abort) {
-      // Directly reject with BusyError instead of waiting indefinitely
-      throw new Session.BusyError(sessionID)
-    }
-
-    using _ = defer(() => cancel(sessionID))
+  async function loopWithAbort(sessionID: string, abort: AbortSignal) {
+    using _ = defer(() => release(sessionID))
 
     let step = 0
     const session = await Session.get(sessionID)
     while (true) {
-      SessionStatus.set(sessionID, { type: "busy" })
       log.info("loop", { step, sessionID })
       if (abort.aborted) break
       let msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
@@ -747,26 +763,6 @@ export namespace SessionPrompt {
       }
 
       const sessionMessages = clone(msgs)
-
-      // Ephemerally wrap queued user messages with a reminder to stay on track
-      if (step > 1 && lastFinished) {
-        for (const msg of sessionMessages) {
-          if (msg.info.role !== "user" || msg.info.id <= lastFinished.id) continue
-          for (const part of msg.parts) {
-            if (part.type !== "text" || part.ignored || part.synthetic) continue
-            if (!part.text.trim()) continue
-            part.text = [
-              "<system-reminder>",
-              "The user sent the following message:",
-              part.text,
-              "",
-              "Please address this message and continue with your tasks.",
-              "</system-reminder>",
-            ].join("\n")
-          }
-        }
-      }
-
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: sessionMessages })
 
       const result = await processor.process({
@@ -807,13 +803,14 @@ export namespace SessionPrompt {
     SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
-      const queued = state()[sessionID]?.callbacks ?? []
-      for (const q of queued) {
-        q.resolve(item)
-      }
       return item
     }
     throw new Error("Impossible")
+  }
+
+  export const loop = fn(Identifier.schema("session"), async (sessionID) => {
+    const abort = reserve(sessionID)
+    return loopWithAbort(sessionID, abort)
   })
 
   async function lastModel(sessionID: string) {
@@ -1405,11 +1402,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   })
   export type ShellInput = z.infer<typeof ShellInput>
   export async function shell(input: ShellInput) {
-    const abort = start(input.sessionID)
-    if (!abort) {
-      throw new Session.BusyError(input.sessionID)
-    }
-    using _ = defer(() => cancel(input.sessionID))
+    const abort = reserve(input.sessionID)
+    using _ = defer(() => release(input.sessionID))
 
     const session = await Session.get(input.sessionID)
     if (session.revert) {

--- a/opencode/packages/opencode/test/server/session-prompt-busy.test.ts
+++ b/opencode/packages/opencode/test/server/session-prompt-busy.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util/log"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session prompt routes busy semantics", () => {
+  test("message endpoint returns 409 without persisting a queued prompt", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const app = Server.App()
+        const session = await Session.create({})
+
+        SessionPrompt._testing.reserve(session.id)
+        const beforeMessages = await Session.messages({ sessionID: session.id })
+
+        const response = await app.request(`/session/${session.id}/message`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            parts: [
+              {
+                type: "text",
+                text: "blocked over http",
+              },
+            ],
+          }),
+        })
+
+        expect(response.status).toBe(409)
+        expect(await response.json()).toEqual({
+          name: "BusyError",
+          message: `Session ${session.id} is busy`,
+          data: {
+            sessionID: session.id,
+          },
+        })
+
+        const afterMessages = await Session.messages({ sessionID: session.id })
+        expect(afterMessages.length).toBe(beforeMessages.length)
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("prompt_async returns 409 without side effects when busy", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const app = Server.App()
+        const session = await Session.create({})
+
+        SessionPrompt._testing.reserve(session.id)
+        const beforeMessages = await Session.messages({ sessionID: session.id })
+
+        const response = await app.request(`/session/${session.id}/prompt_async`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            parts: [
+              {
+                type: "text",
+                text: "blocked async request",
+              },
+            ],
+          }),
+        })
+
+        expect(response.status).toBe(409)
+        expect(await response.json()).toEqual({
+          name: "BusyError",
+          message: `Session ${session.id} is busy`,
+          data: {
+            sessionID: session.id,
+          },
+        })
+
+        const afterMessages = await Session.messages({ sessionID: session.id })
+        expect(afterMessages.length).toBe(beforeMessages.length)
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("prompt_async accepts idle noReply requests and persists the message", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const app = Server.App()
+        const session = await Session.create({})
+
+        const response = await app.request(`/session/${session.id}/prompt_async`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            noReply: true,
+            parts: [
+              {
+                type: "text",
+                text: "accepted async request",
+              },
+            ],
+          }),
+        })
+
+        expect(response.status).toBe(204)
+
+        const messages = await Session.messages({ sessionID: session.id })
+        expect(messages).toHaveLength(1)
+        expect(messages[0]?.info.role).toBe("user")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/opencode/packages/opencode/test/session/busy.test.ts
+++ b/opencode/packages/opencode/test/session/busy.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionStatus } from "../../src/session/status"
+import { Log } from "../../src/util/log"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session.prompt busy semantics", () => {
+  test("marks reserved sessions busy immediately and clears them on cancel", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        SessionPrompt._testing.reserve(session.id)
+        expect(SessionStatus.get(session.id).type).toBe("busy")
+
+        SessionPrompt.cancel(session.id)
+        expect(SessionStatus.get(session.id).type).toBe("idle")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("rejects busy prompts before cleanup or message persistence", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        SessionPrompt._testing.reserve(session.id)
+        await Session.update(session.id, (draft) => {
+          draft.revert = {
+            messageID: "message_busy_marker",
+          }
+        })
+
+        const beforeMessages = await Session.messages({ sessionID: session.id })
+
+        await expect(
+          SessionPrompt.prompt({
+            sessionID: session.id,
+            parts: [
+              {
+                type: "text",
+                text: "blocked while busy",
+              },
+            ],
+          }),
+        ).rejects.toBeInstanceOf(Session.BusyError)
+
+        const afterMessages = await Session.messages({ sessionID: session.id })
+        expect(afterMessages.length).toBe(beforeMessages.length)
+        expect((await Session.get(session.id)).revert?.messageID).toBe("message_busy_marker")
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("rejects busy noReply prompts before persisting a message", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        SessionPrompt._testing.reserve(session.id)
+        const beforeMessages = await Session.messages({ sessionID: session.id })
+
+        await expect(
+          SessionPrompt.prompt({
+            sessionID: session.id,
+            noReply: true,
+            parts: [
+              {
+                type: "text",
+                text: "noReply should still be rejected",
+              },
+            ],
+          }),
+        ).rejects.toBeInstanceOf(Session.BusyError)
+
+        const afterMessages = await Session.messages({ sessionID: session.id })
+        expect(afterMessages.length).toBe(beforeMessages.length)
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("persists idle noReply prompts without leaving the session busy", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const message = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [
+            {
+              type: "text",
+              text: "persist without starting the loop",
+            },
+          ],
+        })
+
+        expect(message.info.role).toBe("user")
+        expect(SessionStatus.get(session.id).type).toBe("idle")
+
+        const messages = await Session.messages({ sessionID: session.id })
+        expect(messages).toHaveLength(1)
+        expect(messages[0]?.info.id).toBe(message.info.id)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/opencode/packages/sdk/js/src/gen/types.gen.ts
+++ b/opencode/packages/sdk/js/src/gen/types.gen.ts
@@ -2635,6 +2635,16 @@ export type SessionPromptResponses = {
     info: AssistantMessage
     parts: Array<Part>
   }
+  /**
+   * Conflict
+   */
+  409: {
+    name: "BusyError"
+    message: string
+    data: {
+      sessionID: string
+    }
+  }
 }
 
 export type SessionPromptResponse = SessionPromptResponses[keyof SessionPromptResponses]
@@ -2727,6 +2737,16 @@ export type SessionPromptAsyncResponses = {
    * Prompt accepted
    */
   204: void
+  /**
+   * Conflict
+   */
+  409: {
+    name: "BusyError"
+    message: string
+    data: {
+      sessionID: string
+    }
+  }
 }
 
 export type SessionPromptAsyncResponse = SessionPromptAsyncResponses[keyof SessionPromptAsyncResponses]

--- a/opencode/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/opencode/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3305,6 +3305,16 @@ export type SessionPromptResponses = {
     info: AssistantMessage
     parts: Array<Part>
   }
+  /**
+   * Conflict
+   */
+  409: {
+    name: "BusyError"
+    message: string
+    data: {
+      sessionID: string
+    }
+  }
 }
 
 export type SessionPromptResponse = SessionPromptResponses[keyof SessionPromptResponses]
@@ -3489,6 +3499,16 @@ export type SessionPromptAsyncResponses = {
    * Prompt accepted
    */
   204: void
+  /**
+   * Conflict
+   */
+  409: {
+    name: "BusyError"
+    message: string
+    data: {
+      sessionID: string
+    }
+  }
 }
 
 export type SessionPromptAsyncResponse = SessionPromptAsyncResponses[keyof SessionPromptAsyncResponses]


### PR DESCRIPTION
Tighten session prompt handling so busy sessions are rejected before cleanup, message persistence, session touch, or permission override side effects can run. Accepted prompts now reserve processing first and publish busy immediately, covering pre-LLM preparation as well as the loop itself.

Remove the remaining implicit queued-message behavior for session prompts. noReply still writes messages when idle, but now goes through the same upfront busy gate; prompt_async now synchronously returns 409 when busy instead of accepting first and failing later in the background.

Update session route/API contracts so both /session/:sessionID/message and /session/:sessionID/prompt_async declare busy 409 responses, and add regression coverage for zero-side-effect busy rejection, early busy status, prompt_async behavior, normal idle prompts, and noReply handling.

Closes #26