### PR TITLE
fix(runtime): disable opencode plugin dependency install

### DIFF
--- a/opencode/packages/opencode/src/config/config.ts
+++ b/opencode/packages/opencode/src/config/config.ts
@@ -159,9 +159,11 @@ export namespace Config {
         }
       }
 
-      const exists = existsSync(path.join(dir, "node_modules"))
-      const installing = installDependencies(dir)
-      if (!exists) await installing
+      if (!Flag.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL) {
+        const exists = existsSync(path.join(dir, "node_modules"))
+        const installing = installDependencies(dir)
+        if (!exists) await installing
+      }
 
       result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
       result.agent = mergeDeep(result.agent, await loadAgent(dir))

--- a/opencode/packages/opencode/src/flag/flag.ts
+++ b/opencode/packages/opencode/src/flag/flag.ts
@@ -28,6 +28,7 @@ export namespace Flag {
   export const OPENCODE_DISABLE_CLAUDE_CODE_MCP =
     OPENCODE_DISABLE_CLAUDE_CODE || truthy("OPENCODE_DISABLE_CLAUDE_CODE_MCP")
   export const OPENCODE_DISABLE_OPENCODE_AUTH = truthy("OPENCODE_DISABLE_OPENCODE_AUTH")
+  export declare const OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL: boolean
   export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
   export declare const OPENCODE_DISABLE_GLOBAL_CONFIG: boolean
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
@@ -112,6 +113,17 @@ Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
 Object.defineProperty(Flag, "OPENCODE_DISABLE_DEFAULT_PLUGINS", {
   get() {
     return truthy("OPENCODE_DISABLE_DEFAULT_PLUGINS")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+// This keeps embedded runtimes from running package manager installs while
+// still allowing them to read compatible opencode config files.
+Object.defineProperty(Flag, "OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", {
+  get() {
+    return truthy("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL")
   },
   enumerable: true,
   configurable: false,

--- a/opencode/packages/opencode/test/config/config.test.ts
+++ b/opencode/packages/opencode/test/config/config.test.ts
@@ -18,6 +18,48 @@ test("loads config with defaults when no files exist", async () => {
   })
 })
 
+test("skips plugin dependency install when disabled", async () => {
+  const originalDisableGlobal = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+  const originalDisableProject = process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+  const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+  const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const configDir = path.join(dir, ".opencode")
+      await fs.mkdir(configDir, { recursive: true })
+      await Bun.write(path.join(configDir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+  const configDir = path.join(tmp.path, ".opencode")
+
+  try {
+    process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "true"
+    process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+    process.env.OPENCODE_CONFIG_DIR = configDir
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+        expect(await Bun.file(path.join(configDir, "package.json")).exists()).toBe(false)
+        expect(await Bun.file(path.join(configDir, "bun.lock")).exists()).toBe(false)
+        expect(await Bun.file(path.join(configDir, "node_modules")).exists()).toBe(false)
+      },
+    })
+  } finally {
+    if (originalDisableGlobal === undefined) delete process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+    else process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = originalDisableGlobal
+    if (originalDisableProject === undefined) delete process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+    else process.env.OPENCODE_DISABLE_PROJECT_CONFIG = originalDisableProject
+    if (originalDisablePluginInstall === undefined) delete process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+    else process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = originalDisablePluginInstall
+    if (originalConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+  }
+})
+
 test("loads JSON config file", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/nine1bot/src/config/loader.test.ts
+++ b/packages/nine1bot/src/config/loader.test.ts
@@ -46,6 +46,9 @@ describe('loadConfig remote MCP oauth support', () => {
         scope: 'read write',
       },
     })
+  })
+})
+
 describe('loadConfig browser migration guards', () => {
   it('rejects deprecated mcp.browser config', async () => {
     const configPath = await writeConfig({

--- a/packages/nine1bot/src/index.ts
+++ b/packages/nine1bot/src/index.ts
@@ -8,6 +8,8 @@ if (!process.env.NINE1BOT_PROJECT_DIR) {
 // 禁用 OpenCode 默认插件（必须在导入 OpenCode 模块之前设置）
 // 这些插件依赖 @openauthjs/openauth，在编译后的二进制中无法正确解析
 process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = 'true'
+// Nine1Bot 使用自己的资源解析链路，不需要 OpenCode 在运行时为插件目录执行 bun add/install
+process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = 'true'
 
 // 全局错误兜底：防止未捕获的 Promise rejection 导致服务崩溃
 process.on("unhandledRejection", (e) => {

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -175,6 +175,7 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
 
   // 设置环境变量
   process.env.OPENCODE_CONFIG = opencodeConfigPath
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = 'true'
 
   // 配置隔离：禁用全局或项目配置
   const isolation = fullConfig.isolation || {}


### PR DESCRIPTION
## Summary
- Add a new `OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL` flag to stop OpenCode from running `bun add`/`bun install` while loading config directories.
- Enable the flag from Nine1Bot startup paths so embedded runtime starts no longer trigger repeated plugin dependency installs.
- Add a regression test covering the disabled-install path, and fix the Nine1Bot config loader test syntax issue.

## Testing
- Added a config regression test for the disabled plugin-install path.
- Ran `bun run --cwd opencode/packages/opencode typecheck` and `bun test packages/nine1bot/src/config/loader.test.ts` successfully.
- Verified `git diff --check` passed.