### PR TITLE
fix(mcp): remove Feishu preflight coupling

### DIFF
--- a/opencode/packages/opencode/src/mcp/index.ts
+++ b/opencode/packages/opencode/src/mcp/index.ts
@@ -410,14 +410,6 @@ export namespace MCP {
     ]).catch(() => undefined)
   }
 
-  function isFeishuLikeServer(serverName: string, mcp: McpRemote) {
-    return /lark|feishu/i.test(serverName) || /lark|feishu/i.test(mcp.url)
-  }
-
-  function shouldPreflightFeishuIntent(userText: string) {
-    return /飞书|feishu|lark|知识库|文档|wiki|docs|群聊|群|chat|消息/i.test(userText)
-  }
-
   function getPendingSessionByName(mcpName: string) {
     for (const session of pendingOAuthSessions.values()) {
       if (session.mcpName === mcpName) {
@@ -1919,44 +1911,6 @@ export namespace MCP {
   export async function hasStoredTokens(mcpName: string): Promise<boolean> {
     const entry = await McpAuth.get(mcpName)
     return !!entry?.tokens
-  }
-
-  export async function prepareServersForTurn(
-    userText: string,
-    options: { waitForAuthMs?: number } = {},
-  ): Promise<{ authInProgressServers: string[] }> {
-    if (!shouldPreflightFeishuIntent(userText)) {
-      return { authInProgressServers: [] }
-    }
-
-    const cfg = await Config.get()
-    const config = cfg.mcp ?? {}
-    const authInProgressServers: string[] = []
-    const waitForAuthMs = options.waitForAuthMs ?? 120_000
-
-    for (const [serverName, entry] of Object.entries(config)) {
-      if (!isMcpConfigured(entry) || entry.type !== "remote" || entry.oauth === false || entry.enabled === false) {
-        continue
-      }
-
-      if (!isFeishuLikeServer(serverName, entry)) {
-        continue
-      }
-
-      const connected = await ensureServerConnected(serverName, entry, {
-        interactiveAuth: true,
-        waitForAuthMs,
-      })
-
-      if (!connected) {
-        const nextState = await state()
-        if (nextState.status[serverName]?.status === "auth_in_progress") {
-          authInProgressServers.push(serverName)
-        }
-      }
-    }
-
-    return { authInProgressServers }
   }
 
   export type AuthStatus = "authenticated" | "expired" | "not_authenticated"

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -745,7 +745,7 @@ export namespace SessionPrompt {
       const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
       const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
-      const { tools, systemHints } = await resolveTools({
+      const tools = await resolveTools({
         agent,
         session,
         model,
@@ -773,7 +773,6 @@ export namespace SessionPrompt {
         system: [
           ...(await SystemPrompt.environment(model, session.directory)),
           ...(await InstructionPrompt.system()),
-          ...systemHints,
         ],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),
@@ -829,7 +828,6 @@ export namespace SessionPrompt {
     bypassAgentCheck: boolean
     messages: MessageV2.WithParts[]
   }) {
-    const systemHints: string[] = []
     using _ = log.time("resolveTools")
     const tools: Record<string, AITool> = {}
 
@@ -904,26 +902,6 @@ export namespace SessionPrompt {
           return result
         },
       })
-    }
-
-    const lastUserMessage = [...input.messages].reverse().find((message) => message.info.role === "user")
-    const lastUserText = lastUserMessage?.parts
-      .filter((part): part is MessageV2.TextPart => part.type === "text" && !part.ignored)
-      .map((part) => part.text)
-      .join("\n")
-      .trim()
-
-    if (lastUserText) {
-      const preflight = await Instance.provide({
-        directory: input.session.directory,
-        fn: () => MCP.prepareServersForTurn(lastUserText),
-      })
-
-      if (preflight.authInProgressServers.length > 0) {
-        systemHints.push(
-          "Feishu MCP authentication is in progress; do not ask the user to edit JSON or provide clientId manually.",
-        )
-      }
     }
 
     // Get MCP tools within session directory's Instance context
@@ -1024,7 +1002,7 @@ export namespace SessionPrompt {
       tools[key] = item
     }
 
-    return { tools, systemHints }
+    return tools
   }
 
   async function createUserMessage(input: PromptInput, session: Session.Info) {

--- a/opencode/packages/opencode/test/mcp/no-feishu-preflight.test.ts
+++ b/opencode/packages/opencode/test/mcp/no-feishu-preflight.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const packageRoot = path.join(__dirname, "../..")
+
+async function readSource(relativePath: string) {
+  return Bun.file(path.join(packageRoot, relativePath)).text()
+}
+
+describe("mcp turn preflight", () => {
+  test("does not keep Feishu/Lark-specific preflight on the prompt critical path", async () => {
+    const [mcpSource, promptSource] = await Promise.all([
+      readSource("src/mcp/index.ts"),
+      readSource("src/session/prompt.ts"),
+    ])
+
+    expect(mcpSource).not.toContain("prepareServersForTurn")
+    expect(mcpSource).not.toContain("shouldPreflightFeishuIntent")
+    expect(mcpSource).not.toContain("isFeishuLikeServer")
+    expect(promptSource).not.toContain("prepareServersForTurn")
+    expect(promptSource).not.toContain("Feishu MCP authentication is in progress")
+    expect(mcpSource).toContain("export async function tools()")
+  })
+})


### PR DESCRIPTION
Remove the Feishu/Lark-specific MCP preflight path from core MCP resolution.

This deletes the prompt-time keyword detection and turn preflight that eagerly
connected Feishu-like remote MCP servers before the model loop started. MCP tool
discovery, resource access, and auth recovery remain on the generic MCP paths.

Also adds a regression test to ensure Feishu-specific preflight logic is not
reintroduced on the prompt critical path.