### PR TITLE
feat: add scheduled automations

### DIFF
--- a/opencode/packages/opencode/src/runtime/controller/protocol.ts
+++ b/opencode/packages/opencode/src/runtime/controller/protocol.ts
@@ -71,7 +71,7 @@ export namespace RuntimeControllerProtocol {
 
   export const Entry = z
     .object({
-      source: z.enum(["web", "feishu", "browser-extension", "api", "webhook"]).optional(),
+      source: z.enum(["web", "feishu", "browser-extension", "api", "webhook", "schedule"]).optional(),
       platform: z.string().optional(),
       mode: z.string().optional(),
       templateIds: z.array(z.string()).optional(),

--- a/opencode/packages/opencode/src/runtime/controller/template-resolver.ts
+++ b/opencode/packages/opencode/src/runtime/controller/template-resolver.ts
@@ -78,6 +78,11 @@ export namespace ControllerTemplateResolver {
     "Do not use markdown in this chat, and do not include code blocks.",
     "If a permission request or follow-up question is rejected, clearly tell the user that they need to continue in the web UI.",
   ].join("\n")
+  const SCHEDULED_ENTRY_CONTEXT = [
+    "This session was created by a Nine1Bot scheduled task.",
+    "There may be no user available to answer follow-up questions during this run.",
+    "Stay within the configured unattended permissions and make the final result easy to inspect later.",
+  ].join("\n")
 
   export async function resolve(input: Input = {}): Promise<Resolved> {
     const requestedTemplateIds = normalizeTemplateIds(input.entry?.templateIds ?? [])
@@ -178,6 +183,7 @@ export namespace ControllerTemplateResolver {
     if (source === "feishu" || platform === "feishu" || mode === "feishu-private-chat") ids.push("feishu-chat")
     if (source === "browser-extension" || mode === "browser-sidepanel") ids.push("browser-generic")
     if (platform === "generic-browser") ids.push("browser-generic")
+    if (source === "schedule" || mode === "scheduled-run") ids.push("scheduled-entry")
     ids.push(...RuntimePlatformAdapterRegistry.inferTemplateIds({ entry: input.entry, page }))
     return ids
   }
@@ -234,6 +240,19 @@ export namespace ControllerTemplateResolver {
             layer: "platform",
             source: "template.browser-generic",
             content: "This session was created from the browser extension side panel. Active page and selection context may be attached when the user sends a message.",
+            lifecycle: "session",
+            visibility: "developer-toggle",
+            priority: 35,
+          }),
+        )
+      }
+      if (templateId === "scheduled-entry") {
+        blocks.push(
+          RuntimeContextPipeline.textBlock({
+            id: "template:scheduled-entry",
+            layer: "business",
+            source: "template.scheduled-entry",
+            content: SCHEDULED_ENTRY_CONTEXT,
             lifecycle: "session",
             visibility: "developer-toggle",
             priority: 35,

--- a/opencode/packages/opencode/src/runtime/protocol/agent-run-spec.ts
+++ b/opencode/packages/opencode/src/runtime/protocol/agent-run-spec.ts
@@ -75,7 +75,7 @@ export type SessionPermissionGrant = {
 }
 
 export type EntrySpec = {
-  source: "web" | "feishu" | "browser-extension" | "api" | "webhook"
+  source: "web" | "feishu" | "browser-extension" | "api" | "webhook" | "schedule"
   platform?: string
   mode?: string
   templateIds: string[]

--- a/opencode/packages/opencode/src/schedule/schedule.ts
+++ b/opencode/packages/opencode/src/schedule/schedule.ts
@@ -1,0 +1,801 @@
+import { PermissionNext } from "@/permission/next"
+import { Project } from "@/project/project"
+import { RuntimeControllerProtocol } from "@/runtime/controller/protocol"
+import { Scheduler } from "@/scheduler"
+import {
+  runAutomatedControllerSession,
+  type AutomatedControllerResponse,
+  type AutomatedControllerRunner,
+} from "@/server/routes/automated-controller"
+import { Storage } from "@/storage/storage"
+import { ulid } from "ulid"
+import z from "zod"
+
+export namespace Schedule {
+  const SCANNER_ID = "schedule.due-scanner"
+  const SCANNER_INTERVAL_MS = 60_000
+  const RUN_MONITOR_TIMEOUT_MS = 30 * 60 * 1000
+  const PROMPT_PREVIEW_LIMIT = 4000
+
+  const taskLocks = new Map<string, Promise<void>>()
+  let scannerStarted = false
+
+  export const ModelChoice = z.object({
+    providerID: z.string(),
+    modelID: z.string(),
+  })
+  export type ModelChoice = z.infer<typeof ModelChoice>
+
+  export const RuntimeProfile = z
+    .object({
+      modelMode: z.enum(["default", "custom"]).default("default"),
+      model: ModelChoice.optional(),
+      resourcesMode: z.enum(["default", "default-plus-selected"]).default("default"),
+      mcpServers: z.array(z.string()).default([]),
+    })
+    .default(() => defaultRuntimeProfile())
+  export type RuntimeProfile = z.infer<typeof RuntimeProfile>
+
+  export const PermissionPolicy = z
+    .object({
+      mode: z.enum(["default", "full"]).default("default"),
+    })
+    .default(() => defaultPermissionPolicy())
+  export type PermissionPolicy = z.infer<typeof PermissionPolicy>
+
+  export const ScheduleRule = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("once-after"),
+      delayMs: z.coerce.number().int().positive(),
+    }),
+    z.object({
+      type: z.literal("daily"),
+      timeOfDay: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/),
+      daysOfWeek: z.array(z.coerce.number().int().min(0).max(6)).optional(),
+    }),
+    z.object({
+      type: z.literal("interval"),
+      every: z.coerce.number().int().positive(),
+      unit: z.enum(["hour", "day"]),
+      anchorAt: z.coerce.number().int().positive().optional(),
+    }),
+  ])
+  export type ScheduleRule = z.infer<typeof ScheduleRule>
+
+  export const OverlapPolicy = z.enum(["skip"])
+  export type OverlapPolicy = z.infer<typeof OverlapPolicy>
+
+  export const MisfirePolicy = z
+    .object({
+      mode: z.literal("skip").default("skip"),
+    })
+    .default(() => defaultMisfirePolicy())
+  export type MisfirePolicy = z.infer<typeof MisfirePolicy>
+
+  export const Task = z.object({
+    id: z.string(),
+    name: z.string(),
+    enabled: z.boolean(),
+    projectID: z.string(),
+    schedule: ScheduleRule,
+    promptTemplate: z.string(),
+    timezone: z.string(),
+    runtimeProfile: RuntimeProfile,
+    permissionPolicy: PermissionPolicy,
+    overlapPolicy: OverlapPolicy,
+    misfirePolicy: MisfirePolicy,
+    nextRunAt: z.number().optional(),
+    lastRunAt: z.number().optional(),
+    deletedAt: z.number().optional(),
+    time: z.object({
+      created: z.number(),
+      updated: z.number(),
+    }),
+  })
+  export type Task = z.infer<typeof Task>
+
+  export const RunStatus = z.enum(["scheduled", "accepted", "running", "succeeded", "failed", "skipped"])
+  export type RunStatus = z.infer<typeof RunStatus>
+
+  export const RunReason = z.enum(["disabled", "overlap", "misfire", "manual", "due"])
+  export type RunReason = z.infer<typeof RunReason>
+
+  export const Run = z.object({
+    id: z.string(),
+    taskID: z.string(),
+    projectID: z.string(),
+    sessionID: z.string().optional(),
+    turnSnapshotId: z.string().optional(),
+    status: RunStatus,
+    reason: RunReason.optional(),
+    scheduledAt: z.number(),
+    triggeredAt: z.number().optional(),
+    promptPreview: z.string().optional(),
+    responseBody: z.unknown().optional(),
+    error: z.string().optional(),
+    time: z.object({
+      created: z.number(),
+      started: z.number().optional(),
+      finished: z.number().optional(),
+    }),
+  })
+  export type Run = z.infer<typeof Run>
+
+  export const TaskCreate = z.object({
+    name: z.string().trim().min(1),
+    enabled: z.boolean().optional(),
+    projectID: z.string(),
+    schedule: ScheduleRule,
+    promptTemplate: z.string().optional(),
+    timezone: z.string().optional(),
+    runtimeProfile: RuntimeProfile.optional(),
+    permissionPolicy: PermissionPolicy.optional(),
+    overlapPolicy: OverlapPolicy.optional(),
+    misfirePolicy: MisfirePolicy.optional(),
+  })
+  export type TaskCreate = z.infer<typeof TaskCreate>
+
+  export const TaskUpdate = z.object({
+    name: z.string().trim().min(1).optional(),
+    enabled: z.boolean().optional(),
+    projectID: z.string().optional(),
+    schedule: ScheduleRule.optional(),
+    promptTemplate: z.string().optional(),
+    timezone: z.string().optional(),
+    runtimeProfile: RuntimeProfile.optional(),
+    permissionPolicy: PermissionPolicy.optional(),
+    overlapPolicy: OverlapPolicy.optional(),
+    misfirePolicy: MisfirePolicy.optional(),
+  })
+  export type TaskUpdate = z.infer<typeof TaskUpdate>
+
+  const FULL_PERMISSION_RULES: PermissionNext.Ruleset = [
+    {
+      permission: "*",
+      pattern: "*",
+      action: "allow",
+    },
+  ]
+
+  const SCHEDULED_CLIENT_CAPABILITIES = {
+    interactions: false,
+    permissionRequests: false,
+    questionRequests: false,
+    artifacts: false,
+    filePreview: false,
+    resourceFailures: true,
+    continueInWeb: true,
+  } satisfies RuntimeControllerProtocol.ClientCapabilities
+
+  const SCHEDULED_ENTRY_BASE = {
+    source: "schedule",
+    platform: "nine1bot-scheduler",
+    mode: "scheduled-run",
+    templateIds: ["default-user-template", "scheduled-entry"],
+  } satisfies RuntimeControllerProtocol.Entry
+
+  export function init() {
+    if (scannerStarted) return
+    scannerStarted = true
+    void skipMissedRuns().finally(() => {
+      Scheduler.register({
+        id: SCANNER_ID,
+        interval: SCANNER_INTERVAL_MS,
+        scope: "global",
+        run: async () => {
+          await runDueTasks()
+        },
+      })
+    })
+  }
+
+  export function stopScanner() {
+    Scheduler.unregister(SCANNER_ID, "global")
+    scannerStarted = false
+  }
+
+  export function defaultPromptTemplate() {
+    return [
+      "Scheduled task {{task.name}} triggered an automated Nine1Bot run.",
+      "",
+      "Project: {{project.name}}",
+      "Scheduled at: {{schedule.scheduledAt}}",
+      "Triggered at: {{schedule.triggeredAt}}",
+      "",
+      "Please execute the configured recurring task using the project context and stay within the configured permissions.",
+    ].join("\n")
+  }
+
+  export function defaultRuntimeProfile(): RuntimeProfile {
+    return {
+      modelMode: "default",
+      resourcesMode: "default",
+      mcpServers: [],
+    }
+  }
+
+  export function defaultPermissionPolicy(): PermissionPolicy {
+    return {
+      mode: "default",
+    }
+  }
+
+  export function defaultMisfirePolicy(): MisfirePolicy {
+    return {
+      mode: "skip",
+    }
+  }
+
+  export function defaultTimezone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+  }
+
+  export async function createTask(input: TaskCreate, now = Date.now()) {
+    await Project.get(input.projectID)
+    const timezone = validateTimezone(input.timezone || defaultTimezone())
+    const schedule = normalizeSchedule(input.schedule, now)
+    const task: Task = {
+      id: `task_${ulid().toLowerCase()}`,
+      name: input.name,
+      enabled: input.enabled ?? true,
+      projectID: input.projectID,
+      schedule,
+      promptTemplate: input.promptTemplate ?? defaultPromptTemplate(),
+      timezone,
+      runtimeProfile: RuntimeProfile.parse(input.runtimeProfile),
+      permissionPolicy: PermissionPolicy.parse(input.permissionPolicy),
+      overlapPolicy: input.overlapPolicy ?? "skip",
+      misfirePolicy: MisfirePolicy.parse(input.misfirePolicy),
+      nextRunAt: input.enabled === false ? undefined : initialNextRunAt(schedule, now, timezone),
+      time: {
+        created: now,
+        updated: now,
+      },
+    }
+    await Storage.write(["scheduled_task", task.id], task)
+    return Task.parse(task)
+  }
+
+  export async function updateTask(taskID: string, input: TaskUpdate, now = Date.now()) {
+    if (input.projectID) {
+      await Project.get(input.projectID)
+    }
+    const updated = await Storage.update<Task>(["scheduled_task", taskID], (draft) => {
+      Object.assign(draft, Task.parse(draft))
+      if (draft.deletedAt) return
+      const scheduleChanged = input.schedule !== undefined
+      const timezoneChanged = input.timezone !== undefined
+      if (input.name !== undefined) draft.name = input.name
+      if (input.enabled !== undefined) draft.enabled = input.enabled
+      if (input.projectID !== undefined) draft.projectID = input.projectID
+      if (input.schedule !== undefined) draft.schedule = normalizeSchedule(input.schedule, now)
+      if (input.promptTemplate !== undefined) draft.promptTemplate = input.promptTemplate
+      if (input.timezone !== undefined) draft.timezone = validateTimezone(input.timezone)
+      if (input.runtimeProfile !== undefined) {
+        draft.runtimeProfile = RuntimeProfile.parse({
+          ...draft.runtimeProfile,
+          ...input.runtimeProfile,
+        })
+      }
+      if (input.permissionPolicy !== undefined) {
+        draft.permissionPolicy = PermissionPolicy.parse({
+          ...draft.permissionPolicy,
+          ...input.permissionPolicy,
+        })
+      }
+      if (input.overlapPolicy !== undefined) draft.overlapPolicy = input.overlapPolicy
+      if (input.misfirePolicy !== undefined) draft.misfirePolicy = MisfirePolicy.parse(input.misfirePolicy)
+      if (!draft.enabled) {
+        draft.nextRunAt = undefined
+      } else if (scheduleChanged || timezoneChanged || input.enabled === true || !draft.nextRunAt) {
+        draft.nextRunAt = initialNextRunAt(draft.schedule, now, draft.timezone)
+      }
+      draft.time.updated = now
+    })
+    return Task.parse(updated)
+  }
+
+  export async function deleteTask(taskID: string) {
+    const deleted = await Storage.update<Task>(["scheduled_task", taskID], (draft) => {
+      Object.assign(draft, Task.parse(draft))
+      draft.enabled = false
+      draft.nextRunAt = undefined
+      draft.deletedAt = Date.now()
+      draft.time.updated = Date.now()
+    })
+    return Task.parse(deleted)
+  }
+
+  export async function getTask(taskID: string) {
+    return Task.parse(await Storage.read<Task>(["scheduled_task", taskID]))
+  }
+
+  export async function listTasks() {
+    const tasks: Task[] = []
+    for (const key of await Storage.list(["scheduled_task"])) {
+      const task = await Storage.read<Task>(key).catch(() => undefined)
+      if (!task || task.deletedAt) continue
+      tasks.push(Task.parse(task))
+    }
+    tasks.sort((a, b) => b.time.updated - a.time.updated)
+    return tasks
+  }
+
+  export async function createRun(input: {
+    taskID: string
+    projectID: string
+    status?: RunStatus
+    reason?: RunReason
+    scheduledAt: number
+    triggeredAt?: number
+    promptPreview?: string
+    responseBody?: unknown
+    error?: string
+  }) {
+    const run: Run = {
+      id: `run_${ulid().toLowerCase()}`,
+      taskID: input.taskID,
+      projectID: input.projectID,
+      status: input.status ?? "scheduled",
+      reason: input.reason,
+      scheduledAt: input.scheduledAt,
+      triggeredAt: input.triggeredAt,
+      promptPreview: input.promptPreview,
+      responseBody: summarize(input.responseBody),
+      error: input.error,
+      time: {
+        created: Date.now(),
+      },
+    }
+    await Storage.write(["scheduled_run", run.id], run)
+    return run
+  }
+
+  export async function updateRun(runID: string, input: Partial<Omit<Run, "id" | "time">> & {
+    time?: Partial<Run["time"]>
+  }) {
+    return Storage.update<Run>(["scheduled_run", runID], (draft) => {
+      const { time, ...rest } = input
+      Object.assign(draft, {
+        ...rest,
+        ...(rest.responseBody !== undefined ? { responseBody: summarize(rest.responseBody) } : {}),
+      })
+      if (time) {
+        draft.time = {
+          ...draft.time,
+          ...time,
+        }
+      }
+    })
+  }
+
+  export async function listRuns(input: { taskID?: string; limit?: number } = {}) {
+    const runs: Run[] = []
+    for (const key of await Storage.list(["scheduled_run"])) {
+      const run = await Storage.read<Run>(key).catch(() => undefined)
+      if (!run) continue
+      const parsed = Run.parse(run)
+      if (input.taskID && parsed.taskID !== input.taskID) continue
+      runs.push(parsed)
+    }
+    runs.sort((a, b) => b.time.created - a.time.created)
+    return runs.slice(0, input.limit ?? 100)
+  }
+
+  export async function runTaskNow(taskID: string, input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
+    const now = input.now ?? Date.now()
+    return withTaskLock(taskID, async () => {
+      const task = await getTask(taskID)
+      if (task.deletedAt) throw new Storage.NotFoundError({ message: `Scheduled task not found: ${taskID}` })
+      if (!task.enabled) {
+        return createRun({
+          taskID: task.id,
+          projectID: task.projectID,
+          status: "skipped",
+          reason: "disabled",
+          scheduledAt: now,
+          triggeredAt: now,
+          error: "Scheduled task is disabled.",
+        })
+      }
+      return triggerTaskRun(task, {
+        reason: "manual",
+        scheduledAt: now,
+        triggeredAt: now,
+        runner: input.runner,
+      })
+    })
+  }
+
+  export async function runDueTasks(input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
+    const now = input.now ?? Date.now()
+    const tasks = await listTasks()
+    const runs: Run[] = []
+    for (const task of tasks) {
+      if (!task.enabled || !task.nextRunAt || task.nextRunAt > now) continue
+      const run = await withTaskLock(task.id, async () => {
+        const current = await getTask(task.id).catch(() => undefined)
+        if (!current || current.deletedAt || !current.enabled || !current.nextRunAt || current.nextRunAt > now) {
+          return undefined
+        }
+        if (await hasActiveRun(current.id)) {
+          const skipped = await createRun({
+            taskID: current.id,
+            projectID: current.projectID,
+            status: "skipped",
+            reason: "overlap",
+            scheduledAt: current.nextRunAt,
+            triggeredAt: now,
+            error: "Previous scheduled run is still active.",
+          })
+          await advanceTaskAfterDue(current, current.nextRunAt, now)
+          return skipped
+        }
+        const run = await triggerTaskRun(current, {
+          reason: "due",
+          scheduledAt: current.nextRunAt,
+          triggeredAt: now,
+          runner: input.runner,
+        })
+        await advanceTaskAfterDue(current, current.nextRunAt, now)
+        return run
+      })
+      if (run) runs.push(run)
+    }
+    return runs
+  }
+
+  export async function skipMissedRuns(now = Date.now()) {
+    const tasks = await listTasks()
+    const runs: Run[] = []
+    for (const task of tasks) {
+      if (!task.enabled || !task.nextRunAt || task.nextRunAt > now) continue
+      const run = await withTaskLock(task.id, async () => {
+        const current = await getTask(task.id).catch(() => undefined)
+        if (!current || current.deletedAt || !current.enabled || !current.nextRunAt || current.nextRunAt > now) {
+          return undefined
+        }
+        const skipped = await createRun({
+          taskID: current.id,
+          projectID: current.projectID,
+          status: "skipped",
+          reason: "misfire",
+          scheduledAt: current.nextRunAt,
+          triggeredAt: now,
+          error: "Missed scheduled run skipped on startup.",
+        })
+        await advanceTaskAfterDue(current, current.nextRunAt, now)
+        return skipped
+      })
+      if (run) runs.push(run)
+    }
+    return runs
+  }
+
+  export function initialNextRunAt(rule: ScheduleRule, now = Date.now(), timezone = defaultTimezone()) {
+    if (rule.type === "once-after") return now + rule.delayMs
+    return nextRunAfter(rule, now, timezone)
+  }
+
+  export function nextRunAfter(rule: ScheduleRule, after: number, timezone = defaultTimezone()): number | undefined {
+    if (rule.type === "once-after") return undefined
+    if (rule.type === "interval") return nextIntervalRunAt(rule, after)
+    return nextDailyRunAt(rule, after, validateTimezone(timezone))
+  }
+
+  export function renderPrompt(task: Task, project: Project.Info, input: {
+    scheduledAt: number
+    triggeredAt: number
+  }) {
+    return renderTemplate(task.promptTemplate, renderContext(task, project, input))
+  }
+
+  function normalizeSchedule(rule: ScheduleRule, now: number): ScheduleRule {
+    if (rule.type !== "interval" || rule.anchorAt) return rule
+    return {
+      ...rule,
+      anchorAt: now,
+    }
+  }
+
+  function sessionChoiceForTask(task: Task): RuntimeControllerProtocol.SessionChoice {
+    const choice: NonNullable<RuntimeControllerProtocol.SessionChoice> = {}
+    if (task.runtimeProfile.modelMode === "custom" && task.runtimeProfile.model) {
+      choice.model = task.runtimeProfile.model
+    }
+    const mcpServers = task.runtimeProfile.resourcesMode === "default-plus-selected"
+      ? task.runtimeProfile.mcpServers.filter((server) => server.trim().length > 0)
+      : []
+    if (mcpServers.length > 0) {
+      choice.resources = {
+        mcp: {
+          servers: mcpServers,
+        },
+      }
+    }
+    return Object.keys(choice).length > 0 ? choice : undefined
+  }
+
+  function permissionForTask(task: Task) {
+    return task.permissionPolicy.mode === "full" ? FULL_PERMISSION_RULES : undefined
+  }
+
+  async function triggerTaskRun(task: Task, input: {
+    reason: RunReason
+    scheduledAt: number
+    triggeredAt: number
+    runner?: AutomatedControllerRunner
+  }) {
+    const project = await Project.get(task.projectID)
+    const directory = project.rootDirectory || project.worktree
+    const renderedPrompt = renderPrompt(task, project, {
+      scheduledAt: input.scheduledAt,
+      triggeredAt: input.triggeredAt,
+    })
+    const run = await createRun({
+      taskID: task.id,
+      projectID: task.projectID,
+      status: "accepted",
+      reason: input.reason,
+      scheduledAt: input.scheduledAt,
+      triggeredAt: input.triggeredAt,
+      promptPreview: promptPreview(renderedPrompt),
+    })
+    const entry = {
+      ...SCHEDULED_ENTRY_BASE,
+      traceId: run.id,
+    } satisfies RuntimeControllerProtocol.Entry
+    const runner = input.runner ?? runAutomatedControllerSession
+
+    try {
+      await runner({
+        directory,
+        title: `Scheduled: ${task.name}`,
+        permission: permissionForTask(task),
+        sessionChoice: sessionChoiceForTask(task),
+        entry,
+        clientCapabilities: SCHEDULED_CLIENT_CAPABILITIES,
+        parts: [{ type: "text", text: renderedPrompt }],
+        timeoutMs: RUN_MONITOR_TIMEOUT_MS,
+        timeoutMessage: "Scheduled run monitor timed out.",
+        interactionPolicy: {
+          permission: task.permissionPolicy.mode === "full" ? "allow-session" : "deny",
+          question: "deny",
+          permissionAllowMessage: "Scheduled run uses the full permission policy, so permission requests are allowed for this session.",
+          permissionDenyMessage: "Scheduled runs use the default non-interactive permission policy, so permission requests are denied.",
+          questionDenyMessage: "Question request denied automatically in scheduled run.",
+        },
+        async onControllerResponse(response) {
+          await updateRun(run.id, {
+            sessionID: response.sessionID,
+            turnSnapshotId: response.turnSnapshotId,
+            status: response.accepted ? "running" : "failed",
+            responseBody: responseForRun(run.id, response),
+            time: { started: Date.now() },
+            ...(response.accepted ? {} : { error: "controller_message_not_accepted" }),
+          })
+        },
+        async onFinished(result) {
+          await updateRun(run.id, {
+            status: result.status,
+            ...(result.error ? { error: result.error } : {}),
+            time: { finished: Date.now() },
+          }).catch(() => undefined)
+        },
+        async onInteraction(interaction) {
+          if (!interaction.error) return
+          await updateRun(run.id, {
+            error: interaction.error,
+          }).catch(() => undefined)
+        },
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await updateRun(run.id, {
+        status: "failed",
+        error: message,
+        responseBody: {
+          accepted: false,
+          runId: run.id,
+          error: message,
+        },
+        time: { finished: Date.now() },
+      }).catch(() => undefined)
+    }
+
+    return Run.parse(await Storage.read<Run>(["scheduled_run", run.id]))
+  }
+
+  async function advanceTaskAfterDue(task: Task, scheduledAt: number, now: number) {
+    await Storage.update<Task>(["scheduled_task", task.id], (draft) => {
+      Object.assign(draft, Task.parse(draft))
+      draft.lastRunAt = now
+      draft.nextRunAt = nextRunAfter(draft.schedule, Math.max(now, scheduledAt), draft.timezone)
+      draft.time.updated = now
+    })
+  }
+
+  async function hasActiveRun(taskID: string) {
+    for (const run of await listRuns({ taskID, limit: 500 })) {
+      if (run.status === "accepted" || run.status === "running" || run.status === "scheduled") return true
+    }
+    return false
+  }
+
+  async function withTaskLock<T>(taskID: string, fn: () => Promise<T>) {
+    const previous = taskLocks.get(taskID) ?? Promise.resolve()
+    let release!: () => void
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const tail = previous.catch(() => undefined).then(() => current)
+    taskLocks.set(taskID, tail)
+    await previous.catch(() => undefined)
+    try {
+      return await fn()
+    } finally {
+      release()
+      if (taskLocks.get(taskID) === tail) {
+        taskLocks.delete(taskID)
+      }
+    }
+  }
+
+  function responseForRun(runID: string, response: AutomatedControllerResponse) {
+    return {
+      accepted: response.accepted,
+      runId: runID,
+      sessionId: response.sessionID,
+      turnSnapshotId: response.turnSnapshotId,
+      ...(response.accepted ? {} : { error: "controller_message_not_accepted" }),
+    }
+  }
+
+  function promptPreview(prompt: string) {
+    return prompt.length > PROMPT_PREVIEW_LIMIT ? `${prompt.slice(0, PROMPT_PREVIEW_LIMIT)}...` : prompt
+  }
+
+  function nextIntervalRunAt(rule: Extract<ScheduleRule, { type: "interval" }>, after: number) {
+    const anchor = rule.anchorAt ?? after
+    const intervalMs = rule.every * (rule.unit === "hour" ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000)
+    if (anchor > after) return anchor
+    const elapsed = after - anchor
+    return anchor + (Math.floor(elapsed / intervalMs) + 1) * intervalMs
+  }
+
+  function nextDailyRunAt(rule: Extract<ScheduleRule, { type: "daily" }>, after: number, timezone: string) {
+    const [hour, minute] = rule.timeOfDay.split(":").map((part) => Number(part))
+    if (hour > 23 || minute > 59) throw new Error(`Invalid timeOfDay: ${rule.timeOfDay}`)
+    const now = zonedParts(after, timezone)
+    for (let offset = 0; offset <= 8; offset++) {
+      const localDate = new Date(Date.UTC(now.year, now.month - 1, now.day + offset, hour, minute, 0, 0))
+      const localYear = localDate.getUTCFullYear()
+      const localMonth = localDate.getUTCMonth() + 1
+      const localDay = localDate.getUTCDate()
+      const localWeekday = new Date(Date.UTC(localYear, localMonth - 1, localDay)).getUTCDay()
+      if (rule.daysOfWeek?.length && !rule.daysOfWeek.includes(localWeekday)) continue
+      const candidate = zonedDateTimeToUtc({
+        year: localYear,
+        month: localMonth,
+        day: localDay,
+        hour,
+        minute,
+        second: 0,
+      }, timezone)
+      if (candidate > after) return candidate
+    }
+    return undefined
+  }
+
+  function validateTimezone(timezone: string) {
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: timezone }).format(new Date())
+      return timezone
+    } catch {
+      throw new Error(`Invalid timezone: ${timezone}`)
+    }
+  }
+
+  function zonedParts(timestamp: number, timezone: string) {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(timestamp))
+    const values = Object.fromEntries(parts.map((part) => [part.type, part.value]))
+    return {
+      year: Number(values.year),
+      month: Number(values.month),
+      day: Number(values.day),
+      hour: Number(values.hour),
+      minute: Number(values.minute),
+      second: Number(values.second),
+    }
+  }
+
+  function zonedDateTimeToUtc(input: {
+    year: number
+    month: number
+    day: number
+    hour: number
+    minute: number
+    second: number
+  }, timezone: string) {
+    const utc = Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, input.second, 0)
+    const first = utc - timezoneOffset(utc, timezone)
+    const second = utc - timezoneOffset(first, timezone)
+    return second
+  }
+
+  function timezoneOffset(timestamp: number, timezone: string) {
+    const parts = zonedParts(timestamp, timezone)
+    const asUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, 0)
+    return asUtc - Math.floor(timestamp / 1000) * 1000
+  }
+
+  function renderContext(task: Task, project: Project.Info, input: {
+    scheduledAt: number
+    triggeredAt: number
+  }) {
+    return {
+      task: {
+        id: task.id,
+        name: task.name,
+      },
+      project: {
+        id: project.id,
+        name: project.name || project.rootDirectory || project.worktree || project.id,
+        rootDirectory: project.rootDirectory,
+        worktree: project.worktree,
+      },
+      schedule: {
+        timezone: task.timezone,
+        scheduledAt: new Date(input.scheduledAt).toISOString(),
+        triggeredAt: new Date(input.triggeredAt).toISOString(),
+        previousRunAt: task.lastRunAt ? new Date(task.lastRunAt).toISOString() : undefined,
+      },
+    }
+  }
+
+  function renderTemplate(template: string, context: Record<string, any>) {
+    return template.replace(/{{\s*([a-zA-Z0-9_.-]+)\s*}}/g, (_match, expression) => {
+      return stringifyTemplateValue(readPath(context, expression))
+    })
+  }
+
+  function readPath(value: unknown, path: string): unknown {
+    let current = value
+    for (const segment of path.split(".")) {
+      if (!segment) return undefined
+      if (typeof current !== "object" || current === null) return undefined
+      current = (current as Record<string, unknown>)[segment]
+    }
+    return current
+  }
+
+  function stringifyTemplateValue(value: unknown) {
+    if (value === undefined || value === null) return ""
+    if (typeof value === "string") return value
+    if (typeof value === "number" || typeof value === "boolean") return String(value)
+    return JSON.stringify(value, null, 2)
+  }
+
+  function summarize(value: unknown, depth = 0): unknown {
+    if (depth > 4) return "[truncated]"
+    if (typeof value === "string") {
+      return value.length > 1000 ? `${value.slice(0, 1000)}...` : value
+    }
+    if (typeof value !== "object" || value === null) return value
+    if (Array.isArray(value)) return value.slice(0, 20).map((item) => summarize(item, depth + 1))
+    const result: Record<string, unknown> = {}
+    for (const [key, item] of Object.entries(value).slice(0, 50)) {
+      result[key] = summarize(item, depth + 1)
+    }
+    return result
+  }
+}

--- a/opencode/packages/opencode/src/schedule/schedule.ts
+++ b/opencode/packages/opencode/src/schedule/schedule.ts
@@ -8,7 +8,7 @@ import {
   type AutomatedControllerRunner,
 } from "@/server/routes/automated-controller"
 import { Storage } from "@/storage/storage"
-import { ulid } from "ulid"
+import { monotonicFactory, ulid } from "ulid"
 import z from "zod"
 
 export namespace Schedule {
@@ -16,8 +16,10 @@ export namespace Schedule {
   const SCANNER_INTERVAL_MS = 60_000
   const RUN_MONITOR_TIMEOUT_MS = 30 * 60 * 1000
   const PROMPT_PREVIEW_LIMIT = 4000
+  const DEFAULT_RUN_LIST_LIMIT = 100
 
   const taskLocks = new Map<string, Promise<void>>()
+  const runUlid = monotonicFactory()
   let scannerStarted = false
   let automatedControllerRunnerOverride: AutomatedControllerRunner | undefined
 
@@ -354,7 +356,7 @@ export namespace Schedule {
     error?: string
   }) {
     const run: Run = {
-      id: `run_${ulid().toLowerCase()}`,
+      id: `run_${runUlid().toLowerCase()}`,
       taskID: input.taskID,
       projectID: input.projectID,
       status: input.status ?? "scheduled",
@@ -369,13 +371,14 @@ export namespace Schedule {
       },
     }
     await Storage.write(["scheduled_run", run.id], run)
+    await writeRunIndexes(run)
     return run
   }
 
   export async function updateRun(runID: string, input: Partial<Omit<Run, "id" | "time">> & {
     time?: Partial<Run["time"]>
   }) {
-    return Storage.update<Run>(["scheduled_run", runID], (draft) => {
+    const updated = await Storage.update<Run>(["scheduled_run", runID], (draft) => {
       const { time, ...rest } = input
       Object.assign(draft, {
         ...rest,
@@ -388,20 +391,27 @@ export namespace Schedule {
         }
       }
     })
+    const parsed = Run.parse(updated)
+    await writeRunIndexes(parsed)
+    return parsed
   }
 
   export async function listRuns(input: { taskID?: string; limit?: number; offset?: number } = {}) {
-    const runs: Run[] = []
-    for (const key of await Storage.list(["scheduled_run"])) {
-      const run = await Storage.read<Run>(key).catch(() => undefined)
-      if (!run) continue
-      const parsed = Run.parse(run)
-      if (input.taskID && parsed.taskID !== input.taskID) continue
-      runs.push(parsed)
+    const paging = normalizeRunPaging(input)
+    if (input.taskID) {
+      const keys = (await Storage.list(["scheduled_run_by_task", input.taskID])).reverse()
+      if (keys.length > 0) {
+        return listRunsFromKeys(keys, {
+          ...paging,
+          taskID: input.taskID,
+          indexed: true,
+        })
+      }
     }
-    runs.sort((a, b) => b.time.created - a.time.created)
-    const offset = input.offset ?? 0
-    return runs.slice(offset, offset + (input.limit ?? 100))
+    return listRunsFromKeys((await Storage.list(["scheduled_run"])).reverse(), {
+      ...paging,
+      taskID: input.taskID,
+    })
   }
 
   export async function runTaskNow(taskID: string, input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
@@ -642,8 +652,21 @@ export namespace Schedule {
   }
 
   async function hasActiveRun(taskID: string) {
-    for (const run of await listRuns({ taskID, limit: 500 })) {
-      if (run.status === "accepted" || run.status === "running" || run.status === "scheduled") return true
+    const keys = (await Storage.list(["scheduled_run_active", taskID])).reverse()
+    for (const key of keys) {
+      const run = await readRunFromKey(key, { indexed: true })
+      if (!run || run.taskID !== taskID || !isActiveRunStatus(run.status)) {
+        await Storage.remove(key).catch(() => undefined)
+        continue
+      }
+      return true
+    }
+
+    for (const run of await listRuns({ taskID, limit: 100 })) {
+      if (isActiveRunStatus(run.status)) {
+        await writeRunIndexes(run).catch(() => undefined)
+        return true
+      }
     }
     return false
   }
@@ -689,6 +712,56 @@ export namespace Schedule {
 
   function promptPreview(prompt: string) {
     return prompt.length > PROMPT_PREVIEW_LIMIT ? `${prompt.slice(0, PROMPT_PREVIEW_LIMIT)}...` : prompt
+  }
+
+  function normalizeRunPaging(input: { limit?: number; offset?: number }) {
+    return {
+      limit: Math.max(0, input.limit ?? DEFAULT_RUN_LIST_LIMIT),
+      offset: Math.max(0, input.offset ?? 0),
+    }
+  }
+
+  async function listRunsFromKeys(keys: string[][], input: {
+    taskID?: string
+    limit: number
+    offset: number
+    indexed?: boolean
+  }) {
+    if (input.limit === 0) return []
+    const runs: Run[] = []
+    let matched = 0
+    for (const key of keys) {
+      const run = await readRunFromKey(key, { indexed: input.indexed })
+      if (!run) continue
+      if (input.taskID && run.taskID !== input.taskID) continue
+      if (matched++ < input.offset) continue
+      runs.push(run)
+      if (runs.length >= input.limit) break
+    }
+    return runs
+  }
+
+  async function readRunFromKey(key: string[], input: { indexed?: boolean } = {}) {
+    const runID = key[key.length - 1]
+    if (!runID) return undefined
+    const run = await Storage.read<Run>(["scheduled_run", runID]).catch(async () => {
+      if (input.indexed) await Storage.remove(key).catch(() => undefined)
+      return undefined
+    })
+    return run ? Run.parse(run) : undefined
+  }
+
+  async function writeRunIndexes(run: Run) {
+    await Storage.write(["scheduled_run_by_task", run.taskID, run.id], { id: run.id })
+    if (isActiveRunStatus(run.status)) {
+      await Storage.write(["scheduled_run_active", run.taskID, run.id], { id: run.id })
+    } else {
+      await Storage.remove(["scheduled_run_active", run.taskID, run.id]).catch(() => undefined)
+    }
+  }
+
+  function isActiveRunStatus(status: RunStatus) {
+    return status === "scheduled" || status === "accepted" || status === "running"
   }
 
   function nextIntervalRunAt(rule: Extract<ScheduleRule, { type: "interval" }>, after: number) {

--- a/opencode/packages/opencode/src/schedule/schedule.ts
+++ b/opencode/packages/opencode/src/schedule/schedule.ts
@@ -19,6 +19,7 @@ export namespace Schedule {
 
   const taskLocks = new Map<string, Promise<void>>()
   let scannerStarted = false
+  let automatedControllerRunnerOverride: AutomatedControllerRunner | undefined
 
   export const ModelChoice = z.object({
     providerID: z.string(),
@@ -121,6 +122,15 @@ export namespace Schedule {
   })
   export type Run = z.infer<typeof Run>
 
+  export const RunResponse = z.object({
+    accepted: z.boolean(),
+    run: Run,
+    sessionId: z.string().optional(),
+    turnSnapshotId: z.string().optional(),
+    error: z.string().optional(),
+  })
+  export type RunResponse = z.infer<typeof RunResponse>
+
   export const TaskCreate = z.object({
     name: z.string().trim().min(1),
     enabled: z.boolean().optional(),
@@ -192,6 +202,15 @@ export namespace Schedule {
   export function stopScanner() {
     Scheduler.unregister(SCANNER_ID, "global")
     scannerStarted = false
+  }
+
+  export const _testing = {
+    setAutomatedControllerRunner(runner?: AutomatedControllerRunner) {
+      automatedControllerRunnerOverride = runner
+    },
+    resetAutomatedControllerRunner() {
+      automatedControllerRunnerOverride = undefined
+    },
   }
 
   export function defaultPromptTemplate() {
@@ -307,7 +326,9 @@ export namespace Schedule {
   }
 
   export async function getTask(taskID: string) {
-    return Task.parse(await Storage.read<Task>(["scheduled_task", taskID]))
+    const task = Task.parse(await Storage.read<Task>(["scheduled_task", taskID]))
+    if (task.deletedAt) throw new Storage.NotFoundError({ message: `Scheduled task not found: ${taskID}` })
+    return task
   }
 
   export async function listTasks() {
@@ -369,7 +390,7 @@ export namespace Schedule {
     })
   }
 
-  export async function listRuns(input: { taskID?: string; limit?: number } = {}) {
+  export async function listRuns(input: { taskID?: string; limit?: number; offset?: number } = {}) {
     const runs: Run[] = []
     for (const key of await Storage.list(["scheduled_run"])) {
       const run = await Storage.read<Run>(key).catch(() => undefined)
@@ -379,7 +400,8 @@ export namespace Schedule {
       runs.push(parsed)
     }
     runs.sort((a, b) => b.time.created - a.time.created)
-    return runs.slice(0, input.limit ?? 100)
+    const offset = input.offset ?? 0
+    return runs.slice(offset, offset + (input.limit ?? 100))
   }
 
   export async function runTaskNow(taskID: string, input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
@@ -402,9 +424,13 @@ export namespace Schedule {
         reason: "manual",
         scheduledAt: now,
         triggeredAt: now,
-        runner: input.runner,
+        runner: input.runner ?? automatedControllerRunnerOverride,
       })
     })
+  }
+
+  export async function runTaskNowResponse(taskID: string, input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
+    return runResponse(await runTaskNow(taskID, input))
   }
 
   export async function runDueTasks(input: { now?: number; runner?: AutomatedControllerRunner } = {}) {
@@ -435,7 +461,7 @@ export namespace Schedule {
           reason: "due",
           scheduledAt: current.nextRunAt,
           triggeredAt: now,
-          runner: input.runner,
+          runner: input.runner ?? automatedControllerRunnerOverride,
         })
         await advanceTaskAfterDue(current, current.nextRunAt, now)
         return run
@@ -545,7 +571,7 @@ export namespace Schedule {
       ...SCHEDULED_ENTRY_BASE,
       traceId: run.id,
     } satisfies RuntimeControllerProtocol.Entry
-    const runner = input.runner ?? runAutomatedControllerSession
+    const runner = input.runner ?? automatedControllerRunnerOverride ?? runAutomatedControllerSession
 
     try {
       await runner({
@@ -649,6 +675,16 @@ export namespace Schedule {
       turnSnapshotId: response.turnSnapshotId,
       ...(response.accepted ? {} : { error: "controller_message_not_accepted" }),
     }
+  }
+
+  function runResponse(run: Run): RunResponse {
+    return RunResponse.parse({
+      accepted: run.status !== "failed" && run.status !== "skipped",
+      run,
+      sessionId: run.sessionID,
+      turnSnapshotId: run.turnSnapshotId,
+      error: run.error,
+    })
   }
 
   function promptPreview(prompt: string) {

--- a/opencode/packages/opencode/src/schedule/schedule.ts
+++ b/opencode/packages/opencode/src/schedule/schedule.ts
@@ -283,7 +283,7 @@ export namespace Schedule {
     }
     const updated = await Storage.update<Task>(["scheduled_task", taskID], (draft) => {
       Object.assign(draft, Task.parse(draft))
-      if (draft.deletedAt) return
+      if (draft.deletedAt) throw taskNotFound(taskID)
       const scheduleChanged = input.schedule !== undefined
       const timezoneChanged = input.timezone !== undefined
       if (input.name !== undefined) draft.name = input.name
@@ -319,6 +319,7 @@ export namespace Schedule {
   export async function deleteTask(taskID: string) {
     const deleted = await Storage.update<Task>(["scheduled_task", taskID], (draft) => {
       Object.assign(draft, Task.parse(draft))
+      if (draft.deletedAt) throw taskNotFound(taskID)
       draft.enabled = false
       draft.nextRunAt = undefined
       draft.deletedAt = Date.now()
@@ -329,7 +330,7 @@ export namespace Schedule {
 
   export async function getTask(taskID: string) {
     const task = Task.parse(await Storage.read<Task>(["scheduled_task", taskID]))
-    if (task.deletedAt) throw new Storage.NotFoundError({ message: `Scheduled task not found: ${taskID}` })
+    if (task.deletedAt) throw taskNotFound(taskID)
     return task
   }
 
@@ -762,6 +763,10 @@ export namespace Schedule {
 
   function isActiveRunStatus(status: RunStatus) {
     return status === "scheduled" || status === "accepted" || status === "running"
+  }
+
+  function taskNotFound(taskID: string) {
+    return new Storage.NotFoundError({ message: `Scheduled task not found: ${taskID}` })
   }
 
   function nextIntervalRunAt(rule: Extract<ScheduleRule, { type: "interval" }>, after: number) {

--- a/opencode/packages/opencode/src/schedule/schedule.ts
+++ b/opencode/packages/opencode/src/schedule/schedule.ts
@@ -849,7 +849,8 @@ export namespace Schedule {
   function timezoneOffset(timestamp: number, timezone: string) {
     const parts = zonedParts(timestamp, timezone)
     const asUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second, 0)
-    return asUtc - Math.floor(timestamp / 1000) * 1000
+    const milliseconds = timestamp - Math.floor(timestamp / 1000) * 1000
+    return asUtc + milliseconds - timestamp
   }
 
   function renderContext(task: Task, project: Project.Info, input: {

--- a/opencode/packages/opencode/src/server/routes/automated-controller.ts
+++ b/opencode/packages/opencode/src/server/routes/automated-controller.ts
@@ -1,0 +1,193 @@
+import { Bus } from "@/bus"
+import type { PermissionNext } from "@/permission/next"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { Instance } from "@/project/instance"
+import type { RuntimeControllerProtocol } from "@/runtime/controller/protocol"
+import {
+  answerInteraction,
+  createControllerSession,
+  sendControllerMessage,
+} from "./nine1bot-agent"
+
+export type AutomatedRunStatus = "succeeded" | "failed"
+
+export type AutomatedInteractionPolicy = {
+  permission: "deny" | "allow-session"
+  question: "deny"
+  permissionAllowMessage: string
+  permissionDenyMessage: string
+  questionDenyMessage: string
+}
+
+export type AutomatedControllerResponse = {
+  accepted: boolean
+  sessionID: string
+  turnSnapshotId?: string
+  status: number
+  response: RuntimeControllerProtocol.MessageSendResponse
+}
+
+export type AutomatedControllerInput = {
+  title: string
+  directory: string
+  permission?: PermissionNext.Ruleset
+  sessionChoice?: RuntimeControllerProtocol.SessionChoice
+  entry: RuntimeControllerProtocol.Entry
+  clientCapabilities: RuntimeControllerProtocol.ClientCapabilities
+  parts: RuntimeControllerProtocol.MessageSendRequest["parts"]
+  interactionPolicy: AutomatedInteractionPolicy
+  timeoutMs: number
+  timeoutMessage?: string
+  onControllerResponse?: (response: AutomatedControllerResponse) => Promise<void>
+  onFinished?: (result: { status: AutomatedRunStatus; error?: string }) => Promise<void>
+  onInteraction?: (interaction: {
+    kind: "permission" | "question"
+    requestID: string
+    action: "allow-session" | "deny"
+    error?: string
+  }) => Promise<void>
+}
+
+export type AutomatedControllerRunner = typeof runAutomatedControllerSession
+
+export async function runAutomatedControllerSession(input: AutomatedControllerInput): Promise<AutomatedControllerResponse> {
+  return Instance.provide({
+    directory: input.directory,
+    init: InstanceBootstrap,
+    async fn() {
+      const sessionResponse = await createControllerSession({
+        directory: input.directory,
+        title: input.title,
+        permission: input.permission,
+        sessionChoice: input.sessionChoice,
+        entry: input.entry,
+        clientCapabilities: input.clientCapabilities,
+      })
+      const messageResponse = await sendControllerMessage(sessionResponse.sessionId, {
+        parts: input.parts,
+        entry: input.entry,
+        clientCapabilities: input.clientCapabilities,
+      })
+      const response = {
+        accepted: messageResponse.response.accepted,
+        sessionID: sessionResponse.sessionId,
+        turnSnapshotId: messageResponse.response.turnSnapshotId,
+        status: messageResponse.status,
+        response: messageResponse.response,
+      } satisfies AutomatedControllerResponse
+
+      await input.onControllerResponse?.(response)
+
+      if (!response.accepted) {
+        await input.onFinished?.({
+          status: "failed",
+          error: "controller_message_not_accepted",
+        })
+        return response
+      }
+
+      startAutomatedRunMonitor({
+        sessionID: sessionResponse.sessionId,
+        timeoutMs: input.timeoutMs,
+        timeoutMessage: input.timeoutMessage,
+        interactionPolicy: input.interactionPolicy,
+        onFinished: input.onFinished,
+        onInteraction: input.onInteraction,
+      })
+
+      return response
+    },
+  })
+}
+
+export function startAutomatedRunMonitor(input: {
+  sessionID: string
+  timeoutMs: number
+  timeoutMessage?: string
+  interactionPolicy: AutomatedInteractionPolicy
+  onFinished?: (result: { status: AutomatedRunStatus; error?: string }) => Promise<void>
+  onInteraction?: AutomatedControllerInput["onInteraction"]
+}) {
+  let finished = false
+  let unsubscribe: (() => void) | undefined
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  const finish = async (status: AutomatedRunStatus, error?: string) => {
+    if (finished) return
+    finished = true
+    if (timeout) clearTimeout(timeout)
+    unsubscribe?.()
+    await input.onFinished?.({ status, error }).catch(() => undefined)
+  }
+
+  unsubscribe = Bus.subscribeAll(async (event) => {
+    const properties = event.properties as Record<string, any> | undefined
+    const eventSessionID = properties?.sessionID || properties?.info?.id
+    if (eventSessionID !== input.sessionID) return
+
+    if (event.type === "permission.asked") {
+      const allow = input.interactionPolicy.permission === "allow-session"
+      const action = allow ? "allow-session" : "deny"
+      const error = allow
+        ? undefined
+        : `Permission request denied automatically: ${String(properties?.permission || "unknown")}`
+      await answerInteraction(String(properties?.id || ""), {
+        kind: "permission",
+        answer: action,
+        message: allow
+          ? input.interactionPolicy.permissionAllowMessage
+          : input.interactionPolicy.permissionDenyMessage,
+      }).catch(() => undefined)
+      await input.onInteraction?.({
+        kind: "permission",
+        requestID: String(properties?.id || ""),
+        action,
+        error,
+      }).catch(() => undefined)
+      return
+    }
+
+    if (event.type === "question.asked") {
+      await answerInteraction(String(properties?.id || ""), {
+        kind: "question",
+        answer: "deny",
+      }).catch(() => undefined)
+      await input.onInteraction?.({
+        kind: "question",
+        requestID: String(properties?.id || ""),
+        action: "deny",
+        error: input.interactionPolicy.questionDenyMessage,
+      }).catch(() => undefined)
+      return
+    }
+
+    if (event.type === "session.idle") {
+      await finish("succeeded")
+      return
+    }
+
+    if (event.type === "session.error") {
+      await finish("failed", formatSessionError(properties?.error))
+    }
+  })
+
+  timeout = setTimeout(() => {
+    finish("failed", input.timeoutMessage ?? "Automated run monitor timed out.").catch(() => undefined)
+  }, input.timeoutMs)
+  timeout.unref?.()
+
+  return {
+    stop() {
+      if (timeout) clearTimeout(timeout)
+      unsubscribe?.()
+      finished = true
+    },
+  }
+}
+
+function formatSessionError(error: unknown) {
+  if (!error) return "Session failed"
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return JSON.stringify(error)
+}

--- a/opencode/packages/opencode/src/server/routes/schedules.ts
+++ b/opencode/packages/opencode/src/server/routes/schedules.ts
@@ -45,29 +45,110 @@ export const ScheduleRoutes = lazy(() =>
       validator("json", Schedule.TaskCreate),
       async (c) => c.json(await Schedule.createTask(c.req.valid("json"))),
     )
+    .get(
+      "/tasks/:taskID",
+      describeRoute({
+        summary: "Get scheduled task",
+        operationId: "schedules.tasks.get",
+        responses: {
+          200: {
+            description: "Scheduled task",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Task),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      validator("param", z.object({ taskID: z.string() })),
+      async (c) => c.json(await Schedule.getTask(c.req.valid("param").taskID)),
+    )
     .patch(
       "/tasks/:taskID",
+      describeRoute({
+        summary: "Update scheduled task",
+        operationId: "schedules.tasks.update",
+        responses: {
+          200: {
+            description: "Updated scheduled task",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Task),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
       validator("param", z.object({ taskID: z.string() })),
       validator("json", Schedule.TaskUpdate),
       async (c) => c.json(await Schedule.updateTask(c.req.valid("param").taskID, c.req.valid("json"))),
     )
     .delete(
       "/tasks/:taskID",
+      describeRoute({
+        summary: "Delete scheduled task",
+        operationId: "schedules.tasks.delete",
+        responses: {
+          200: {
+            description: "Deleted scheduled task",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Task),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
       validator("param", z.object({ taskID: z.string() })),
       async (c) => c.json(await Schedule.deleteTask(c.req.valid("param").taskID)),
     )
     .post(
       "/tasks/:taskID/run",
+      describeRoute({
+        summary: "Run scheduled task now",
+        operationId: "schedules.tasks.run",
+        responses: {
+          200: {
+            description: "Accepted or skipped scheduled task run",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.RunResponse),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
       validator("param", z.object({ taskID: z.string() })),
-      async (c) => c.json(await Schedule.runTaskNow(c.req.valid("param").taskID)),
+      async (c) => c.json(await Schedule.runTaskNowResponse(c.req.valid("param").taskID)),
     )
     .get(
       "/runs",
+      describeRoute({
+        summary: "List scheduled task runs",
+        operationId: "schedules.runs.list",
+        responses: {
+          200: {
+            description: "Scheduled runs",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Run.array()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
       validator(
         "query",
         z.object({
           taskID: z.string().optional(),
-          limit: z.coerce.number().min(1).max(500).optional(),
+          limit: z.coerce.number().int().min(1).max(500).optional(),
+          offset: z.coerce.number().int().min(0).optional(),
         }),
       ),
       async (c) => c.json(await Schedule.listRuns(c.req.valid("query"))),

--- a/opencode/packages/opencode/src/server/routes/schedules.ts
+++ b/opencode/packages/opencode/src/server/routes/schedules.ts
@@ -1,0 +1,75 @@
+import { Schedule } from "@/schedule/schedule"
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { lazy } from "../../util/lazy"
+import { errors } from "../error"
+
+export const ScheduleRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/tasks",
+      describeRoute({
+        summary: "List scheduled tasks",
+        operationId: "schedules.tasks.list",
+        responses: {
+          200: {
+            description: "Scheduled tasks",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Task.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => c.json(await Schedule.listTasks()),
+    )
+    .post(
+      "/tasks",
+      describeRoute({
+        summary: "Create scheduled task",
+        operationId: "schedules.tasks.create",
+        responses: {
+          200: {
+            description: "Created scheduled task",
+            content: {
+              "application/json": {
+                schema: resolver(Schedule.Task),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("json", Schedule.TaskCreate),
+      async (c) => c.json(await Schedule.createTask(c.req.valid("json"))),
+    )
+    .patch(
+      "/tasks/:taskID",
+      validator("param", z.object({ taskID: z.string() })),
+      validator("json", Schedule.TaskUpdate),
+      async (c) => c.json(await Schedule.updateTask(c.req.valid("param").taskID, c.req.valid("json"))),
+    )
+    .delete(
+      "/tasks/:taskID",
+      validator("param", z.object({ taskID: z.string() })),
+      async (c) => c.json(await Schedule.deleteTask(c.req.valid("param").taskID)),
+    )
+    .post(
+      "/tasks/:taskID/run",
+      validator("param", z.object({ taskID: z.string() })),
+      async (c) => c.json(await Schedule.runTaskNow(c.req.valid("param").taskID)),
+    )
+    .get(
+      "/runs",
+      validator(
+        "query",
+        z.object({
+          taskID: z.string().optional(),
+          limit: z.coerce.number().min(1).max(500).optional(),
+        }),
+      ),
+      async (c) => c.json(await Schedule.listRuns(c.req.valid("query"))),
+    ),
+)

--- a/opencode/packages/opencode/src/server/routes/webhooks.ts
+++ b/opencode/packages/opencode/src/server/routes/webhooks.ts
@@ -1,7 +1,4 @@
-import { Bus } from "@/bus"
 import { PermissionNext } from "@/permission/next"
-import { InstanceBootstrap } from "@/project/bootstrap"
-import { Instance } from "@/project/instance"
 import { Project } from "@/project/project"
 import { RuntimeControllerProtocol } from "@/runtime/controller/protocol"
 import { Webhook } from "@/webhook/webhook"
@@ -10,11 +7,7 @@ import { describeRoute, resolver, validator } from "hono-openapi"
 import z from "zod"
 import { lazy } from "../../util/lazy"
 import { errors } from "../error"
-import {
-  answerInteraction,
-  createControllerSession,
-  sendControllerMessage,
-} from "./nine1bot-agent"
+import { runAutomatedControllerSession, type AutomatedControllerResponse } from "./automated-controller"
 
 const WEBHOOK_CLIENT_CAPABILITIES = {
   interactions: false,
@@ -81,6 +74,16 @@ function permissionForSource(source: Webhook.Source) {
   return source.permissionPolicy.mode === "full" ? FULL_PERMISSION_RULES : undefined
 }
 
+function responseForRun(runID: string, response: AutomatedControllerResponse): Webhook.TriggerResponse {
+  return {
+    accepted: response.accepted,
+    runId: runID,
+    sessionId: response.sessionID,
+    turnSnapshotId: response.turnSnapshotId,
+    ...(response.accepted ? {} : { error: "controller_message_not_accepted" }),
+  }
+}
+
 async function createRejectedRun(c: any, input: {
   sourceID: string
   projectID: string
@@ -116,71 +119,6 @@ async function createRejectedRun(c: any, input: {
     } satisfies Webhook.TriggerResponse,
     input.httpStatus,
   )
-}
-
-function startRunMonitor(runID: string, sessionID: string, permissionMode: Webhook.PermissionPolicy["mode"]) {
-  let finished = false
-  let unsubscribe: (() => void) | undefined
-  let timeout: ReturnType<typeof setTimeout> | undefined
-
-  const finish = async (status: "succeeded" | "failed", error?: string) => {
-    if (finished) return
-    finished = true
-    if (timeout) clearTimeout(timeout)
-    unsubscribe?.()
-    await Webhook.updateRun(runID, {
-      status,
-      ...(error ? { error } : {}),
-      time: { finished: Date.now() },
-    }).catch(() => undefined)
-  }
-
-  unsubscribe = Bus.subscribeAll(async (event) => {
-    const properties = event.properties as Record<string, any> | undefined
-    const eventSessionID = properties?.sessionID || properties?.info?.id
-    if (eventSessionID !== sessionID) return
-
-    if (event.type === "permission.asked") {
-      const allowFull = permissionMode === "full"
-      await answerInteraction(String(properties?.id || ""), {
-        kind: "permission",
-        answer: allowFull ? "allow-session" : "deny",
-        message: allowFull
-          ? "Webhook run uses the full permission policy, so permission requests are allowed for this session."
-          : "Webhook runs use the default non-interactive permission policy, so permission requests are denied.",
-      }).catch(() => undefined)
-      if (!allowFull) {
-        await Webhook.updateRun(runID, {
-          error: `Permission request denied automatically: ${String(properties?.permission || "unknown")}`,
-        }).catch(() => undefined)
-      }
-      return
-    }
-
-    if (event.type === "question.asked") {
-      await answerInteraction(String(properties?.id || ""), {
-        kind: "question",
-        answer: "deny",
-      }).catch(() => undefined)
-      await Webhook.updateRun(runID, {
-        error: "Question request denied automatically in webhook run.",
-      }).catch(() => undefined)
-      return
-    }
-
-    if (event.type === "session.idle") {
-      await finish("succeeded")
-      return
-    }
-
-    if (event.type === "session.error") {
-      await finish("failed", JSON.stringify(properties?.error || "Session failed"))
-    }
-  })
-
-  timeout = setTimeout(() => {
-    finish("failed", "Webhook run monitor timed out.").catch(() => undefined)
-  }, RUN_MONITOR_TIMEOUT_MS)
 }
 
 async function triggerWebhook(c: any) {
@@ -330,60 +268,54 @@ async function triggerWebhook(c: any) {
 
     try {
       const directory = projectDirectory(project)
-      const created = await Instance.provide({
+      const created = await runAutomatedControllerSession({
         directory,
-        init: InstanceBootstrap,
-        async fn() {
-          const sessionResponse = await createControllerSession({
-            directory,
-            title: `Webhook: ${source.name}`,
-            permission: permissionForSource(source),
-            sessionChoice: sessionChoiceForSource(source),
-            entry,
-            clientCapabilities: WEBHOOK_CLIENT_CAPABILITIES,
+        title: `Webhook: ${source.name}`,
+        permission: permissionForSource(source),
+        sessionChoice: sessionChoiceForSource(source),
+        entry,
+        clientCapabilities: WEBHOOK_CLIENT_CAPABILITIES,
+        parts: [{ type: "text", text: renderedPrompt }],
+        timeoutMs: RUN_MONITOR_TIMEOUT_MS,
+        timeoutMessage: "Webhook run monitor timed out.",
+        interactionPolicy: {
+          permission: source.permissionPolicy.mode === "full" ? "allow-session" : "deny",
+          question: "deny",
+          permissionAllowMessage: "Webhook run uses the full permission policy, so permission requests are allowed for this session.",
+          permissionDenyMessage: "Webhook runs use the default non-interactive permission policy, so permission requests are denied.",
+          questionDenyMessage: "Question request denied automatically in webhook run.",
+        },
+        async onControllerResponse(response) {
+          const responseBody = responseForRun(run.id, response)
+          await Webhook.updateRun(run.id, {
+            sessionID: response.sessionID,
+            turnSnapshotId: response.turnSnapshotId,
+            status: response.accepted ? "running" : "failed",
+            httpStatus: response.status,
+            responseBody,
+            time: { started: Date.now() },
+            ...(response.accepted ? {} : { error: "controller_message_not_accepted" }),
           })
-          const messageResponse = await sendControllerMessage(sessionResponse.sessionId, {
-            parts: [{ type: "text", text: renderedPrompt }],
-            entry,
-            clientCapabilities: WEBHOOK_CLIENT_CAPABILITIES,
-          })
-          return {
-            sessionResponse,
-            messageResponse,
+          if (response.accepted) {
+            await Webhook.markCooldown(source, run.id)
           }
+        },
+        async onFinished(result) {
+          await Webhook.updateRun(run.id, {
+            status: result.status,
+            ...(result.error ? { error: result.error } : {}),
+            time: { finished: Date.now() },
+          }).catch(() => undefined)
+        },
+        async onInteraction(interaction) {
+          if (!interaction.error) return
+          await Webhook.updateRun(run.id, {
+            error: interaction.error,
+          }).catch(() => undefined)
         },
       })
 
-      const responseBody = {
-        accepted: created.messageResponse.response.accepted,
-        runId: run.id,
-        sessionId: created.sessionResponse.sessionId,
-        turnSnapshotId: created.messageResponse.response.turnSnapshotId,
-        ...(created.messageResponse.response.accepted ? {} : { error: "controller_message_not_accepted" }),
-      } satisfies Webhook.TriggerResponse
-
-      await Webhook.updateRun(run.id, {
-        sessionID: created.sessionResponse.sessionId,
-        turnSnapshotId: created.messageResponse.response.turnSnapshotId,
-        status: created.messageResponse.response.accepted ? "running" : "failed",
-        httpStatus: created.messageResponse.status,
-        responseBody,
-        time: { started: Date.now() },
-        ...(created.messageResponse.response.accepted ? {} : { error: "controller_message_not_accepted" }),
-      })
-
-      if (created.messageResponse.response.accepted) {
-        await Webhook.markCooldown(source, run.id)
-        await Instance.provide({
-          directory,
-          init: InstanceBootstrap,
-          fn() {
-            startRunMonitor(run.id, created.sessionResponse.sessionId, source.permissionPolicy.mode)
-          },
-        })
-      }
-
-      return c.json(responseBody, created.messageResponse.status as never)
+      return c.json(responseForRun(run.id, created), created.status as never)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       const responseBody = {

--- a/opencode/packages/opencode/src/server/server.ts
+++ b/opencode/packages/opencode/src/server/server.ts
@@ -46,8 +46,10 @@ import { PreferencesRoutes } from "./routes/preferences"
 import { AgentTerminalRoutes } from "./routes/agent-terminal"
 import { BrowserRoutes } from "./routes/browser"
 import { Nine1BotAgentRoutes } from "./routes/nine1bot-agent"
+import { ScheduleRoutes } from "./routes/schedules"
 import { WebhookPublicRoutes, WebhookRoutes } from "./routes/webhooks"
 import { MDNS } from "./mdns"
+import { Schedule } from "@/schedule/schedule"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -212,6 +214,7 @@ export namespace Server {
         .use(validator("query", z.object({ directory: z.string().optional() })))
         .route("/nine1bot", Nine1BotAgentRoutes())
         .route("/webhooks", WebhookRoutes())
+        .route("/schedules", ScheduleRoutes())
         .route("/project", ProjectRoutes())
         .route("/pty", PtyRoutes())
         .route("/browser", BrowserRoutes())
@@ -738,6 +741,7 @@ export namespace Server {
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
     _url = server.url
+    Schedule.init()
 
     const shouldPublishMDNS =
       opts.mdns &&
@@ -753,6 +757,7 @@ export namespace Server {
 
     const originalStop = server.stop.bind(server)
     server.stop = async (closeActiveConnections?: boolean) => {
+      Schedule.stopScanner()
       if (shouldPublishMDNS) MDNS.unpublish()
       return originalStop(closeActiveConnections)
     }

--- a/opencode/packages/opencode/test/schedule/schedule.test.ts
+++ b/opencode/packages/opencode/test/schedule/schedule.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { RuntimeControllerProtocol } from "../../src/runtime/controller/protocol"
+import { Schedule } from "../../src/schedule/schedule"
+import type { AutomatedControllerRunner } from "../../src/server/routes/automated-controller"
+import { Storage } from "../../src/storage/storage"
+import { tmpdir } from "../fixture/fixture"
+
+const acceptedRunner: AutomatedControllerRunner = async (input) => {
+  const response = {
+    accepted: true,
+    sessionID: "ses_test_scheduled",
+    turnSnapshotId: "turn_test_scheduled",
+    status: 202,
+    response: {
+      version: RuntimeControllerProtocol.VERSION,
+      accepted: true,
+      sessionId: "ses_test_scheduled",
+      turnSnapshotId: "turn_test_scheduled",
+    },
+  }
+  await input.onControllerResponse?.(response)
+  await input.onFinished?.({ status: "succeeded" })
+  return response
+}
+
+async function cleanup(taskIDs: string[], projectID?: string) {
+  for (const taskID of taskIDs) {
+    for (const run of await Schedule.listRuns({ taskID, limit: 500 }).catch(() => [])) {
+      await Storage.remove(["scheduled_run", run.id]).catch(() => undefined)
+    }
+    await Storage.remove(["scheduled_task", taskID]).catch(() => undefined)
+  }
+  if (projectID) {
+    await Storage.remove(["project", projectID]).catch(() => undefined)
+    await Storage.remove(["project_meta", projectID]).catch(() => undefined)
+  }
+  await Instance.disposeAll().catch(() => undefined)
+}
+
+describe("scheduled task time calculation", () => {
+  test("computes once-after, daily, and interval next run times", () => {
+    const now = Date.parse("2026-01-01T00:00:00.000Z")
+
+    expect(Schedule.initialNextRunAt({ type: "once-after", delayMs: 2 * 60 * 60 * 1000 }, now, "UTC")).toBe(
+      Date.parse("2026-01-01T02:00:00.000Z"),
+    )
+    expect(Schedule.initialNextRunAt({ type: "daily", timeOfDay: "00:05" }, now, "UTC")).toBe(
+      Date.parse("2026-01-01T00:05:00.000Z"),
+    )
+    expect(Schedule.nextRunAfter({ type: "interval", every: 6, unit: "hour", anchorAt: now }, now, "UTC")).toBe(
+      Date.parse("2026-01-01T06:00:00.000Z"),
+    )
+  })
+
+  test("supports explicit timezone for daily schedules", () => {
+    const now = Date.parse("2026-01-01T00:00:00.000Z")
+
+    expect(Schedule.initialNextRunAt({ type: "daily", timeOfDay: "09:30" }, now, "Asia/Shanghai")).toBe(
+      Date.parse("2026-01-01T01:30:00.000Z"),
+    )
+  })
+
+  test("does not accept cron schedules in v1", () => {
+    const parsed = Schedule.TaskCreate.safeParse({
+      name: "Cron task",
+      projectID: "project_test",
+      schedule: {
+        type: "cron",
+        expression: "0 9 * * *",
+      },
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+})
+
+describe("scheduled task storage and run behavior", () => {
+  test("manual run records controller response and success", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          const task = await Schedule.createTask({
+            name: "Manual test",
+            projectID,
+            schedule: { type: "once-after", delayMs: 60_000 },
+            timezone: "UTC",
+            promptTemplate: "Run {{task.name}} for {{project.name}}",
+          }, 1000)
+          taskIDs.push(task.id)
+
+          const run = await Schedule.runTaskNow(task.id, {
+            now: 2000,
+            runner: acceptedRunner,
+          })
+
+          expect(run.status).toBe("succeeded")
+          expect(run.reason).toBe("manual")
+          expect(run.sessionID).toBe("ses_test_scheduled")
+          expect(run.turnSnapshotId).toBe("turn_test_scheduled")
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+
+  test("skips due task when previous run is active and advances one-shot schedule", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          const task = await Schedule.createTask({
+            name: "Overlap test",
+            projectID,
+            schedule: { type: "once-after", delayMs: 1000 },
+            timezone: "UTC",
+          }, 1000)
+          taskIDs.push(task.id)
+          await Schedule.createRun({
+            taskID: task.id,
+            projectID,
+            status: "running",
+            reason: "due",
+            scheduledAt: 2000,
+          })
+
+          const runs = await Schedule.runDueTasks({
+            now: 3000,
+            runner: acceptedRunner,
+          })
+          const updated = await Schedule.getTask(task.id)
+
+          expect(runs).toHaveLength(1)
+          expect(runs[0].status).toBe("skipped")
+          expect(runs[0].reason).toBe("overlap")
+          expect(updated.nextRunAt).toBeUndefined()
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+
+  test("skips missed startup runs and advances the schedule", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          const task = await Schedule.createTask({
+            name: "Misfire test",
+            projectID,
+            schedule: { type: "once-after", delayMs: 1000 },
+            timezone: "UTC",
+          }, 1000)
+          taskIDs.push(task.id)
+
+          const runs = await Schedule.skipMissedRuns(3000)
+          const updated = await Schedule.getTask(task.id)
+
+          expect(runs).toHaveLength(1)
+          expect(runs[0].status).toBe("skipped")
+          expect(runs[0].reason).toBe("misfire")
+          expect(updated.nextRunAt).toBeUndefined()
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+})

--- a/opencode/packages/opencode/test/schedule/schedule.test.ts
+++ b/opencode/packages/opencode/test/schedule/schedule.test.ts
@@ -28,6 +28,8 @@ async function cleanup(taskIDs: string[], projectID?: string) {
   for (const taskID of taskIDs) {
     for (const run of await Schedule.listRuns({ taskID, limit: 500 }).catch(() => [])) {
       await Storage.remove(["scheduled_run", run.id]).catch(() => undefined)
+      await Storage.remove(["scheduled_run_by_task", taskID, run.id]).catch(() => undefined)
+      await Storage.remove(["scheduled_run_active", taskID, run.id]).catch(() => undefined)
     }
     await Storage.remove(["scheduled_task", taskID]).catch(() => undefined)
   }
@@ -178,6 +180,53 @@ describe("scheduled task storage and run behavior", () => {
           expect(runs[0].status).toBe("skipped")
           expect(runs[0].reason).toBe("misfire")
           expect(updated.nextRunAt).toBeUndefined()
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+
+  test("lists scheduled runs through the per-task index with pagination", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          const task = await Schedule.createTask({
+            name: "Run index test",
+            projectID,
+            schedule: { type: "once-after", delayMs: 1000 },
+            timezone: "UTC",
+          }, 1000)
+          taskIDs.push(task.id)
+
+          const first = await Schedule.createRun({
+            taskID: task.id,
+            projectID,
+            status: "succeeded",
+            reason: "manual",
+            scheduledAt: 1000,
+          })
+          const second = await Schedule.createRun({
+            taskID: task.id,
+            projectID,
+            status: "succeeded",
+            reason: "manual",
+            scheduledAt: 2000,
+          })
+
+          const newest = await Schedule.listRuns({ taskID: task.id, limit: 1 })
+          const next = await Schedule.listRuns({ taskID: task.id, limit: 1, offset: 1 })
+
+          expect(newest).toHaveLength(1)
+          expect(newest[0].id).toBe(second.id)
+          expect(next).toHaveLength(1)
+          expect(next[0].id).toBe(first.id)
         },
       })
     } finally {

--- a/opencode/packages/opencode/test/server/schedules-routes.test.ts
+++ b/opencode/packages/opencode/test/server/schedules-routes.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { RuntimeControllerProtocol } from "../../src/runtime/controller/protocol"
+import { Schedule } from "../../src/schedule/schedule"
+import type { AutomatedControllerRunner } from "../../src/server/routes/automated-controller"
+import { Server } from "../../src/server/server"
+import { Storage } from "../../src/storage/storage"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+const acceptedRunner: AutomatedControllerRunner = async (input) => {
+  const response = {
+    accepted: true,
+    sessionID: "ses_route_scheduled",
+    turnSnapshotId: "turn_route_scheduled",
+    status: 202,
+    response: {
+      version: RuntimeControllerProtocol.VERSION,
+      accepted: true,
+      sessionId: "ses_route_scheduled",
+      turnSnapshotId: "turn_route_scheduled",
+    },
+  }
+  await input.onControllerResponse?.(response)
+  await input.onFinished?.({ status: "succeeded" })
+  return response
+}
+
+async function cleanup(taskIDs: string[], projectID?: string) {
+  Schedule._testing.resetAutomatedControllerRunner()
+  for (const taskID of taskIDs) {
+    for (const run of await Schedule.listRuns({ taskID, limit: 500 }).catch(() => [])) {
+      await Storage.remove(["scheduled_run", run.id]).catch(() => undefined)
+    }
+    await Storage.remove(["scheduled_task", taskID]).catch(() => undefined)
+  }
+  if (projectID) {
+    await Storage.remove(["project", projectID]).catch(() => undefined)
+    await Storage.remove(["project_meta", projectID]).catch(() => undefined)
+  }
+  await Instance.disposeAll().catch(() => undefined)
+}
+
+describe("schedules routes", () => {
+  test("creates, reads, updates, lists, and deletes scheduled tasks", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          const app = Server.App()
+          const headers = {
+            "Content-Type": "application/json",
+            "x-opencode-directory": tmp.path,
+          }
+
+          const created = await app.request("/schedules/tasks", {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+              name: "Route schedule",
+              projectID,
+              timezone: "UTC",
+              schedule: { type: "daily", timeOfDay: "09:30" },
+              promptTemplate: "Run {{task.name}}",
+            }),
+          })
+          expect(created.status).toBe(200)
+          const task = await created.json() as Schedule.Task
+          taskIDs.push(task.id)
+          expect(task.name).toBe("Route schedule")
+          expect(typeof task.nextRunAt).toBe("number")
+
+          const fetched = await app.request(`/schedules/tasks/${task.id}`, { headers })
+          expect(fetched.status).toBe(200)
+          const fetchedTask = await fetched.json() as Schedule.Task
+          expect(fetchedTask.id).toBe(task.id)
+
+          const list = await app.request("/schedules/tasks", { headers })
+          expect(list.status).toBe(200)
+          const tasks = await list.json() as Schedule.Task[]
+          expect(tasks.some((item) => item.id === task.id)).toBe(true)
+
+          const updated = await app.request(`/schedules/tasks/${task.id}`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({
+              name: "Route schedule updated",
+              enabled: false,
+            }),
+          })
+          expect(updated.status).toBe(200)
+          const updatedTask = await updated.json() as Schedule.Task
+          expect(updatedTask.name).toBe("Route schedule updated")
+          expect(updatedTask.enabled).toBe(false)
+          expect(updatedTask.nextRunAt).toBeUndefined()
+
+          const deleted = await app.request(`/schedules/tasks/${task.id}`, {
+            method: "DELETE",
+            headers,
+          })
+          expect(deleted.status).toBe(200)
+          const deletedTask = await deleted.json() as Schedule.Task
+          expect(typeof deletedTask.deletedAt).toBe("number")
+
+          const hiddenList = await app.request("/schedules/tasks", { headers })
+          const visibleTasks = await hiddenList.json() as Schedule.Task[]
+          expect(visibleTasks.some((item) => item.id === task.id)).toBe(false)
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+
+  test("runs a scheduled task manually and lists run records with pagination", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const taskIDs: string[] = []
+    let projectID: string | undefined
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          projectID = Instance.project.id
+          Schedule._testing.setAutomatedControllerRunner(acceptedRunner)
+          const app = Server.App()
+          const headers = {
+            "Content-Type": "application/json",
+            "x-opencode-directory": tmp.path,
+          }
+
+          const created = await app.request("/schedules/tasks", {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+              name: "Manual route schedule",
+              projectID,
+              timezone: "UTC",
+              schedule: { type: "once-after", delayMs: 60_000 },
+              promptTemplate: "Manual run {{task.name}}",
+            }),
+          })
+          expect(created.status).toBe(200)
+          const task = await created.json() as Schedule.Task
+          taskIDs.push(task.id)
+
+          const runResponse = await app.request(`/schedules/tasks/${task.id}/run`, {
+            method: "POST",
+            headers,
+          })
+          expect(runResponse.status).toBe(200)
+          const runBody = await runResponse.json() as Schedule.RunResponse
+          expect(runBody.accepted).toBe(true)
+          expect(runBody.sessionId).toBe("ses_route_scheduled")
+          expect(runBody.turnSnapshotId).toBe("turn_route_scheduled")
+          expect(runBody.run.status).toBe("succeeded")
+          expect(runBody.run.promptPreview).toContain("Manual route schedule")
+
+          const runsResponse = await app.request(`/schedules/runs?taskID=${encodeURIComponent(task.id)}&limit=1&offset=0`, {
+            headers,
+          })
+          expect(runsResponse.status).toBe(200)
+          const runs = await runsResponse.json() as Schedule.Run[]
+          expect(runs).toHaveLength(1)
+          expect(runs[0].id).toBe(runBody.run.id)
+        },
+      })
+    } finally {
+      await cleanup(taskIDs, projectID)
+    }
+  })
+})

--- a/opencode/packages/opencode/test/server/schedules-routes.test.ts
+++ b/opencode/packages/opencode/test/server/schedules-routes.test.ts
@@ -33,6 +33,8 @@ async function cleanup(taskIDs: string[], projectID?: string) {
   for (const taskID of taskIDs) {
     for (const run of await Schedule.listRuns({ taskID, limit: 500 }).catch(() => [])) {
       await Storage.remove(["scheduled_run", run.id]).catch(() => undefined)
+      await Storage.remove(["scheduled_run_by_task", taskID, run.id]).catch(() => undefined)
+      await Storage.remove(["scheduled_run_active", taskID, run.id]).catch(() => undefined)
     }
     await Storage.remove(["scheduled_task", taskID]).catch(() => undefined)
   }

--- a/opencode/packages/opencode/test/server/schedules-routes.test.ts
+++ b/opencode/packages/opencode/test/server/schedules-routes.test.ts
@@ -114,6 +114,21 @@ describe("schedules routes", () => {
           const hiddenList = await app.request("/schedules/tasks", { headers })
           const visibleTasks = await hiddenList.json() as Schedule.Task[]
           expect(visibleTasks.some((item) => item.id === task.id)).toBe(false)
+
+          const updateDeleted = await app.request(`/schedules/tasks/${task.id}`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({
+              name: "Should not update",
+            }),
+          })
+          expect(updateDeleted.status).toBe(404)
+
+          const deleteDeleted = await app.request(`/schedules/tasks/${task.id}`, {
+            method: "DELETE",
+            headers,
+          })
+          expect(deleteDeleted.status).toBe(404)
         },
       })
     } finally {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -15,7 +15,7 @@ import InputBox from './components/InputBox.vue'
 import PromptCategories from './components/PromptCategories.vue'
 import SearchOverlay from './components/SearchOverlay.vue'
 import ProjectsPage from './components/ProjectsPage.vue'
-import WebhooksPage from './components/WebhooksPage.vue'
+import AutomationsPage from './components/AutomationsPage.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import FileViewer from './components/FileViewer.vue'
 import TodoList from './components/TodoList.vue'
@@ -144,8 +144,8 @@ const showSearch = ref(false)
 // Projects page
 const showProjectsPage = ref(false)
 
-// Webhooks page
-const showWebhooksPage = ref(false)
+// Automations page
+const showAutomationsPage = ref(false)
 
 const sidebarCollapsed = ref(false)
 const projectContextRevision = ref(0)
@@ -179,7 +179,7 @@ const searchRecentSessions = computed(() => {
 
 // Empty state detection for centered layout
 const isEmptyState = computed(() =>
-  messages.value.length === 0 && !isLoading.value && !showProjectsPage.value && !showWebhooksPage.value
+  messages.value.length === 0 && !isLoading.value && !showProjectsPage.value && !showAutomationsPage.value
 )
 
 // Handle model selection from InputBox
@@ -358,8 +358,8 @@ async function handleSend(content: string, files?: Array<{ type: 'file'; mime: s
   if (showProjectsPage.value) {
     showProjectsPage.value = false
   }
-  if (showWebhooksPage.value) {
-    showWebhooksPage.value = false
+  if (showAutomationsPage.value) {
+    showAutomationsPage.value = false
   }
 
   // sendMessage 会自动处理草稿模式，在发送前创建会话
@@ -383,7 +383,7 @@ async function ensureCurrentSessionId() {
 
 function handleNewSession() {
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   createSession(currentDirectory.value || '.')
 }
 
@@ -395,7 +395,7 @@ function toggleSidebar() {
 function handleSwitchMode(newMode: 'chat' | 'agent') {
   setAppMode(newMode)
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   createSession(currentDirectory.value || '.')
 }
 
@@ -405,7 +405,7 @@ async function handleSelectProject(projectId: string) {
     return
   }
 
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   const project = await selectProject(projectId)
   if (!project) return
 
@@ -423,14 +423,14 @@ async function handleSelectProject(projectId: string) {
 
 function handleOpenProjects() {
   showProjectsPage.value = true
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   loadProjects().catch((error) => {
     console.error('Failed to load projects:', error)
   })
 }
 
-function handleOpenWebhooks() {
-  showWebhooksPage.value = true
+function handleOpenAutomations() {
+  showAutomationsPage.value = true
   showProjectsPage.value = false
   loadProjects().catch((error) => {
     console.error('Failed to load projects:', error)
@@ -454,7 +454,7 @@ async function handleCreateProject(name: string, instructions: string, directory
     createSession(targetDirectory)
   }
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   await loadSessions()
   await refreshGlobalRecentsIfAgent()
 }
@@ -467,7 +467,7 @@ async function handleUpdateProject(projectId: string, updates: { name?: string; 
 function handleSearchSelect(sessionId: string) {
   showSearch.value = false
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   const session = searchRecentSessions.value.find(s => s.id === sessionId) || sessions.value.find(s => s.id === sessionId)
   if (session) {
     selectSession(session)
@@ -478,7 +478,7 @@ function handleProjectNewSession(projectId: string) {
   const project = getProject(projectId)
   if (!project) return
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   createSession(project.rootDirectory || project.worktree)
 }
 
@@ -489,19 +489,19 @@ async function handleDeleteProject(projectId: string) {
 
 async function handleProjectSelectSession(session: Session) {
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   await selectSession(session)
 }
 
 async function handleSidebarSelectSession(session: Session) {
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   await selectSession(session)
 }
 
-async function handleWebhookSelectSession(session: Session) {
+async function handleAutomationSelectSession(session: Session) {
   showProjectsPage.value = false
-  showWebhooksPage.value = false
+  showAutomationsPage.value = false
   await selectSession(session)
 }
 
@@ -607,7 +607,7 @@ function handlePromptSelect(prompt: string) {
       :isSessionRunning="isSessionRunning"
       :runningCount="runningCount"
       :maxParallelAgents="MAX_PARALLEL_AGENTS"
-      :activePage="showWebhooksPage ? 'webhooks' : showProjectsPage ? 'projects' : 'chat'"
+      :activePage="showAutomationsPage ? 'automations' : showProjectsPage ? 'projects' : 'chat'"
       @toggle-collapse="toggleSidebar"
       @select-session="handleSidebarSelectSession"
       @new-session="handleNewSession"
@@ -622,7 +622,7 @@ function handlePromptSelect(prompt: string) {
       @switch-mode="handleSwitchMode"
       @select-project="handleSelectProject"
       @open-projects="handleOpenProjects"
-      @open-webhooks="handleOpenWebhooks"
+      @open-automations="handleOpenAutomations"
     />
 
     <!-- Main Content -->
@@ -640,11 +640,11 @@ function handlePromptSelect(prompt: string) {
 
       <!-- Chat Area -->
       <div class="chat-panel" :class="{ 'empty-layout': isEmptyState }">
-        <!-- Webhooks Page -->
-        <WebhooksPage
-          v-if="showWebhooksPage"
+        <!-- Automations Page -->
+        <AutomationsPage
+          v-if="showAutomationsPage"
           :projects="projects"
-          @select-session="handleWebhookSelectSession"
+          @select-session="handleAutomationSelectSession"
         />
 
         <!-- Projects Page -->

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -284,6 +284,81 @@ export interface WebhookSourceInput {
   requestGuards?: WebhookRequestGuards
 }
 
+export type ScheduleRule =
+  | { type: 'once-after'; delayMs: number }
+  | { type: 'daily'; timeOfDay: string; daysOfWeek?: number[] }
+  | { type: 'interval'; every: number; unit: 'hour' | 'day'; anchorAt?: number }
+
+export interface ScheduleRuntimeProfile {
+  modelMode: 'default' | 'custom'
+  model?: { providerID: string; modelID: string }
+  resourcesMode: 'default' | 'default-plus-selected'
+  mcpServers: string[]
+}
+
+export interface SchedulePermissionPolicy {
+  mode: 'default' | 'full'
+}
+
+export interface ScheduleTask {
+  id: string
+  name: string
+  enabled: boolean
+  projectID: string
+  schedule: ScheduleRule
+  promptTemplate: string
+  timezone: string
+  runtimeProfile: ScheduleRuntimeProfile
+  permissionPolicy: SchedulePermissionPolicy
+  overlapPolicy: 'skip'
+  misfirePolicy: { mode: 'skip' }
+  nextRunAt?: number
+  lastRunAt?: number
+  deletedAt?: number
+  time: { created: number; updated: number }
+}
+
+export interface ScheduleRun {
+  id: string
+  taskID: string
+  projectID: string
+  sessionID?: string
+  turnSnapshotId?: string
+  status: 'scheduled' | 'accepted' | 'running' | 'succeeded' | 'failed' | 'skipped'
+  reason?: 'disabled' | 'overlap' | 'misfire' | 'manual' | 'due'
+  scheduledAt: number
+  triggeredAt?: number
+  promptPreview?: string
+  responseBody?: unknown
+  error?: string
+  time: {
+    created: number
+    started?: number
+    finished?: number
+  }
+}
+
+export interface ScheduleTaskInput {
+  name: string
+  enabled?: boolean
+  projectID: string
+  schedule: ScheduleRule
+  promptTemplate?: string
+  timezone?: string
+  runtimeProfile?: ScheduleRuntimeProfile
+  permissionPolicy?: SchedulePermissionPolicy
+  overlapPolicy?: 'skip'
+  misfirePolicy?: { mode: 'skip' }
+}
+
+export interface ScheduleRunResponse {
+  accepted: boolean
+  run: ScheduleRun
+  sessionId?: string
+  turnSnapshotId?: string
+  error?: string
+}
+
 // 后端返回格式: { info: MessageInfo, parts: Part[] }
 export interface Message {
   info: MessageInfo
@@ -1144,6 +1219,85 @@ export const webhookApi = {
       status: res.status,
       body,
     }
+  },
+}
+
+export const scheduleApi = {
+  async tasks(): Promise<ScheduleTask[]> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks`)
+    if (!res.ok) {
+      throw new Error(`Failed to list scheduled tasks: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async task(taskID: string): Promise<ScheduleTask> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks/${encodeURIComponent(taskID)}`)
+    if (!res.ok) {
+      throw new Error(`Failed to get scheduled task: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async createTask(input: ScheduleTaskInput): Promise<ScheduleTask> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to create scheduled task: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async updateTask(taskID: string, input: Partial<ScheduleTaskInput>): Promise<ScheduleTask> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks/${encodeURIComponent(taskID)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to update scheduled task: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async deleteTask(taskID: string): Promise<ScheduleTask> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks/${encodeURIComponent(taskID)}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to delete scheduled task: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async runTask(taskID: string): Promise<ScheduleRunResponse> {
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/tasks/${encodeURIComponent(taskID)}/run`, {
+      method: 'POST',
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `Failed to run scheduled task: ${res.status}`)
+    }
+    return res.json()
+  },
+
+  async runs(opts: { taskID?: string; limit?: number; offset?: number } = {}): Promise<ScheduleRun[]> {
+    const params = new URLSearchParams()
+    if (opts.taskID) params.set('taskID', opts.taskID)
+    if (opts.limit !== undefined) params.set('limit', String(opts.limit))
+    if (opts.offset !== undefined) params.set('offset', String(opts.offset))
+    const suffix = params.toString() ? `?${params}` : ''
+    const res = await fetchWithTimeout(`${BASE_URL}/schedules/runs${suffix}`)
+    if (!res.ok) {
+      throw new Error(`Failed to list scheduled runs: ${res.status}`)
+    }
+    return res.json()
   },
 }
 

--- a/web/src/components/AutomationsPage.vue
+++ b/web/src/components/AutomationsPage.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { CalendarClock, Webhook } from 'lucide-vue-next'
+import type { Session } from '../api/client'
+import type { ProjectInfo } from './Sidebar.vue'
+import SchedulesPage from './SchedulesPage.vue'
+import WebhooksPage from './WebhooksPage.vue'
+
+defineProps<{
+  projects: ProjectInfo[]
+}>()
+
+const emit = defineEmits<{
+  selectSession: [session: Session]
+}>()
+
+const activeTab = ref<'webhooks' | 'schedules'>('webhooks')
+</script>
+
+<template>
+  <div class="automations-page">
+    <header class="automations-header">
+      <div>
+        <h1>Automations</h1>
+        <p>Project-bound triggers for unattended agent runs.</p>
+      </div>
+      <div class="automation-tabs" role="tablist" aria-label="Automation types">
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'webhooks' }"
+          role="tab"
+          :aria-selected="activeTab === 'webhooks'"
+          @click="activeTab = 'webhooks'"
+        >
+          <Webhook :size="16" />
+          Webhooks
+        </button>
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'schedules' }"
+          role="tab"
+          :aria-selected="activeTab === 'schedules'"
+          @click="activeTab = 'schedules'"
+        >
+          <CalendarClock :size="16" />
+          Schedules
+        </button>
+      </div>
+    </header>
+
+    <WebhooksPage
+      v-if="activeTab === 'webhooks'"
+      embedded
+      :projects="projects"
+      @select-session="emit('selectSession', $event)"
+    />
+    <SchedulesPage
+      v-else
+      :projects="projects"
+      @select-session="emit('selectSession', $event)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.automations-page {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  padding: var(--space-lg);
+  overflow: auto;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.automations-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.automations-header h1 {
+  margin: 0;
+  font-size: 30px;
+  font-weight: 650;
+  line-height: 1.15;
+}
+
+.automations-header p {
+  margin: var(--space-xs) 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.automation-tabs {
+  display: inline-flex;
+  gap: var(--space-xs);
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.tab-btn {
+  height: 34px;
+  padding: 0 var(--space-md);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.tab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.tab-btn.active {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+@media (max-width: 760px) {
+  .automations-page {
+    padding: var(--space-md);
+  }
+
+  .automations-header {
+    display: grid;
+  }
+
+  .automation-tabs {
+    width: 100%;
+  }
+
+  .tab-btn {
+    flex: 1 1 0;
+  }
+}
+</style>

--- a/web/src/components/SchedulesPage.vue
+++ b/web/src/components/SchedulesPage.vue
@@ -371,7 +371,7 @@ async function openRunSession(run: ScheduleRun) {
 
 async function copyText(text: string) {
   if (!text) return
-  await navigator.clipboard?.writeText(text).catch(() => undefined)
+  await navigator.clipboard?.writeText(text)?.catch(() => undefined)
   notice.value = 'Copied.'
 }
 

--- a/web/src/components/SchedulesPage.vue
+++ b/web/src/components/SchedulesPage.vue
@@ -371,8 +371,18 @@ async function openRunSession(run: ScheduleRun) {
 
 async function copyText(text: string) {
   if (!text) return
-  await navigator.clipboard?.writeText(text)?.catch(() => undefined)
-  notice.value = 'Copied.'
+  error.value = ''
+  notice.value = ''
+  if (!navigator.clipboard?.writeText) {
+    error.value = 'Clipboard is not available in this browser.'
+    return
+  }
+  try {
+    await navigator.clipboard.writeText(text)
+    notice.value = 'Copied.'
+  } catch {
+    error.value = 'Unable to copy to clipboard.'
+  }
 }
 
 function beginCreate() {

--- a/web/src/components/SchedulesPage.vue
+++ b/web/src/components/SchedulesPage.vue
@@ -1,0 +1,1285 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  Activity,
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  Clock,
+  Copy,
+  Play,
+  Plus,
+  RefreshCw,
+  Save,
+  Settings2,
+  Trash2,
+} from 'lucide-vue-next'
+import {
+  mcpApi,
+  projectApi,
+  providerApi,
+  scheduleApi,
+  type McpServer,
+  type Provider,
+  type ScheduleRun,
+  type ScheduleRule,
+  type ScheduleTask,
+  type ScheduleTaskInput,
+  type Session,
+} from '../api/client'
+import type { ProjectInfo } from './Sidebar.vue'
+
+const props = defineProps<{
+  projects: ProjectInfo[]
+}>()
+
+const emit = defineEmits<{
+  selectSession: [session: Session]
+}>()
+
+const DEFAULT_PROMPT = [
+  'Scheduled task {{task.name}} triggered an automated Nine1Bot run.',
+  '',
+  'Project: {{project.name}}',
+  'Scheduled at: {{schedule.scheduledAt}}',
+  'Triggered at: {{schedule.triggeredAt}}',
+  '',
+  'Please execute the configured recurring task using the project context and stay within the configured permissions.',
+].join('\n')
+
+const TIMEZONE_FALLBACKS = [
+  'UTC',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Europe/London',
+  'Europe/Berlin',
+  'America/New_York',
+  'America/Los_Angeles',
+]
+
+type RuleType = ScheduleRule['type']
+
+const tasks = ref<ScheduleTask[]>([])
+const runs = ref<ScheduleRun[]>([])
+const providers = ref<Provider[]>([])
+const mcpServers = ref<McpServer[]>([])
+const selectedTaskId = ref('')
+const selectedRunId = ref('')
+const showCreateForm = ref(false)
+const showMcpPicker = ref(false)
+const pendingMcpServers = ref<string[]>([])
+const fullPermissionConfirmed = ref(false)
+const isLoading = ref(false)
+const isSaving = ref(false)
+const isRunning = ref(false)
+const error = ref('')
+const notice = ref('')
+const pollingTimer = ref<ReturnType<typeof setInterval> | null>(null)
+const form = ref(defaultForm())
+
+const timezoneOptions = computed(() => {
+  const supported = (Intl as any).supportedValuesOf?.('timeZone') as string[] | undefined
+  const current = form.value.timezone || browserTimezone()
+  return [...new Set([current, ...(supported?.length ? supported : TIMEZONE_FALLBACKS)])]
+})
+const sortedProjects = computed(() => props.projects.slice().sort((a, b) => b.time.updated - a.time.updated))
+const selectedTask = computed(() => tasks.value.find((task) => task.id === selectedTaskId.value) || null)
+const selectedRuns = computed(() => {
+  if (!selectedTaskId.value) return runs.value
+  return runs.value.filter((run) => run.taskID === selectedTaskId.value)
+})
+const selectedRun = computed(() => selectedRuns.value.find((run) => run.id === selectedRunId.value) || null)
+const selectedProvider = computed(() => providers.value.find((provider) => provider.id === form.value.modelProviderID))
+const selectedProviderModels = computed(() => selectedProvider.value?.models || [])
+const defaultMcpServers = computed(() => mcpServers.value.filter((server) => server.status !== 'disabled').map((server) => server.name))
+const addedMcpServers = computed(() => form.value.mcpServers.filter((server) => server.trim()))
+const availableMcpServers = computed(() => mcpServers.value.filter((server) => server.status !== 'disabled'))
+const effectiveMcpServers = computed(() => {
+  if (form.value.resourcesMode === 'default') return defaultMcpServers.value
+  return [...new Set([...defaultMcpServers.value, ...addedMcpServers.value])]
+})
+const enabledCount = computed(() => tasks.value.filter((task) => task.enabled).length)
+const activeRunCount = computed(() => runs.value.filter((run) => run.status === 'accepted' || run.status === 'running').length)
+
+function browserTimezone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+}
+
+function defaultForm() {
+  return {
+    name: '',
+    enabled: true,
+    projectID: '',
+    ruleType: 'daily' as RuleType,
+    onceAmount: 1,
+    onceUnit: 'hour' as 'hour' | 'day',
+    dailyTime: '09:00',
+    intervalEvery: 24,
+    intervalUnit: 'hour' as 'hour' | 'day',
+    timezone: browserTimezone(),
+    promptTemplate: DEFAULT_PROMPT,
+    modelMode: 'default' as 'default' | 'custom',
+    modelProviderID: '',
+    modelID: '',
+    resourcesMode: 'default' as 'default' | 'default-plus-selected',
+    mcpServers: [] as string[],
+    permissionMode: 'default' as 'default' | 'full',
+  }
+}
+
+function projectLabel(projectID: string) {
+  const project = props.projects.find((item) => item.id === projectID)
+  return project?.name || project?.rootDirectory || project?.worktree || projectID
+}
+
+function resetCreateForm() {
+  const next = defaultForm()
+  next.projectID = sortedProjects.value[0]?.id || ''
+  next.modelProviderID = providers.value[0]?.id || ''
+  next.modelID = providers.value[0]?.models[0]?.id || ''
+  form.value = next
+  selectedRunId.value = ''
+  fullPermissionConfirmed.value = false
+}
+
+function loadFormFromTask(task: ScheduleTask | null) {
+  if (!task) {
+    resetCreateForm()
+    return
+  }
+  const model = task.runtimeProfile.model
+  form.value = {
+    ...defaultForm(),
+    name: task.name,
+    enabled: task.enabled,
+    projectID: task.projectID,
+    ruleType: task.schedule.type,
+    onceAmount: task.schedule.type === 'once-after' ? Math.max(1, Math.round(task.schedule.delayMs / 3_600_000)) : 1,
+    onceUnit: 'hour',
+    dailyTime: task.schedule.type === 'daily' ? task.schedule.timeOfDay : '09:00',
+    intervalEvery: task.schedule.type === 'interval' ? task.schedule.every : 24,
+    intervalUnit: task.schedule.type === 'interval' ? task.schedule.unit : 'hour',
+    timezone: task.timezone || browserTimezone(),
+    promptTemplate: task.promptTemplate || DEFAULT_PROMPT,
+    modelMode: task.runtimeProfile.modelMode,
+    modelProviderID: model?.providerID || providers.value[0]?.id || '',
+    modelID: model?.modelID || providers.value[0]?.models[0]?.id || '',
+    resourcesMode: task.runtimeProfile.resourcesMode,
+    mcpServers: [...(task.runtimeProfile.mcpServers || [])],
+    permissionMode: task.permissionPolicy.mode,
+  }
+  fullPermissionConfirmed.value = task.permissionPolicy.mode === 'full'
+}
+
+watch(selectedTask, (task) => {
+  if (!showCreateForm.value) loadFormFromTask(task)
+})
+
+watch(
+  () => props.projects,
+  () => {
+    if (!form.value.projectID && sortedProjects.value[0]) {
+      form.value.projectID = sortedProjects.value[0].id
+    }
+  },
+  { immediate: true },
+)
+
+watch(selectedProviderModels, (models) => {
+  if (form.value.modelMode === 'custom' && models.length > 0 && !models.some((model) => model.id === form.value.modelID)) {
+    form.value.modelID = models[0].id
+  }
+})
+
+watch(
+  () => form.value.resourcesMode,
+  (mode) => {
+    if (mode === 'default') form.value.mcpServers = []
+  },
+)
+
+async function loadAll() {
+  isLoading.value = true
+  error.value = ''
+  try {
+    const [nextTasks, nextRuns, providerResult, nextMcpServers] = await Promise.all([
+      scheduleApi.tasks(),
+      scheduleApi.runs({ limit: 100 }),
+      providerApi.list(),
+      mcpApi.list(),
+    ])
+    tasks.value = nextTasks
+    runs.value = nextRuns
+    providers.value = providerResult.providers
+    mcpServers.value = nextMcpServers
+    if (!selectedTaskId.value && nextTasks[0]) {
+      selectedTaskId.value = nextTasks[0].id
+    }
+    if (!showCreateForm.value) {
+      loadFormFromTask(selectedTask.value)
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function refreshRuns() {
+  runs.value = await scheduleApi.runs({ limit: 100 })
+}
+
+async function refreshTasksAndRuns() {
+  const [nextTasks, nextRuns] = await Promise.all([
+    scheduleApi.tasks(),
+    scheduleApi.runs({ limit: 100 }),
+  ])
+  tasks.value = nextTasks
+  runs.value = nextRuns
+}
+
+function scheduleFromForm(): ScheduleRule {
+  if (form.value.ruleType === 'once-after') {
+    const multiplier = form.value.onceUnit === 'day' ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000
+    return {
+      type: 'once-after',
+      delayMs: Math.max(1, form.value.onceAmount) * multiplier,
+    }
+  }
+  if (form.value.ruleType === 'interval') {
+    return {
+      type: 'interval',
+      every: Math.max(1, form.value.intervalEvery),
+      unit: form.value.intervalUnit,
+    }
+  }
+  return {
+    type: 'daily',
+    timeOfDay: form.value.dailyTime,
+  }
+}
+
+function taskInput(): ScheduleTaskInput {
+  if (!form.value.name.trim()) throw new Error('Name is required')
+  if (!form.value.projectID) throw new Error('Project is required')
+  if (form.value.modelMode === 'custom' && (!form.value.modelProviderID || !form.value.modelID)) {
+    throw new Error('Choose a provider and model for custom model mode')
+  }
+  if (form.value.permissionMode === 'full' && !fullPermissionConfirmed.value) {
+    throw new Error('Confirm full permission mode before saving')
+  }
+  return {
+    name: form.value.name.trim(),
+    enabled: form.value.enabled,
+    projectID: form.value.projectID,
+    schedule: scheduleFromForm(),
+    timezone: form.value.timezone || browserTimezone(),
+    promptTemplate: form.value.promptTemplate || DEFAULT_PROMPT,
+    runtimeProfile: {
+      modelMode: form.value.modelMode,
+      model: form.value.modelMode === 'custom'
+        ? { providerID: form.value.modelProviderID, modelID: form.value.modelID }
+        : undefined,
+      resourcesMode: form.value.resourcesMode,
+      mcpServers: form.value.resourcesMode === 'default-plus-selected'
+        ? form.value.mcpServers.filter((server) => server.trim())
+        : [],
+    },
+    permissionPolicy: {
+      mode: form.value.permissionMode,
+    },
+    overlapPolicy: 'skip',
+    misfirePolicy: { mode: 'skip' },
+  }
+}
+
+async function saveTask() {
+  isSaving.value = true
+  error.value = ''
+  notice.value = ''
+  try {
+    const payload = taskInput()
+    if (showCreateForm.value) {
+      const created = await scheduleApi.createTask(payload)
+      tasks.value = await scheduleApi.tasks()
+      selectedTaskId.value = created.id
+      showCreateForm.value = false
+      notice.value = 'Scheduled task created.'
+    } else if (selectedTask.value) {
+      const updated = await scheduleApi.updateTask(selectedTask.value.id, payload)
+      tasks.value = tasks.value.map((task) => task.id === updated.id ? updated : task)
+      notice.value = 'Scheduled task saved.'
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function deleteTask() {
+  if (!selectedTask.value) return
+  const ok = confirm(`Delete scheduled task "${selectedTask.value.name}"?`)
+  if (!ok) return
+  isSaving.value = true
+  error.value = ''
+  notice.value = ''
+  try {
+    await scheduleApi.deleteTask(selectedTask.value.id)
+    tasks.value = await scheduleApi.tasks()
+    selectedTaskId.value = tasks.value[0]?.id || ''
+    selectedRunId.value = ''
+    loadFormFromTask(selectedTask.value)
+    notice.value = 'Scheduled task deleted.'
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function runTaskNow() {
+  if (!selectedTask.value) return
+  isRunning.value = true
+  error.value = ''
+  notice.value = ''
+  try {
+    const result = await scheduleApi.runTask(selectedTask.value.id)
+    await refreshTasksAndRuns()
+    selectedRunId.value = result.run.id
+    notice.value = result.accepted ? 'Scheduled task run started.' : (result.error || 'Scheduled task run was skipped.')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    isRunning.value = false
+  }
+}
+
+async function openRunSession(run: ScheduleRun) {
+  if (!run.sessionID) return
+  error.value = ''
+  try {
+    const sessions = await projectApi.sessions(run.projectID, { roots: true, limit: 300 })
+    const session = sessions.find((item) => item.id === run.sessionID)
+    if (!session) throw new Error('Session no longer exists')
+    emit('selectSession', session)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  }
+}
+
+async function copyText(text: string) {
+  if (!text) return
+  await navigator.clipboard?.writeText(text).catch(() => undefined)
+  notice.value = 'Copied.'
+}
+
+function beginCreate() {
+  showCreateForm.value = true
+  selectedTaskId.value = ''
+  selectedRunId.value = ''
+  showMcpPicker.value = false
+  resetCreateForm()
+}
+
+function selectTask(task: ScheduleTask) {
+  showCreateForm.value = false
+  selectedTaskId.value = task.id
+  selectedRunId.value = ''
+  showMcpPicker.value = false
+}
+
+function selectRun(run: ScheduleRun) {
+  selectedRunId.value = selectedRunId.value === run.id ? '' : run.id
+}
+
+function openMcpPicker() {
+  pendingMcpServers.value = [...form.value.mcpServers]
+  showMcpPicker.value = true
+}
+
+function applyMcpPicker() {
+  form.value.mcpServers = [...new Set(pendingMcpServers.value)]
+  form.value.resourcesMode = form.value.mcpServers.length > 0 ? 'default-plus-selected' : 'default'
+  showMcpPicker.value = false
+}
+
+function removeMcpServer(server: string) {
+  form.value.mcpServers = form.value.mcpServers.filter((item) => item !== server)
+  if (form.value.mcpServers.length === 0) form.value.resourcesMode = 'default'
+}
+
+function handlePermissionModeChange() {
+  if (form.value.permissionMode !== 'full') {
+    fullPermissionConfirmed.value = false
+    return
+  }
+  const ok = confirm('Full permission mode will automatically allow permission requests for scheduled runs in this session.')
+  if (ok) {
+    fullPermissionConfirmed.value = true
+  } else {
+    form.value.permissionMode = 'default'
+    fullPermissionConfirmed.value = false
+  }
+}
+
+function describeRule(task: ScheduleTask) {
+  if (task.schedule.type === 'once-after') {
+    const hours = Math.round(task.schedule.delayMs / 3_600_000)
+    return `Once after ${hours}h`
+  }
+  if (task.schedule.type === 'daily') {
+    return `Daily at ${task.schedule.timeOfDay}`
+  }
+  return `Every ${task.schedule.every} ${task.schedule.unit}${task.schedule.every === 1 ? '' : 's'}`
+}
+
+function latestRunFor(taskID: string) {
+  return runs.value.find((run) => run.taskID === taskID)
+}
+
+function statusClass(status?: ScheduleRun['status']) {
+  if (status === 'succeeded') return 'ok'
+  if (status === 'failed') return 'error'
+  if (status === 'skipped') return 'warn'
+  if (status === 'running' || status === 'accepted') return 'blue'
+  return 'muted'
+}
+
+function runSummary(run: ScheduleRun) {
+  return run.error || run.promptPreview || run.reason || 'Scheduled run'
+}
+
+function formatDate(value?: number) {
+  if (!value) return 'Never'
+  return new Date(value).toLocaleString()
+}
+
+function formatJson(value: unknown) {
+  if (value === undefined || value === null) return ''
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function renderPreview() {
+  const projectName = projectLabel(form.value.projectID)
+  return (form.value.promptTemplate || DEFAULT_PROMPT)
+    .replace(/{{\s*task\.name\s*}}/g, form.value.name || 'Scheduled task')
+    .replace(/{{\s*project\.name\s*}}/g, projectName || 'Project')
+    .replace(/{{\s*schedule\.scheduledAt\s*}}/g, '2026-01-01T09:00:00.000Z')
+    .replace(/{{\s*schedule\.triggeredAt\s*}}/g, '2026-01-01T09:00:02.000Z')
+}
+
+onMounted(() => {
+  void loadAll()
+  pollingTimer.value = setInterval(() => {
+    refreshTasksAndRuns().catch(() => undefined)
+  }, 5000)
+})
+
+onUnmounted(() => {
+  if (pollingTimer.value) clearInterval(pollingTimer.value)
+})
+</script>
+
+<template>
+  <div class="schedules-page">
+    <header class="schedules-toolbar">
+      <div class="metric">
+        <CalendarClock :size="16" />
+        <span>{{ enabledCount }} enabled</span>
+      </div>
+      <div class="metric">
+        <Activity :size="16" />
+        <span>{{ activeRunCount }} active</span>
+      </div>
+      <div class="toolbar-actions">
+        <button class="btn" @click="loadAll" :disabled="isLoading">
+          <RefreshCw :size="16" :class="{ spin: isLoading }" />
+          Refresh
+        </button>
+        <button class="btn primary" @click="beginCreate">
+          <Plus :size="16" />
+          New task
+        </button>
+      </div>
+    </header>
+
+    <div v-if="error" class="notice error">
+      <AlertTriangle :size="16" />
+      {{ error }}
+    </div>
+    <div v-if="notice" class="notice">
+      <CheckCircle2 :size="16" />
+      {{ notice }}
+    </div>
+
+    <section class="schedules-workspace">
+      <aside class="tasks-column">
+        <div class="column-header">
+          <h2>Tasks</h2>
+          <span class="pill blue">{{ tasks.length }} total</span>
+        </div>
+        <button
+          v-for="task in tasks"
+          :key="task.id"
+          class="task-item"
+          :class="{ active: selectedTaskId === task.id }"
+          @click="selectTask(task)"
+        >
+          <span class="task-icon"><Clock :size="16" /></span>
+          <span class="task-copy">
+            <strong>{{ task.name }}</strong>
+            <span>{{ projectLabel(task.projectID) }} · {{ describeRule(task) }}</span>
+          </span>
+          <span class="task-badges">
+            <span class="pill" :class="task.enabled ? 'ok' : 'muted'">{{ task.enabled ? 'on' : 'off' }}</span>
+            <span class="pill" :class="statusClass(latestRunFor(task.id)?.status)">{{ latestRunFor(task.id)?.status || 'no runs' }}</span>
+          </span>
+        </button>
+        <div v-if="tasks.length === 0" class="empty-note">
+          No scheduled tasks yet.
+        </div>
+      </aside>
+
+      <main class="detail-column">
+        <div class="detail-header">
+          <div>
+            <h2>{{ showCreateForm ? 'New scheduled task' : selectedTask?.name || 'Scheduled task' }}</h2>
+            <p>{{ showCreateForm ? 'Create a project-bound recurring entry point.' : projectLabel(selectedTask?.projectID || '') }}</p>
+          </div>
+          <div v-if="selectedTask && !showCreateForm" class="detail-actions">
+            <button class="btn" @click="runTaskNow" :disabled="isSaving || isRunning">
+              <Play :size="16" />
+              Run now
+            </button>
+            <button class="btn danger" @click="deleteTask" :disabled="isSaving || isRunning">
+              <Trash2 :size="16" />
+              Delete
+            </button>
+          </div>
+        </div>
+
+        <div class="detail-grid">
+          <section class="panel wide">
+            <h3>Task</h3>
+            <div class="form-grid two">
+              <label>
+                <span>Name</span>
+                <input v-model="form.name" placeholder="Daily project check" />
+              </label>
+              <label>
+                <span>Project</span>
+                <select v-model="form.projectID">
+                  <option v-for="project in sortedProjects" :key="project.id" :value="project.id">
+                    {{ projectLabel(project.id) }}
+                  </option>
+                </select>
+              </label>
+            </div>
+            <label class="toggle-row">
+              <input v-model="form.enabled" type="checkbox" />
+              <span>Enabled</span>
+            </label>
+          </section>
+
+          <section class="panel wide">
+            <h3>Schedule</h3>
+            <div class="segmented">
+              <label><input v-model="form.ruleType" type="radio" value="once-after" /> Once later</label>
+              <label><input v-model="form.ruleType" type="radio" value="daily" /> Daily</label>
+              <label><input v-model="form.ruleType" type="radio" value="interval" /> Interval</label>
+            </div>
+            <div class="form-grid two">
+              <template v-if="form.ruleType === 'once-after'">
+                <label>
+                  <span>Delay</span>
+                  <input v-model.number="form.onceAmount" type="number" min="1" />
+                </label>
+                <label>
+                  <span>Unit</span>
+                  <select v-model="form.onceUnit">
+                    <option value="hour">Hours</option>
+                    <option value="day">Days</option>
+                  </select>
+                </label>
+              </template>
+              <template v-else-if="form.ruleType === 'daily'">
+                <label>
+                  <span>Time</span>
+                  <input v-model="form.dailyTime" type="time" />
+                </label>
+                <label>
+                  <span>Timezone</span>
+                  <select v-model="form.timezone">
+                    <option v-for="timezone in timezoneOptions" :key="timezone" :value="timezone">
+                      {{ timezone }}
+                    </option>
+                  </select>
+                </label>
+              </template>
+              <template v-else>
+                <label>
+                  <span>Every</span>
+                  <input v-model.number="form.intervalEvery" type="number" min="1" />
+                </label>
+                <label>
+                  <span>Unit</span>
+                  <select v-model="form.intervalUnit">
+                    <option value="hour">Hours</option>
+                    <option value="day">Days</option>
+                  </select>
+                </label>
+              </template>
+            </div>
+            <div v-if="selectedTask && !showCreateForm" class="schedule-meta">
+              <span>Next: {{ formatDate(selectedTask.nextRunAt) }}</span>
+              <span>Last: {{ formatDate(selectedTask.lastRunAt) }}</span>
+            </div>
+          </section>
+
+          <section class="panel wide">
+            <h3>Runtime</h3>
+            <div class="form-grid two">
+              <label>
+                <span>Permission</span>
+                <select v-model="form.permissionMode" @change="handlePermissionModeChange">
+                  <option value="default">Default</option>
+                  <option value="full">Full session</option>
+                </select>
+              </label>
+              <label>
+                <span>Model</span>
+                <select v-model="form.modelMode">
+                  <option value="default">Default model</option>
+                  <option value="custom">Custom model</option>
+                </select>
+              </label>
+            </div>
+            <div v-if="form.modelMode === 'custom'" class="form-grid two">
+              <label>
+                <span>Provider</span>
+                <select v-model="form.modelProviderID">
+                  <option v-for="provider in providers" :key="provider.id" :value="provider.id">
+                    {{ provider.name || provider.id }}
+                  </option>
+                </select>
+              </label>
+              <label>
+                <span>Model</span>
+                <select v-model="form.modelID">
+                  <option v-for="model in selectedProviderModels" :key="model.id" :value="model.id">
+                    {{ model.name || model.id }}
+                  </option>
+                </select>
+              </label>
+            </div>
+            <div class="mcp-row">
+              <div>
+                <strong>MCP resources</strong>
+                <p>{{ form.resourcesMode === 'default' ? 'Default MCP configuration' : 'Default MCP plus selected servers' }}</p>
+              </div>
+              <button class="btn" @click="openMcpPicker" type="button">
+                <Settings2 :size="16" />
+                Pick MCP
+              </button>
+            </div>
+            <div class="chips">
+              <span v-for="server in effectiveMcpServers" :key="server" class="chip">
+                {{ server }}
+                <button v-if="addedMcpServers.includes(server)" @click="removeMcpServer(server)" type="button">x</button>
+              </span>
+              <span v-if="effectiveMcpServers.length === 0" class="muted-text">No active MCP servers.</span>
+            </div>
+            <div v-if="showMcpPicker" class="picker-panel">
+              <label v-for="server in availableMcpServers" :key="server.name" class="checkbox-row">
+                <input v-model="pendingMcpServers" type="checkbox" :value="server.name" />
+                <span>{{ server.name }}</span>
+                <small>{{ server.status }}</small>
+              </label>
+              <div class="form-actions">
+                <button class="btn" @click="showMcpPicker = false" type="button">Cancel</button>
+                <button class="btn primary" @click="applyMcpPicker" type="button">Apply</button>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel wide">
+            <h3>Prompt</h3>
+            <textarea v-model="form.promptTemplate" rows="9" />
+            <div class="preview-box">
+              <span>Preview</span>
+              <pre>{{ renderPreview() }}</pre>
+            </div>
+          </section>
+
+          <section class="panel wide">
+            <div class="form-actions">
+              <button class="btn primary" @click="saveTask" :disabled="isSaving">
+                <Save :size="16" />
+                {{ showCreateForm ? 'Create task' : 'Save task' }}
+              </button>
+            </div>
+          </section>
+
+          <section class="panel wide runs-panel">
+            <div class="runs-heading">
+              <h3>Runs</h3>
+              <button class="btn" @click="refreshRuns">
+                <RefreshCw :size="16" />
+                Refresh
+              </button>
+            </div>
+            <button
+              v-for="run in selectedRuns"
+              :key="run.id"
+              class="run-item"
+              :class="{ active: selectedRunId === run.id }"
+              @click="selectRun(run)"
+            >
+              <span class="pill" :class="statusClass(run.status)">{{ run.status }}</span>
+              <span>{{ formatDate(run.time.created) }}</span>
+              <span>{{ run.reason || 'run' }}</span>
+              <strong>{{ runSummary(run) }}</strong>
+            </button>
+            <div v-if="selectedRuns.length === 0" class="empty-note">No runs recorded.</div>
+            <div v-if="selectedRun" class="run-detail">
+              <div class="run-detail-actions">
+                <button class="btn" @click="copyText(selectedRun.id)">
+                  <Copy :size="16" />
+                  Copy ID
+                </button>
+                <button class="btn" @click="openRunSession(selectedRun)" :disabled="!selectedRun.sessionID">
+                  <Activity :size="16" />
+                  Open session
+                </button>
+              </div>
+              <dl>
+                <dt>Scheduled</dt><dd>{{ formatDate(selectedRun.scheduledAt) }}</dd>
+                <dt>Triggered</dt><dd>{{ formatDate(selectedRun.triggeredAt) }}</dd>
+                <dt>Started</dt><dd>{{ formatDate(selectedRun.time.started) }}</dd>
+                <dt>Finished</dt><dd>{{ formatDate(selectedRun.time.finished) }}</dd>
+                <dt>Session</dt><dd>{{ selectedRun.sessionID || 'None' }}</dd>
+                <dt>Turn</dt><dd>{{ selectedRun.turnSnapshotId || 'None' }}</dd>
+              </dl>
+              <div v-if="selectedRun.error" class="error-box">{{ selectedRun.error }}</div>
+              <div v-if="selectedRun.promptPreview" class="preview-box">
+                <span>Prompt preview</span>
+                <pre>{{ selectedRun.promptPreview }}</pre>
+              </div>
+              <div v-if="selectedRun.responseBody" class="preview-box">
+                <span>Controller response</span>
+                <pre>{{ formatJson(selectedRun.responseBody) }}</pre>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.schedules-page {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.schedules-toolbar,
+.toolbar-actions,
+.metric,
+.detail-header,
+.detail-actions,
+.form-actions,
+.runs-heading,
+.run-detail-actions,
+.chips,
+.segmented,
+.mcp-row {
+  display: flex;
+  align-items: center;
+}
+
+.schedules-toolbar {
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.metric {
+  gap: var(--space-xs);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.toolbar-actions,
+.detail-actions,
+.form-actions,
+.run-detail-actions,
+.segmented {
+  gap: var(--space-sm);
+}
+
+.btn {
+  height: 36px;
+  padding: 0 var(--space-md);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+
+.btn.danger,
+.notice.error {
+  color: var(--error);
+}
+
+.btn:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  border-color: var(--border-hover);
+}
+
+.btn.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.notice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-elevated);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--success);
+}
+
+.schedules-workspace {
+  display: grid;
+  grid-template-columns: 330px minmax(0, 1fr);
+  gap: var(--space-lg);
+  align-items: start;
+  min-height: 620px;
+}
+
+.tasks-column,
+.detail-column,
+.panel {
+  min-width: 0;
+  background: var(--bg-elevated);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.tasks-column,
+.detail-column {
+  overflow: hidden;
+}
+
+.column-header,
+.detail-header,
+.panel {
+  padding: var(--space-md);
+}
+
+.column-header,
+.detail-header,
+.runs-heading {
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.column-header {
+  border-bottom: 0.5px solid var(--border-default);
+}
+
+.column-header h2,
+.detail-header h2,
+.panel h3,
+.runs-heading h3 {
+  margin: 0;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.column-header h2,
+.panel h3,
+.runs-heading h3 {
+  font-size: 15px;
+}
+
+.detail-header h2 {
+  font-size: 22px;
+}
+
+.detail-header p,
+.mcp-row p,
+.muted-text {
+  margin: 2px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.task-item {
+  width: calc(100% - var(--space-md) * 2);
+  margin: var(--space-xs) var(--space-md);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--space-sm);
+  align-items: center;
+  padding: var(--space-sm);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.task-item.active,
+.run-item.active {
+  background: var(--bg-secondary);
+  border-color: var(--border-default);
+}
+
+.task-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.task-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.task-copy strong,
+.task-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-copy span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.task-badges {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: var(--radius-full);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.pill.ok {
+  color: var(--success);
+  background: var(--success-subtle);
+}
+
+.pill.warn {
+  color: var(--warning);
+  background: var(--warning-subtle);
+}
+
+.pill.error {
+  color: var(--error);
+  background: var(--error-subtle);
+}
+
+.pill.blue {
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.pill.muted {
+  color: var(--text-muted);
+}
+
+.detail-grid {
+  display: grid;
+  gap: var(--space-md);
+  padding: 0 var(--space-md) var(--space-md);
+}
+
+.form-grid {
+  display: grid;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.form-grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+label {
+  display: grid;
+  gap: var(--space-xs);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  min-width: 0;
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+input,
+select {
+  height: 36px;
+  padding: 0 var(--space-sm);
+}
+
+textarea {
+  resize: vertical;
+  padding: var(--space-sm);
+  line-height: 1.45;
+}
+
+.toggle-row,
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.toggle-row input,
+.checkbox-row input {
+  width: 16px;
+  height: 16px;
+}
+
+.segmented {
+  flex-wrap: wrap;
+  margin-bottom: var(--space-md);
+}
+
+.segmented label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 34px;
+  padding: 0 var(--space-sm);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  cursor: pointer;
+}
+
+.segmented input {
+  width: 14px;
+  height: 14px;
+}
+
+.schedule-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.mcp-row {
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.chips {
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: var(--radius-full);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.chip button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.picker-panel {
+  margin-top: var(--space-md);
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.checkbox-row small {
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.preview-box {
+  display: grid;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.preview-box span {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+pre {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  border: 0.5px solid var(--border-default);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.run-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto auto auto minmax(0, 1fr);
+  gap: var(--space-sm);
+  align-items: center;
+  padding: var(--space-sm);
+  border: 0.5px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.run-item strong {
+  min-width: 0;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.run-detail {
+  display: grid;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 0.5px solid var(--border-default);
+}
+
+.run-detail dl {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: var(--space-xs) var(--space-md);
+  margin: 0;
+}
+
+.run-detail dt {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.run-detail dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.error-box {
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  background: var(--error-subtle);
+  color: var(--error);
+  overflow-wrap: anywhere;
+}
+
+.empty-note {
+  padding: var(--space-md);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 980px) {
+  .schedules-workspace,
+  .form-grid.two {
+    grid-template-columns: 1fr;
+  }
+
+  .run-item {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+}
+</style>

--- a/web/src/components/SchedulesPage.vue
+++ b/web/src/components/SchedulesPage.vue
@@ -171,10 +171,6 @@ function loadFormFromTask(task: ScheduleTask | null) {
   fullPermissionConfirmed.value = task.permissionPolicy.mode === 'full'
 }
 
-watch(selectedTask, (task) => {
-  if (!showCreateForm.value) loadFormFromTask(task)
-})
-
 watch(
   () => props.projects,
   () => {
@@ -202,6 +198,7 @@ async function loadAll() {
   isLoading.value = true
   error.value = ''
   try {
+    const previousTaskId = selectedTaskId.value
     const [nextTasks, nextRuns, providerResult, nextMcpServers] = await Promise.all([
       scheduleApi.tasks(),
       scheduleApi.runs({ limit: 100 }),
@@ -212,10 +209,12 @@ async function loadAll() {
     runs.value = nextRuns
     providers.value = providerResult.providers
     mcpServers.value = nextMcpServers
-    if (!selectedTaskId.value && nextTasks[0]) {
+    if (selectedTaskId.value && !nextTasks.some((task) => task.id === selectedTaskId.value)) {
+      selectedTaskId.value = nextTasks[0]?.id || ''
+    } else if (!selectedTaskId.value && nextTasks[0]) {
       selectedTaskId.value = nextTasks[0].id
     }
-    if (!showCreateForm.value) {
+    if (!showCreateForm.value && selectedTaskId.value !== previousTaskId) {
       loadFormFromTask(selectedTask.value)
     }
   } catch (err) {
@@ -304,10 +303,12 @@ async function saveTask() {
       tasks.value = await scheduleApi.tasks()
       selectedTaskId.value = created.id
       showCreateForm.value = false
+      loadFormFromTask(created)
       notice.value = 'Scheduled task created.'
     } else if (selectedTask.value) {
       const updated = await scheduleApi.updateTask(selectedTask.value.id, payload)
       tasks.value = tasks.value.map((task) => task.id === updated.id ? updated : task)
+      loadFormFromTask(updated)
       notice.value = 'Scheduled task saved.'
     }
   } catch (err) {
@@ -383,10 +384,12 @@ function beginCreate() {
 }
 
 function selectTask(task: ScheduleTask) {
+  const changed = showCreateForm.value || selectedTaskId.value !== task.id
   showCreateForm.value = false
   selectedTaskId.value = task.id
   selectedRunId.value = ''
   showMcpPicker.value = false
+  if (changed) loadFormFromTask(task)
 }
 
 function selectRun(run: ScheduleRun) {

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -45,7 +45,7 @@ const props = defineProps<{
   isSessionRunning: (sessionId: string) => boolean
   runningCount: number
   maxParallelAgents: number
-  activePage: 'chat' | 'projects' | 'webhooks'
+  activePage: 'chat' | 'projects' | 'automations'
 }>()
 
 const emit = defineEmits<{
@@ -63,7 +63,7 @@ const emit = defineEmits<{
   'switch-mode': [mode: AppMode]
   'select-project': [projectId: string]
   'open-projects': []
-  'open-webhooks': []
+  'open-automations': []
 }>()
 
 // Session mode mapping
@@ -196,9 +196,9 @@ function contextMenuDelete() {
         <FolderOpen :size="18" />
         <span>Projects</span>
       </button>
-      <button class="nav-item" :class="{ active: activePage === 'webhooks' }" @click="emit('open-webhooks')">
+      <button class="nav-item" :class="{ active: activePage === 'automations' }" @click="emit('open-automations')">
         <Webhook :size="18" />
-        <span>Webhooks</span>
+        <span>Automations</span>
       </button>
     </nav>
 
@@ -213,7 +213,7 @@ function contextMenuDelete() {
       <button class="nav-item-icon" :class="{ active: activePage === 'projects' }" @click="emit('open-projects')" title="Projects">
         <FolderOpen :size="18" />
       </button>
-      <button class="nav-item-icon" :class="{ active: activePage === 'webhooks' }" @click="emit('open-webhooks')" title="Webhooks">
+      <button class="nav-item-icon" :class="{ active: activePage === 'automations' }" @click="emit('open-automations')" title="Automations">
         <Webhook :size="18" />
       </button>
     </nav>

--- a/web/src/components/WebhooksPage.vue
+++ b/web/src/components/WebhooksPage.vue
@@ -39,9 +39,12 @@ import {
   type WebhookPresetId,
 } from '../utils/webhooks'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   projects: ProjectInfo[]
-}>()
+  embedded?: boolean
+}>(), {
+  embedded: false,
+})
 
 const emit = defineEmits<{
   selectSession: [session: Session]
@@ -86,6 +89,7 @@ const endpointPanel = ref<HTMLElement | null>(null)
 
 const form = ref(defaultForm())
 
+const isEmbedded = computed(() => props.embedded)
 const selectedSource = computed(() => sources.value.find((source) => source.id === selectedSourceId.value) || null)
 const selectedRuns = computed(() => {
   if (!selectedSourceId.value) return runs.value
@@ -596,8 +600,8 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="webhooks-page">
-    <header class="webhooks-header">
+  <div class="webhooks-page" :class="{ embedded: isEmbedded }">
+    <header v-if="!isEmbedded" class="webhooks-header">
       <div>
         <h1>Webhooks</h1>
         <div class="header-meta">
@@ -1135,6 +1139,11 @@ onUnmounted(() => {
   font-family: var(--font-sans);
   line-height: 1.45;
   overflow: auto;
+}
+
+.webhooks-page.embedded {
+  padding: 0;
+  overflow: visible;
 }
 
 .webhooks-header,

--- a/web/src/components/WebhooksPage.vue
+++ b/web/src/components/WebhooksPage.vue
@@ -1171,7 +1171,7 @@ onUnmounted(() => {
   margin: 0;
   font-family: var(--font-sans);
   font-weight: 650;
-  line-height: 1.15;
+  line-height: 1.2;
 }
 
 .webhooks-header h1 {
@@ -1286,19 +1286,15 @@ onUnmounted(() => {
   gap: var(--space-sm);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 650;
   text-transform: uppercase;
   margin-bottom: var(--space-sm);
 }
 
-code,
-textarea {
-  font-family: var(--font-sans);
-}
-
 code {
+  font-family: var(--font-mono);
   word-break: break-all;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 1.45;
 }
@@ -1336,6 +1332,7 @@ code {
   font-size: 15px;
   font-family: var(--font-sans);
   font-weight: 650;
+  line-height: 1.2;
 }
 
 .panel h3 {
@@ -1387,7 +1384,11 @@ code {
 }
 
 .source-copy span,
-.source-runs,
+.source-runs {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .detail-header p,
 .muted-text,
 .hint,
@@ -1395,18 +1396,18 @@ code {
 .mcp-group span,
 .summary-line {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 13px;
 }
 
 .detail-header {
   justify-content: space-between;
   gap: var(--space-md);
-  padding: var(--space-lg);
+  padding: var(--space-md);
   border-bottom: 0.5px solid var(--border-default);
 }
 
 .detail-header p {
-  margin: var(--space-xs) 0 0;
+  margin: 2px 0 0;
 }
 
 .detail-grid {
@@ -1446,7 +1447,7 @@ code {
   margin: var(--space-md) 0 var(--space-sm);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 650;
 }
 
 .help-tip {
@@ -1525,13 +1526,16 @@ code {
 label {
   display: grid;
   gap: var(--space-xs);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
 }
 
 label span,
 .section-title {
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 650;
 }
 
 input,
@@ -1539,11 +1543,12 @@ select,
 textarea,
 .endpoint-row {
   width: 100%;
+  min-width: 0;
   border: 0.5px solid var(--border-default);
   border-radius: var(--radius-md);
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-family: var(--font-sans);
+  font: inherit;
   font-size: 13px;
 }
 
@@ -1556,7 +1561,7 @@ textarea:focus {
 
 input,
 select {
-  height: 38px;
+  height: 36px;
   padding: 0 var(--space-sm);
 }
 
@@ -1564,6 +1569,7 @@ textarea {
   min-height: 120px;
   padding: var(--space-sm);
   resize: vertical;
+  line-height: 1.45;
 }
 
 .prompt-template {
@@ -1767,14 +1773,14 @@ textarea {
 
 .preview-card pre,
 .run-detail pre {
-  font-family: var(--font-sans);
+  font-family: var(--font-mono);
   margin: var(--space-xs) 0 0;
   max-height: 230px;
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .chips {
@@ -1783,11 +1789,14 @@ textarea {
 }
 
 .chip {
-  border: 0.5px solid var(--border-default);
-  border-radius: 999px;
-  padding: 4px 9px;
-  background: var(--bg-secondary);
-  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 24px;
+  border-radius: var(--radius-full);
+  padding: 0 8px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
   font-size: 12px;
 }
 
@@ -1847,7 +1856,7 @@ textarea {
   border: 0;
   background: transparent;
   color: var(--accent);
-  font-weight: 700;
+  font-weight: 650;
   cursor: pointer;
 }
 
@@ -1871,36 +1880,35 @@ textarea {
 .pill {
   display: inline-flex;
   align-items: center;
-  min-height: 24px;
-  border-radius: 999px;
-  padding: 0 9px;
+  justify-content: center;
+  min-height: 22px;
+  border-radius: var(--radius-full);
+  padding: 0 8px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
   font-size: 12px;
-  font-family: var(--font-sans);
-  border: 0.5px solid var(--border-default);
+  font-weight: 650;
+  white-space: nowrap;
 }
 
 .pill.ok {
   color: var(--success);
   background: var(--success-subtle);
-  border-color: transparent;
 }
 
 .pill.warn {
   color: var(--warning);
   background: var(--warning-subtle);
-  border-color: transparent;
 }
 
 .pill.danger {
   color: var(--error);
   background: var(--error-subtle);
-  border-color: transparent;
 }
 
 .pill.blue {
   color: var(--accent);
   background: var(--accent-subtle);
-  border-color: transparent;
 }
 
 .pill.muted {
@@ -1911,6 +1919,10 @@ textarea {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-elevated);
+  border: 0.5px solid var(--border-default);
+  border-radius: var(--radius-md);
   margin-bottom: var(--space-md);
   color: var(--success);
 }

--- a/web/src/components/WebhooksPage.vue
+++ b/web/src/components/WebhooksPage.vue
@@ -472,8 +472,18 @@ async function refreshRuns() {
 
 async function copyText(text: string) {
   if (!text) return
-  await navigator.clipboard?.writeText(text)?.catch(() => undefined)
-  notice.value = 'Copied.'
+  error.value = ''
+  notice.value = ''
+  if (!navigator.clipboard?.writeText) {
+    error.value = 'Clipboard is not available in this browser.'
+    return
+  }
+  try {
+    await navigator.clipboard.writeText(text)
+    notice.value = 'Copied.'
+  } catch {
+    error.value = 'Unable to copy to clipboard.'
+  }
 }
 
 async function openRunSession(run: WebhookRun) {

--- a/web/src/components/WebhooksPage.vue
+++ b/web/src/components/WebhooksPage.vue
@@ -472,7 +472,7 @@ async function refreshRuns() {
 
 async function copyText(text: string) {
   if (!text) return
-  await navigator.clipboard?.writeText(text).catch(() => undefined)
+  await navigator.clipboard?.writeText(text)?.catch(() => undefined)
   notice.value = 'Copied.'
 }
 


### PR DESCRIPTION
# 描述 / Summary

本 PR 补齐 Nine1Bot 的自动化入口能力：在现有 Webhook 接入点基础上，新增 Scheduled Tasks，并把两者统一收敛到 `Automations` 页面。后端新增通用 headless controller 运行链路，Webhook 和 Schedule 都通过同一条 Controller -> AgentRunSpec -> Runtime 路径启动无人值守 agent run，避免后续两套自动化入口逻辑漂移。

同时包含 Webhook 管理 UI、Schedule 管理 UI，以及最近发现的 Schedule 编辑态被轮询刷新覆盖的问题修复。

## 类型 / Type of change

- [x] 新功能 (feature)
- [x] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [x] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

无

## 变更点 / What changed

- 新增 Webhook 后端域与管理接口：支持 webhook source、secret、request guards、payload mapping、prompt template、runtime profile、permission policy、run records。
- 新增 Webhook 前端管理页：支持创建、编辑、删除、刷新 secret、复制 endpoint、发送测试 payload、查看运行记录并跳转 session。
- 新增通用 `runAutomatedControllerSession(...)`：复用 controller session/message 路径，监听 session idle/error、permission/question 等事件，并把结果回填到自动化 run record。
- 新增 Schedule 后端域与 API：支持 `once-after`、`daily`、`interval` 三种规则，保存 scheduled task/run，支持手动运行、自动扫描触发、运行记录分页查询。
- 新增 Schedule scanner：全局扫描 due task；第一版固定 overlap skip、misfire skip，每次 run 创建新 session。
- 扩展 runtime entry source：加入 `webhook` / `schedule` entry，使自动化入口在 AgentRunSpec 中可追踪来源。
- 新增 Automations 页面：侧栏入口从 Webhooks 合并为 Automations，页面内提供 Webhooks / Schedules 两个 tab。
- 新增 Scheduled Tasks UI：支持创建、编辑、启停、删除、手动运行、运行记录查看、session 跳转、timezone 选择、model/MCP runtime profile 配置。
- 修复 Schedule 编辑体验：轮询刷新任务列表时不再重置当前正在编辑的表单内容。
- 统一 UI 观感：将 Webhooks 页面的字体层级、label、pill/chip、notice 和 code/pre 样式同步到 Schedules 页面的视觉风格。
- 新增/更新测试覆盖：webhook preset/preview、webhook 后端行为、schedule 纯逻辑、schedule routes fake runner 场景。

## 如何测试 / How to test

已执行：

1. `bun run build:web`
2. 预期结果：Vue typecheck 和 Vite build 均通过。

建议 reviewer 或合并前补充执行：

1. `cd opencode/packages/opencode && bun test test/webhook/webhook.test.ts test/scheduler.test.ts test/schedule/schedule.test.ts test/server/schedules-routes.test.ts`
2. `cd opencode/packages/opencode && bun run typecheck`
3. 手动打开 Automations 页面，验证 Webhooks tab 原功能可用。
4. 在 Schedules tab 创建/编辑/禁用/删除 task，验证编辑时不会被刷新重置。
5. 手动运行一个 schedule，确认 run record 刷新，并且有 sessionID 时可以跳转到对应 session。

## 截图（UI 变更时提供）/ Screenshots for UI changed

本 PR 暂未附截图。建议重点查看 Automations 页面下的 Webhooks / Schedules 两个 tab。

## Checklist（合并前请确认） / Checklist

- [x] 前端构建已通过：`bun run build:web`
- [x] 不提供 cron，不提供 agent 选择，符合第一版 scope
- [x] Schedule overlap/misfire 第一版保持 skip
- [x] Schedule 每次 run 创建新 session
- [x] Full permission policy 仍走自动 allow-session
- [ ] 合并前建议补跑 opencode 后端测试与 typecheck

## 备注 / Notes for reviewers

- Review 建议优先看 `opencode/packages/opencode/src/server/routes/automated-controller.ts`，这是 Webhook 和 Schedule 共用的无人值守 controller 入口。
- Schedule 第一版只做本机单进程 scanner 和进程内锁，暂未做分布式锁、完整 cron、agent 选择。
- Route tests 通过 fake runner 验证 manual run，不触发真实 agent session，避免污染真实会话记录。
- `SchedulesPage.vue` 里刻意避免在普通轮询刷新时重新 load form，只有切换 task、创建成功、保存成功时才回填表单。