### PR TITLE
Feature : add CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         run: cd packages/nine1bot && bun run typecheck || echo "Typecheck completed with warnings"
         continue-on-error: true
 
+      - name: Test nine1bot
+        run: cd packages/nine1bot && bun test
+
   build:
     strategy:
       fail-fast: false

--- a/opencode/packages/opencode/src/browser/bridge.ts
+++ b/opencode/packages/opencode/src/browser/bridge.ts
@@ -33,6 +33,10 @@ export function setBridgeServer(bridge: BridgeServer): void {
   instance = bridge
 }
 
+export function clearBridgeServer(): void {
+  instance = null
+}
+
 export function getBridgeServer(): BridgeServer | null {
   return instance
 }

--- a/packages/nine1bot/package.json
+++ b/packages/nine1bot/package.json
@@ -11,6 +11,7 @@
     "dev": "bun run --conditions=browser ./src/index.ts",
     "build": "bun build ./src/index.ts --outdir=./dist --target=bun",
     "start": "bun run ./src/index.ts",
+    "test": "bun test",
     "typecheck": "tsc --project tsconfig.check.json"
   },
   "dependencies": {

--- a/packages/nine1bot/src/config/compatibility.test.ts
+++ b/packages/nine1bot/src/config/compatibility.test.ts
@@ -30,6 +30,17 @@ async function materializeFixture(relativePath: string): Promise<string> {
   return targetPath
 }
 
+async function createIsolatedUserDirs(): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'nine1bot-home-'))
+  tempDirs.push(root)
+
+  process.env.HOME = root
+  process.env.USERPROFILE = root
+  process.env.XDG_DATA_HOME = join(root, '.local', 'share')
+  process.env.LOCALAPPDATA = join(root, 'AppData', 'Local')
+  process.env.APPDATA = join(root, 'AppData', 'Roaming')
+}
+
 function snapshotEnv(): NodeJS.ProcessEnv {
   return { ...process.env }
 }
@@ -144,9 +155,17 @@ describe('legacy config compatibility', () => {
 
   for (const fixture of supportedFixtures) {
     it(`loads supported legacy fixture: ${fixture.name}`, async () => {
+      const envSnapshot = snapshotEnv()
       const configPath = await materializeFixture(fixture.path)
-      const config = await loadConfig(configPath)
-      fixture.assert(config)
+
+      try {
+        delete process.env.NINE1BOT_COMPAT_OPENAI_API_KEY
+
+        const config = await loadConfig(configPath)
+        fixture.assert(config)
+      } finally {
+        restoreEnv(envSnapshot)
+      }
     })
   }
 
@@ -188,6 +207,8 @@ describe('legacy config compatibility', () => {
     let result: Awaited<ReturnType<typeof launch>> | undefined
 
     try {
+      await createIsolatedUserDirs()
+
       result = await launch({
         configPath,
         port: 0,

--- a/packages/nine1bot/src/config/compatibility.test.ts
+++ b/packages/nine1bot/src/config/compatibility.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { launch, shutdown } from '../launcher/orchestrator'
+import { loadConfig } from './loader'
+import type { Nine1BotConfig } from './schema'
+
+const fixtureRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'compat',
+)
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function materializeFixture(relativePath: string): Promise<string> {
+  const sourcePath = join(fixtureRoot, relativePath)
+  const dir = await mkdtemp(join(tmpdir(), 'nine1bot-compat-'))
+  tempDirs.push(dir)
+  const targetPath = join(dir, 'nine1bot.config.jsonc')
+  await writeFile(targetPath, await readFile(sourcePath, 'utf-8'), 'utf-8')
+  return targetPath
+}
+
+describe('legacy config compatibility', () => {
+  const supportedFixtures: Array<{
+    name: string
+    path: string
+    assert: (config: Nine1BotConfig) => void
+  }> = [
+    {
+      name: 'minimal v1 config',
+      path: 'supported/minimal-v1.jsonc',
+      assert: (config) => {
+        expect(config.server.port).toBe(4107)
+        expect(config.server.hostname).toBe('127.0.0.1')
+        expect(config.server.openBrowser).toBe(false)
+        expect(config.auth.enabled).toBe(false)
+        expect(config.tunnel.enabled).toBe(false)
+        expect(config.browser.enabled).toBe(false)
+        expect(config.runtime.agentRunSpec.enabled).toBe(true)
+      },
+    },
+    {
+      name: 'OpenCode-style user config',
+      path: 'supported/opencode-style-v1.jsonc',
+      assert: (config) => {
+        expect(config.model).toBe('openai/gpt-4.1')
+        expect(config.small_model).toBe('openai/gpt-4.1-mini')
+        expect(config.default_agent).toBe('coder')
+        expect(config.agent?.coder?.mode).toBe('primary')
+        expect(config.permission?.bash).toBe('ask')
+        expect(config.permission?.webfetch).toBe('deny')
+        expect(config.instructions).toEqual(['Prefer small, reviewable changes.'])
+        expect(config.skills.inheritOpencode).toBe(false)
+        expect(config.mcp?.local_docs).toMatchObject({
+          type: 'local',
+          enabled: false,
+          command: ['node', 'server.js'],
+        })
+        expect(config.provider?.openai).toMatchObject({
+          options: {
+            apiKey: 'test-key',
+            timeout: false,
+          },
+          whitelist: ['gpt-4.1', 'gpt-4.1-mini'],
+        })
+      },
+    },
+    {
+      name: 'remote MCP OAuth config',
+      path: 'supported/remote-mcp-oauth-v1.jsonc',
+      assert: (config) => {
+        expect(config.mcp?.inheritOpencode).toBe(false)
+        expect(config.mcp?.remote_docs).toEqual({
+          type: 'remote',
+          url: 'https://mcp.example.com/http',
+          enabled: true,
+          oauth: {
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            scope: 'read write',
+          },
+          headers: {
+            'X-Test': 'compat',
+          },
+          timeout: 30000,
+        })
+      },
+    },
+    {
+      name: 'custom provider config',
+      path: 'supported/custom-provider-v1.jsonc',
+      assert: (config) => {
+        expect(config.model).toBe('compat-openai/compat-chat')
+        expect(config.customProviders['compat-openai']).toEqual({
+          name: 'Compat OpenAI',
+          protocol: 'openai',
+          baseURL: 'https://llm.example.com/v1',
+          models: [
+            {
+              id: 'compat-chat',
+              name: 'Compat Chat',
+            },
+          ],
+          options: {
+            timeout: false,
+            headers: {
+              'X-Compat': 'true',
+            },
+          },
+        })
+      },
+    },
+  ]
+
+  for (const fixture of supportedFixtures) {
+    it(`loads supported legacy fixture: ${fixture.name}`, async () => {
+      const configPath = await materializeFixture(fixture.path)
+      const config = await loadConfig(configPath)
+      fixture.assert(config)
+    })
+  }
+
+  const deprecatedFixtures = [
+    {
+      name: 'deprecated MCP browser config',
+      path: 'deprecated/mcp-browser.jsonc',
+      field: 'mcp.browser',
+      hint: 'remove mcp.browser',
+    },
+    {
+      name: 'deprecated browser bridge port config',
+      path: 'deprecated/browser-bridge-port.jsonc',
+      field: 'browser.bridgePort',
+      hint: 'remove bridgePort',
+    },
+  ]
+
+  for (const fixture of deprecatedFixtures) {
+    it(`rejects ${fixture.name} with a stable migration message`, async () => {
+      const configPath = await materializeFixture(fixture.path)
+
+      try {
+        await loadConfig(configPath)
+        throw new Error('Expected legacy config to be rejected')
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        expect(message).toContain('Invalid config')
+        expect(message).toContain(fixture.field)
+        expect(message).toContain('deprecated')
+        expect(message).toContain(fixture.hint)
+      }
+    })
+  }
+
+  it('starts with a supported minimal legacy config', async () => {
+    const configPath = await materializeFixture('supported/minimal-v1.jsonc')
+    const result = await launch({
+      configPath,
+      port: 0,
+      hostname: '127.0.0.1',
+      noBrowser: true,
+    })
+
+    try {
+      expect(result.localUrl).toContain('http://127.0.0.1:')
+      expect(result.configPath).toBe(configPath)
+    } finally {
+      await shutdown(result)
+    }
+  })
+})

--- a/packages/nine1bot/src/config/compatibility.test.ts
+++ b/packages/nine1bot/src/config/compatibility.test.ts
@@ -30,6 +30,26 @@ async function materializeFixture(relativePath: string): Promise<string> {
   return targetPath
 }
 
+function snapshotEnv(): NodeJS.ProcessEnv {
+  return { ...process.env }
+}
+
+function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 describe('legacy config compatibility', () => {
   const supportedFixtures: Array<{
     name: string
@@ -163,19 +183,25 @@ describe('legacy config compatibility', () => {
   }
 
   it('starts with a supported minimal legacy config', async () => {
+    const envSnapshot = snapshotEnv()
     const configPath = await materializeFixture('supported/minimal-v1.jsonc')
-    const result = await launch({
-      configPath,
-      port: 0,
-      hostname: '127.0.0.1',
-      noBrowser: true,
-    })
+    let result: Awaited<ReturnType<typeof launch>> | undefined
 
     try {
+      result = await launch({
+        configPath,
+        port: 0,
+        hostname: '127.0.0.1',
+        noBrowser: true,
+      })
+
       expect(result.localUrl).toContain('http://127.0.0.1:')
       expect(result.configPath).toBe(configPath)
     } finally {
-      await shutdown(result)
+      if (result) {
+        await shutdown(result)
+      }
+      restoreEnv(envSnapshot)
     }
   })
 })

--- a/packages/nine1bot/src/config/fixtures/compat/deprecated/browser-bridge-port.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/deprecated/browser-bridge-port.jsonc
@@ -1,0 +1,9 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true
+  },
+  "browser": {
+    "enabled": true,
+    "bridgePort": 18793
+  }
+}

--- a/packages/nine1bot/src/config/fixtures/compat/deprecated/mcp-browser.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/deprecated/mcp-browser.jsonc
@@ -1,0 +1,15 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true
+  },
+  "browser": {
+    "enabled": true
+  },
+  "mcp": {
+    "browser": {
+      "type": "local",
+      "enabled": true,
+      "command": ["node", "browser-mcp.js"]
+    }
+  }
+}

--- a/packages/nine1bot/src/config/fixtures/compat/supported/custom-provider-v1.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/supported/custom-provider-v1.jsonc
@@ -1,0 +1,42 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true,
+    "disableProjectConfig": true,
+    "inheritOpencode": false
+  },
+  "model": "compat-openai/compat-chat",
+  "customProviders": {
+    "compat-openai": {
+      "name": "Compat OpenAI",
+      "protocol": "openai",
+      "baseURL": "https://llm.example.com/v1",
+      "models": [
+        {
+          "id": "compat-chat",
+          "name": "Compat Chat"
+        }
+      ],
+      "options": {
+        "timeout": false,
+        "headers": {
+          "X-Compat": "true"
+        }
+      }
+    }
+  },
+  "server": {
+    "openBrowser": false
+  },
+  "auth": {
+    "enabled": false
+  },
+  "tunnel": {
+    "enabled": false
+  },
+  "browser": {
+    "enabled": false
+  },
+  "feishu": {
+    "enabled": false
+  }
+}

--- a/packages/nine1bot/src/config/fixtures/compat/supported/minimal-v1.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/supported/minimal-v1.jsonc
@@ -1,0 +1,24 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true,
+    "disableProjectConfig": true,
+    "inheritOpencode": false
+  },
+  "server": {
+    "port": 4107,
+    "hostname": "127.0.0.1",
+    "openBrowser": false
+  },
+  "auth": {
+    "enabled": false
+  },
+  "tunnel": {
+    "enabled": false
+  },
+  "browser": {
+    "enabled": false
+  },
+  "feishu": {
+    "enabled": false
+  }
+}

--- a/packages/nine1bot/src/config/fixtures/compat/supported/opencode-style-v1.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/supported/opencode-style-v1.jsonc
@@ -47,7 +47,7 @@
     "inheritOpencode": false,
     "openai": {
       "options": {
-        "apiKey": "{env:OPENAI_API_KEY:test-key}",
+        "apiKey": "{env:NINE1BOT_COMPAT_OPENAI_API_KEY:test-key}",
         "timeout": false
       },
       "whitelist": ["gpt-4.1", "gpt-4.1-mini"]

--- a/packages/nine1bot/src/config/fixtures/compat/supported/opencode-style-v1.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/supported/opencode-style-v1.jsonc
@@ -1,0 +1,71 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true,
+    "disableProjectConfig": true,
+    "inheritOpencode": false
+  },
+  "model": "openai/gpt-4.1",
+  "small_model": "openai/gpt-4.1-mini",
+  "default_agent": "coder",
+  "agent": {
+    "coder": {
+      "model": "openai/gpt-4.1",
+      "prompt": "Use the repository conventions and keep changes focused.",
+      "temperature": 0.2,
+      "mode": "primary"
+    }
+  },
+  "permission": {
+    "read": "allow",
+    "edit": {
+      "default": "ask",
+      "deny": ["**/.env"]
+    },
+    "bash": "ask",
+    "webfetch": "deny"
+  },
+  "instructions": [
+    "Prefer small, reviewable changes."
+  ],
+  "skills": {
+    "inheritOpencode": false,
+    "inheritClaudeCode": true
+  },
+  "mcp": {
+    "inheritOpencode": false,
+    "inheritClaudeCode": true,
+    "local_docs": {
+      "type": "local",
+      "command": ["node", "server.js"],
+      "enabled": false,
+      "environment": {
+        "DOCS_MODE": "offline"
+      }
+    }
+  },
+  "provider": {
+    "inheritOpencode": false,
+    "openai": {
+      "options": {
+        "apiKey": "{env:OPENAI_API_KEY:test-key}",
+        "timeout": false
+      },
+      "whitelist": ["gpt-4.1", "gpt-4.1-mini"]
+    }
+  },
+  "server": {
+    "openBrowser": false
+  },
+  "auth": {
+    "enabled": false
+  },
+  "tunnel": {
+    "enabled": false
+  },
+  "browser": {
+    "enabled": false
+  },
+  "feishu": {
+    "enabled": false
+  }
+}

--- a/packages/nine1bot/src/config/fixtures/compat/supported/remote-mcp-oauth-v1.jsonc
+++ b/packages/nine1bot/src/config/fixtures/compat/supported/remote-mcp-oauth-v1.jsonc
@@ -1,0 +1,39 @@
+{
+  "isolation": {
+    "disableGlobalConfig": true,
+    "disableProjectConfig": true,
+    "inheritOpencode": false
+  },
+  "mcp": {
+    "inheritOpencode": false,
+    "remote_docs": {
+      "type": "remote",
+      "url": "https://mcp.example.com/http",
+      "enabled": true,
+      "oauth": {
+        "clientId": "client-id",
+        "clientSecret": "client-secret",
+        "scope": "read write"
+      },
+      "headers": {
+        "X-Test": "compat"
+      },
+      "timeout": 30000
+    }
+  },
+  "server": {
+    "openBrowser": false
+  },
+  "auth": {
+    "enabled": false
+  },
+  "tunnel": {
+    "enabled": false
+  },
+  "browser": {
+    "enabled": false
+  },
+  "feishu": {
+    "enabled": false
+  }
+}

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -9,7 +9,7 @@ import { registerGitLabPlatformAdapter } from '../platform/gitlab'
 import { Server as OpencodeServer } from '../../../../opencode/packages/opencode/src/server/server'
 import { BridgeServer } from '../../../browser-mcp-server/src/bridge/server'
 import type { BridgeServer as OpencodeBridgeServer } from '../../../../opencode/packages/opencode/src/browser/bridge'
-import { setBridgeServer } from '../../../../opencode/packages/opencode/src/browser/bridge'
+import { clearBridgeServer, setBridgeServer } from '../../../../opencode/packages/opencode/src/browser/bridge'
 
 /**
  * 判断是否是发行版模式
@@ -294,10 +294,27 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
     hostname: serverInstance.hostname ?? server.hostname,
     port: serverInstance.port ?? server.port,
     stop: async () => {
+      let stopError: unknown
+
       if (bridgeServer) {
-        try { await bridgeServer.stop() } catch { /* ignore */ }
+        try {
+          await bridgeServer.stop()
+        } catch (error) {
+          stopError = error
+        } finally {
+          clearBridgeServer()
+        }
       }
-      (serverInstance as any).server?.stop?.()
+
+      try {
+        await serverInstance.stop(true)
+      } catch (error) {
+        stopError ??= error
+      }
+
+      if (stopError) {
+        throw stopError
+      }
     },
   }
 }


### PR DESCRIPTION
# 描述 / Summary

<!-- 请简要描述本次变更做了什么，为什么做这次改动 -->
为旧配置兼容性补充自动化测试保护，防止后续配置结构、字段校验或默认值处理变更导致老用户升级后启动失败。  
本次覆盖“旧配置仍可加载/启动”和“已废弃配置给出稳定明确报错”两类场景，并把测试接入 CI。
## 类型 / Type of change

- [ ] 新功能 (feature)
- [ ] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [x] 其他 (describe): 测试覆盖 / CI

## 关联的 issue（如果有）/ Related issues

/（例如：Fixes #123）/
Fixes #27
## 变更点 / What changed
- 新增旧配置兼容性测试 `packages/nine1bot/src/config/compatibility.test.ts`
- 新增 supported/deprecated 两类旧配置 fixtures
- 覆盖旧配置正常加载、最小旧配置启动 smoke test、废弃配置稳定报错
- 启动 smoke test 会在结束后恢复 `process.env`，避免污染后续测试
- 为 `packages/nine1bot` 增加 `bun test` 脚本
- CI 新增阻塞式 `Test nine1bot` 步骤，确保 PR 流程自动执行兼容性测试


## 如何测试 / How to test

1. 进入 `packages/nine1bot`
2. 执行 `bun test`
3. 预期结果：全部测试通过，包括旧配置兼容性测试与现有 config loader 测试

## 截图（UI 变更时提供）/ Screenshots for UI changed

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

<!-- 给 reviewer 的注意事项（比如哪些文件或逻辑需要重点审查） -->
