### PR TITLE
feat(platform): add runtime sources for platform adapters

### DIFF
--- a/docs/agent-runtime-developer-guide/09-platform-adapter-development-guide.md
+++ b/docs/agent-runtime-developer-guide/09-platform-adapter-development-guide.md
@@ -1,71 +1,83 @@
-# 多平台适配层开发参考
+# 多平台适配层开发技术文档
 
-这份文档面向要新增平台适配层的开发者。它整合了平台边界、Platform Adapter Manager 设计和当前 GitLab 样板实现，说明一个新平台应该放在哪里、导出什么、如何注册、如何展示配置、如何进入 runtime，以及如何验证不会绕过 Manager。
+这份文档面向开发新的平台适配层的同学，说明一个平台适配包应该放在哪里、导出什么、如何注册到 Nine1Bot、如何参与 Controller / Runtime，以及如何验证它没有破坏核心 Runtime 的轻量化。
 
-多平台适配的目标是让 GitLab、GitHub、Jira、飞书文档等深度适配像内置插件一样可启用、可禁用、可展示、可审计，同时保持 Agent Runtime / opencode core 的轻量和稳定。当前阶段只支持内置平台插件化，平台包仍随 Nine1Bot workspace 一起发布；外部平台安装、平台市场、本地路径加载等动态扩展能力只保留协议余量。
+当前平台适配只支持 **内置平台插件化**：平台包跟随 Nine1Bot workspace 一起发布，由 Nine1Bot 产品层的 Platform Adapter Manager 统一发现、配置、启用、禁用和注册。外部平台市场、本地动态安装、第三方包热加载暂不在当前范围内。
 
-## 架构分层
+## 1. 核心原则
+
+- 平台语义必须放在 `packages/platform-*`，不要写进 `opencode/packages/opencode/src/runtime`。
+- Runtime core 只保留通用协议、registry、context pipeline、resource resolver、agent / skill source 扫描逻辑。
+- Nine1Bot 产品层负责平台启用状态、配置、secret、status、action、Web 设置页和 runtime 注册。
+- Browser extension 只在用户发送消息时采集页面事实，不做后台监听，也不承担复杂平台业务解释。
+- 平台贡献 context / resources / agents / skills 必须经过 Platform Adapter Manager 和 runtime registry，不能绕过 Manager。
+- 平台禁用是 hard gate：新 session 不使用该平台 template/resource/source，旧 session 后续 turn 也不能继续获得该平台能力。
+- 平台资源默认应使用 `declared-only` 或 `recommendable`，避免污染普通 Web 对话和 default-user-template。
+
+## 2. 架构总览
 
 ```mermaid
 flowchart TD
-  WebConfig["Web 配置页\n配置 > 多平台 > GitLab"] --> PlatformAPI["Nine1Bot Platform API"]
-  PlatformAPI --> PlatformManager["Platform Adapter Manager"]
-  PlatformManager --> Builtin["内置平台 contribution 清单"]
-  PlatformManager --> Config["nine1bot.config platforms"]
-  PlatformManager --> Secrets["Platform Secret Store"]
-  PlatformManager --> RuntimeRegistry["RuntimePlatformAdapterRegistry"]
-  RuntimeRegistry --> TemplateResolver["ControllerTemplateResolver"]
-  RuntimeRegistry --> ContextEvents["RuntimeContextEvents"]
-  RuntimeRegistry --> ResourceResolver["RuntimeResourceResolver"]
-  GitLabPkg["packages/platform-gitlab"] --> Builtin
-  OtherPkg["packages/platform-*"] --> Builtin
+  PlatformPkg["packages/platform-<id>"] --> Contribution["PlatformAdapterContribution"]
+  Contribution --> Builtin["builtinPlatformContributions"]
+  Builtin --> Manager["Platform Adapter Manager"]
+
+  Config["nine1bot.config.platforms"] --> Manager
+  Secrets["Platform Secret Store"] --> Manager
+  WebSettings["Web 设置页\n配置 > 多平台"] --> PlatformAPI["/nine1bot/platforms API"]
+  PlatformAPI --> Manager
+
+  Manager --> PlatformRegistry["RuntimePlatformAdapterRegistry"]
+  Manager --> SourceRegistry["RuntimeSourceRegistry"]
+
+  PlatformRegistry --> TemplateResolver["ControllerTemplateResolver"]
+  PlatformRegistry --> ContextEvents["RuntimeContextEvents"]
+  PlatformRegistry --> ResourceResolver["RuntimeResourceResolver"]
+
+  SourceRegistry --> AgentRegistry["Agent Registry"]
+  SourceRegistry --> SkillRegistry["Skill Registry"]
+  AgentRegistry --> ProfileCompiler["SessionProfileCompiler"]
+  SkillRegistry --> ResourceResolver
+
+  TemplateResolver --> Profile["profileSnapshot"]
+  ProfileCompiler --> Profile
+  ResourceResolver --> PromptLoop["SessionPrompt / Agent Loop"]
+  ContextEvents --> History["Context Events"]
 ```
 
-每一层职责：
+关键点：
 
-- `packages/platform-*`：平台语义、URL/page parser、browser-safe helper、runtime adapter、descriptor、status/action handler。
-- `packages/platform-protocol`：平台包和 Nine1Bot 产品层共享的结构类型，不依赖 runtime core。
-- `PlatformAdapterManager`：读取平台配置、管理 enable/disable、保存 secret、注册/注销 runtime adapter、暴露平台 API。
-- `RuntimePlatformAdapterRegistry`：runtime core 内的通用 registry，只知道 adapter 协议，不知道 GitLab/GitHub/Jira 等具体平台。
-- `ControllerTemplateResolver`：新建 session 时消费当前启用平台的 template/context/resource contribution。
-- `RuntimeContextEvents`：每轮消息按当前启用平台解释 `context.page`，并写入 context event。
-- `RuntimeResourceResolver`：对 profileSnapshot 中声明过的资源继续应用当前配置 live gate。
+- `PlatformAdapterContribution` 是平台包对外提供能力的统一入口。
+- `RuntimePlatformAdapterRegistry` 只接收通用 adapter，不 import 具体平台包。
+- `RuntimeSourceRegistry` 只保存 agent / skill source 元数据，文件扫描由 Agent / Skill registry 完成。
+- `profileSnapshot` 是 session 创建时冻结的平台能力声明；后续 turn 只在该声明内做 live gate。
 
-核心原则：
+## 3. 当前实现地图
 
-- 平台代码必须放在 `packages/platform-*`，不能写进 runtime core。
-- 平台启用、禁用、状态、配置、secret、action 都由 Platform Manager 收口。
-- Controller/template/context/resource 只消费当前启用的平台 adapter。
-- 禁用平台是 hard gate：不能贡献新 session template/resource，也不能继续解释旧 session 后续 turn 的平台 page payload。
-- 历史 context event 不因平台禁用而删除。
+核心文件：
 
-## 当前实现地图
-
-核心文件如下：
-
-- `packages/platform-protocol/src/index.ts`：平台 descriptor / contribution / config / action / secret / runtime adapter 的共享协议类型。
-- `packages/platform-gitlab/`：GitLab 参考实现，后续平台包按这个结构复制。
-- `packages/nine1bot/src/platform/manager.ts`：Nine1Bot 产品层 Platform Adapter Manager。
-- `packages/nine1bot/src/platform/builtin.ts`：内置平台 contribution 清单与注册入口。
-- `packages/nine1bot/src/platform/config-store.ts`：`platforms` 配置持久化 helper。
+- `packages/platform-protocol/src/index.ts`：平台 descriptor、contribution、config、secret、action、runtime adapter、runtime sources 的共享类型。
+- `packages/platform-gitlab/`：当前 GitLab 样板平台包。
+- `packages/nine1bot/src/platform/manager.ts`：Platform Adapter Manager。
+- `packages/nine1bot/src/platform/builtin.ts`：内置平台 contribution 清单。
+- `packages/nine1bot/src/platform/config-store.ts`：只更新 `nine1bot.config` 中 `platforms` 字段的持久化 helper。
 - `packages/nine1bot/src/platform/secrets.ts`：本地平台 secret store。
-- `opencode/packages/opencode/src/runtime/platform/adapter.ts`：runtime core 通用平台 registry。
-- `opencode/packages/opencode/src/runtime/controller/template-resolver.ts`：会话创建时根据 entry/page/template 解析 profile template。
-- `opencode/packages/opencode/src/runtime/context/events.ts`：发送消息时根据 page payload 写入 context event。
-- `opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts`：`/nine1bot/platforms` API。
-- `web/src/components/PlatformManager.vue`：Web `配置 > 多平台` 通用详情页。
-- `packages/browser-extension/src/content/index.ts`：请求式页面采集入口。
+- `opencode/packages/opencode/src/runtime/platform/adapter.ts`：Runtime 平台 adapter registry。
+- `opencode/packages/opencode/src/runtime/source/registry.ts`：Runtime agent / skill source registry。
+- `opencode/packages/opencode/src/agent/agent.ts`：内置 / 用户 / 平台 agent 扫描和可见性控制。
+- `opencode/packages/opencode/src/skill/skill.ts`：默认技能和平台 skill source 扫描。
+- `opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts`：平台管理 API。
+- `web/src/components/PlatformManager.vue`：Web 多平台设置页通用 renderer。
 
-必须遵守的边界：
+边界测试：
 
-- `opencode/packages/opencode/src/runtime` 只能依赖通用 registry 和协议，不能 import `@nine1bot/platform-*`。
-- 第三方平台语义放进 `packages/platform-*`。
-- browser extension 负责采集 DOM 和当前页面事实，不承担复杂平台业务解释。
-- Nine1Bot 产品层负责读取配置、管理启用状态、注册 adapter、保存 secret、暴露平台 API。
+- `opencode/packages/opencode/test/platform/runtime-core-boundary.test.ts`
 
-## 平台包结构
+这个测试会检查 runtime core 是否直接 import 具体平台包。新增平台时如果它失败，通常说明平台语义写错了层。
 
-新增平台使用：
+## 4. 新增平台包结构
+
+新增平台建议使用下面的目录结构：
 
 ```text
 packages/platform-<id>/
@@ -78,30 +90,26 @@ packages/platform-<id>/
     runtime.ts
     shared.ts
     types.ts
+  agents/
+    <optional-platform-agent>.agent.md
+  skills/
+    <optional-platform-skill>/
+      SKILL.md
   test/
     <id>-platform.test.ts
 ```
 
-GitLab 当前结构就是可复制样板：
+文件职责：
 
-```text
-packages/platform-gitlab/
-  src/browser.ts
-  src/runtime.ts
-  src/shared.ts
-  src/types.ts
-  test/gitlab-platform.test.ts
-```
+- `shared.ts`：URL 解析、页面类型识别、payload normalize、稳定 `objectKey` 生成。保持纯函数，便于 browser / runtime / test 复用。
+- `browser.ts`：浏览器安全入口，供 browser extension 或 Web 使用。不要依赖 Node-only API。
+- `runtime.ts`：平台 descriptor、runtime adapter、contribution、status/action handler。
+- `types.ts`：平台内部类型，可以复用或 alias `@nine1bot/platform-protocol` 类型。
+- `agents/`：平台自带 agent source，可选。文件格式是 `*.agent.md`。
+- `skills/`：平台自带 skills source，可选。每个 skill 目录包含 `SKILL.md`。
+- `index.ts`：聚合导出，方便测试和内部引用。
 
-各文件职责：
-
-- `shared.ts`：URL parser、页面类型识别、payload normalize、稳定 objectKey 生成。这里应保持纯函数，方便 browser/runtime/test 共用。
-- `browser.ts`：浏览器安全导出。Web 或 extension 可以使用它构建 page payload、推导 template ids。不要依赖 Node-only API。
-- `runtime.ts`：服务端 runtime adapter、descriptor、contribution。可以依赖 `@nine1bot/platform-protocol`，不要反向依赖 `packages/nine1bot`。
-- `types.ts`：平台包内部类型，必要时 alias 到 `@nine1bot/platform-protocol`。
-- `index.ts`：聚合导出，方便测试或内部引用。
-
-`package.json` 至少需要声明 workspace 包名和导出入口：
+`package.json` 示例：
 
 ```json
 {
@@ -121,9 +129,9 @@ packages/platform-gitlab/
 }
 ```
 
-## Descriptor
+## 5. Descriptor
 
-每个平台必须导出一个可序列化 descriptor。Web 多平台设置页、Platform API 和 Manager 都依赖它展示平台能力和配置入口。
+每个平台必须导出一个可序列化的 `PlatformDescriptor`。Web 设置页、Platform API 和 Manager 都依赖它展示平台能力、配置字段和 action。
 
 ```ts
 import type { PlatformDescriptor } from '@nine1bot/platform-protocol'
@@ -133,6 +141,7 @@ export const examplePlatformDescriptor = {
   name: 'Example',
   packageName: '@nine1bot/platform-example',
   version: '0.1.0',
+  description: 'Example platform integration.',
   defaultEnabled: true,
   capabilities: {
     pageContext: true,
@@ -166,10 +175,11 @@ export const examplePlatformDescriptor = {
   },
   detailPage: {
     sections: [
-      { id: 'status', type: 'status-cards', title: 'Status' },
-      { id: 'settings', type: 'settings-form', title: 'Settings' },
-      { id: 'actions', type: 'action-list', title: 'Actions' },
-      { id: 'recent-events', type: 'event-list', title: 'Recent events' },
+      { id: 'status', title: 'Status', type: 'status-cards' },
+      { id: 'capabilities', title: 'Capabilities', type: 'capability-list' },
+      { id: 'settings', title: 'Settings', type: 'settings-form' },
+      { id: 'actions', title: 'Actions', type: 'action-list' },
+      { id: 'recent-events', title: 'Recent events', type: 'event-list' },
     ],
   },
   actions: [
@@ -182,30 +192,28 @@ export const examplePlatformDescriptor = {
 } satisfies PlatformDescriptor
 ```
 
-字段约定：
+约定：
 
-- `id` 必须稳定，后续配置、secret、audit、registry 都用它作为主键。
-- `capabilities.templates` 必须列出这个平台可能贡献的 template id。禁用平台时，Manager 会用这些 template id 做 runtime live gate。
-- `config.sections[].fields[]` 用于 Web 通用表单渲染。
-- `secret: true` 或 `type: 'password'` 字段不会以明文返回 Web；Platform Manager 会写入 secret store，并在配置里留下 `PlatformSecretRef`。
-- `detailPage.sections` 第一版优先用通用 renderer；只有复杂平台需要额外交互时再使用 `type: 'custom'` 和 `componentKey`。
+- `id` 必须稳定。配置、secret、audit、registry 都用它作为主键。
+- `capabilities.templates` 要列出平台可能贡献的 template id。平台禁用时，Manager 会基于这些 template id 做 live gate。
+- `config.sections[].fields[]` 由 Web 通用表单渲染。
+- `type: 'password'` 或 `secret: true` 的字段不会明文返回 Web。
+- `detailPage.sections` 优先使用通用 section。复杂平台后续可以使用 `type: 'custom'` 和 `componentKey`。
+- 不要在 descriptor 里放函数、token、路径探测结果等运行时对象。
 
-## Runtime Adapter
+## 6. Runtime Adapter
 
-runtime adapter 是平台参与 Controller / Context Pipeline / Resource Resolver 的唯一入口。它由平台包导出，由 Nine1Bot 产品层注册。
+`PlatformRuntimeAdapter` 是平台参与 Controller / Context Pipeline / Resource Resolver 的唯一 Runtime 入口。
 
 ```ts
-import type {
-  PlatformRuntimeAdapter,
-  PlatformResourceContribution,
-} from '@nine1bot/platform-protocol'
+import type { PlatformRuntimeAdapter } from '@nine1bot/platform-protocol'
 
 export function createExamplePlatformAdapter(): PlatformRuntimeAdapter {
   return {
     id: 'example',
 
     matchPage(page) {
-      return page.platform === 'example'
+      return page.platform === 'example' || isExampleUrl(page.url)
     },
 
     normalizePage(page) {
@@ -224,17 +232,19 @@ export function createExamplePlatformAdapter(): PlatformRuntimeAdapter {
     },
 
     blocksFromPage(page, observedAt) {
+      const normalized = this.normalizePage?.(page)
+      if (!normalized) return undefined
       return [
         {
           id: 'platform:example',
           layer: 'platform',
           source: 'page-context.example',
-          content: renderExamplePlatform(page),
+          content: renderExamplePlatformContext(normalized),
           lifecycle: 'turn',
           visibility: 'developer-toggle',
           enabled: true,
           priority: 65,
-          mergeKey: page.objectKey,
+          mergeKey: normalized.objectKey,
           observedAt,
         },
       ]
@@ -242,7 +252,7 @@ export function createExamplePlatformAdapter(): PlatformRuntimeAdapter {
 
     inferTemplateIds(input) {
       if (input.entry?.platform !== 'example' && input.page?.platform !== 'example') return []
-      return ['browser-example', pageTemplateId(input.page)]
+      return ['browser-example', templateIdForPage(input.page)]
     },
 
     templateContextBlocks(input) {
@@ -261,7 +271,7 @@ export function createExamplePlatformAdapter(): PlatformRuntimeAdapter {
       ]
     },
 
-    resourceContributions(input): PlatformResourceContribution | undefined {
+    resourceContributions(input) {
       if (!input.templateIds.includes('browser-example')) return undefined
       return {
         builtinTools: {
@@ -279,22 +289,28 @@ export function createExamplePlatformAdapter(): PlatformRuntimeAdapter {
         },
       }
     },
+
+    recommendedAgent(input) {
+      if (input.templateIds.includes('example-review')) return 'platform.example.coordinator'
+      return undefined
+    },
   }
 }
 ```
 
-实现要点：
+实现规则：
 
-- `normalizePage` 要再次按 URL / raw payload 校验，不完全信任客户端字段。
-- `objectKey` 必须稳定，用于 page context 去重和历史迁移理解。
-- `blocksFromPage` 只生成本轮 page context block，不写存储。
-- `templateContextBlocks` 生成 session 级平台说明，写入 profileSnapshot。
-- `resourceContributions` 只做 add-only 贡献，不能排除用户或其他模板声明的资源。
+- `normalizePage` 必须重新按 URL / raw payload 校验，不完全信任客户端字段。
+- `objectKey` 必须稳定，用于 context event 去重。
+- `blocksFromPage` 只返回本轮 page blocks，不直接写 storage。
+- `templateContextBlocks` 返回 session 级 context blocks，会进入 `profileSnapshot.context`。
+- `resourceContributions` 只能 add-only，不能排除或减少其它资源。
+- `recommendedAgent` 只是 UI 推荐或创建 session 的建议值，不能静默覆盖用户选择。
 - 平台包不要直接调用 `RuntimePlatformAdapterRegistry.register()`。
 
-## Contribution
+## 7. Contribution
 
-平台包还要导出一个 contribution，交给 Platform Manager 使用。
+平台包通过 `PlatformAdapterContribution` 把 descriptor、runtime adapter、runtime sources、status、config validation 和 actions 交给 Platform Manager。
 
 ```ts
 import type { PlatformAdapterContribution } from '@nine1bot/platform-protocol'
@@ -303,6 +319,26 @@ export const examplePlatformContribution = {
   descriptor: examplePlatformDescriptor,
   runtime: {
     createAdapter: createExamplePlatformAdapter,
+    sources: {
+      agents: [
+        {
+          id: 'example-agents',
+          directory: new URL('../agents', import.meta.url).pathname,
+          namespace: 'platform.example',
+          visibility: 'recommendable',
+          lifecycle: 'platform-enabled',
+        },
+      ],
+      skills: [
+        {
+          id: 'example-skills',
+          directory: new URL('../skills', import.meta.url).pathname,
+          namespace: 'platform.example',
+          visibility: 'declared-only',
+          lifecycle: 'platform-enabled',
+        },
+      ],
+    },
   },
   async validateConfig(settings, ctx) {
     return { ok: true }
@@ -322,52 +358,37 @@ export const examplePlatformContribution = {
   },
   async handleAction(actionId, input, ctx) {
     if (actionId === 'connection.test') {
-      return {
-        status: 'ok',
-        message: 'Connection test completed.',
-      }
+      return { status: 'ok', message: 'Connection test completed.' }
     }
-    return {
-      status: 'failed',
-      message: `Unknown action: ${actionId}`,
-    }
+    return { status: 'failed', message: `Unknown action: ${actionId}` }
   },
 } satisfies PlatformAdapterContribution
 ```
 
-`ctx` 中包含：
+`PlatformAdapterContext` 提供：
 
-- `enabled`：当前平台是否启用。
-- `settings`：平台配置，secret 字段只应是 `PlatformSecretRef`。
-- `features`：平台能力开关。
-- `env`：环境变量快照。
-- `secrets`：读取/写入 secret 的安全接口。
-- `audit`：平台 action/status/config 校验可以写入的审计接口。
+- `platformId`
+- `enabled`
+- `settings`
+- `features`
+- `env`
+- `secrets`
+- `audit`
 
-认证差异通过 actions 表达，不要为每个平台新增独立 auth route。比如：
+注意：
 
-- token 平台：`settings.token` + `connection.test`
-- OAuth 平台：`auth.open` 返回 `openUrl`，后续 `health` / `status.refresh` 刷新状态
-- 外部 CLI 平台：`cli.status`、`cli.login.openGuide`、`cli.refresh`
+- `settings` 中的 secret 字段应是 `PlatformSecretRef`，不要假设有明文。
+- `handleAction` 返回 `openUrl` 时只允许 `http:` / `https:`。
+- `danger: true` 的 action 需要请求体带 `confirm: true`。
+- status/action/validation 失败要返回结构化结果或抛错，Manager 会转成 `error/degraded` 状态。
 
-## 注册到 Nine1Bot
+## 8. 注册到 Nine1Bot
 
-新增平台后，在 Nine1Bot 产品层内置清单中注册 contribution。
-
-当前文件：
+新增平台后，只在 Nine1Bot 产品层内置清单中注册 contribution。
 
 ```ts
 // packages/nine1bot/src/platform/builtin.ts
 import { gitlabPlatformContribution } from '@nine1bot/platform-gitlab/runtime'
-
-export const builtinPlatformContributions = [
-  gitlabPlatformContribution,
-]
-```
-
-新增平台时改为：
-
-```ts
 import { examplePlatformContribution } from '@nine1bot/platform-example/runtime'
 
 export const builtinPlatformContributions = [
@@ -376,51 +397,18 @@ export const builtinPlatformContributions = [
 ]
 ```
 
-启动流程会调用：
+不要在下面这些位置手动注册：
 
-```ts
-registerBuiltinPlatformAdapters({
-  config: fullConfig.platforms,
-  secrets: new FilePlatformSecretStore(...),
-})
-```
+- `packages/platform-<id>`
+- `packages/browser-extension`
+- `web`
+- `opencode/packages/opencode/src/runtime`
 
-不要在平台包、runtime core、browser extension 中自行注册 adapter。
+启动时 Nine1Bot 会根据 `fullConfig.platforms` 调用 Manager 注册启用的平台。禁用的平台会被登记到 `RuntimePlatformAdapterRegistry` 的 disabled marker，用于后续 template/page live gate。
 
-## Platform Manager 生命周期
+## 9. 配置与 Secret
 
-Platform Manager 维护的平台状态比 Web 展示更细，用来判断问题发生在发现、配置、启用、注册还是健康检查阶段：
-
-```text
-discovered -> configured -> enabled -> registered -> healthy
-                                      -> degraded
-                                      -> error
-```
-
-状态含义：
-
-- `discovered`：内置平台 contribution 已被发现。
-- `configured`：已合并默认配置和用户配置。
-- `enabled`：用户配置允许启用该平台。
-- `registered`：平台 runtime adapter 已注册进 `RuntimePlatformAdapterRegistry`。
-- `healthy`：平台当前可以正常贡献 template、context 或 resource。
-- `degraded`：平台部分能力不可用，例如 API enrichment 失败，但基础 page context 仍可用。
-- `error`：平台配置错误、依赖缺失或初始化失败，不能参与 runtime。
-
-用户侧展示可以简化成 `available`、`disabled`、`missing`、`auth-required`、`degraded`、`error`。debug/audit 中应尽量保留内部阶段，方便定位平台为何没有参与本轮构建。
-
-配置变化时的处理顺序：
-
-1. `PATCH /nine1bot/platforms/:id` 保存平台配置。
-2. Manager 调用平台 `validateConfig`。
-3. 保存 `platforms` 配置，secret 字段写入 secret store。
-4. 注销旧 runtime adapter。
-5. 按新配置注册启用平台，或登记 disabled marker。
-6. 后续新 session 和旧 session turn 都按最新 live gate 行为执行。
-
-## 配置与 Secret
-
-用户配置入口：
+用户配置位于 `nine1bot.config` 的 `platforms` 字段：
 
 ```jsonc
 {
@@ -446,35 +434,38 @@ discovered -> configured -> enabled -> registered -> healthy
 
 规则：
 
-- `enabled: false` 是 hard gate。Manager 会注销 runtime adapter，并登记 disabled marker。
-- 禁用平台后，新 session 不会使用它的 template/resource contribution。
-- 禁用平台后，旧 session 历史不删除。
-- 旧 session 后续 turn 如果携带该平台 page payload，会走 generic fallback 或跳过，并记录 `platform-disabled-by-current-config`。
-- 重新启用后，adapter 重新注册；旧 session 仍受 profileSnapshot 资源声明限制。
-- secret 真值只通过 `ctx.secrets` 读取，不能进入 config、profileSnapshot、turn snapshot、runtime event、debug payload。
+- `platforms` 是 Nine1Bot-only 配置，不会进入生成给 Runtime 的 opencode config。
+- secret 真值写入本地 `platform-secrets.json` 或通过 `env/external` 引用，不进入 `nine1bot.config`。
+- Platform API 响应中 secret 字段只返回 `{ redacted: true, hasValue, provider }`。
+- `PATCH /nine1bot/platforms/:id` 中 secret 字段传空字符串表示保留旧值，传 `null` 表示删除。
+- `enabled: false` 会立即注销 adapter 和 runtime sources。
 
-## Browser Extension 与 Web
+认证差异应通过平台 action 和 settings 表达，不要新增固定的 `/auth/start` / `/auth/complete` 路由。例如：
 
-browser extension 只在用户发送消息时采集当前页面，不做后台同步。平台包负责解释平台 URL。
+- token：`settings.token` + `connection.test`
+- OAuth：`auth.open` action 返回 `openUrl`
+- 外部 CLI：`cli.status`、`cli.login.openGuide`、`cli.refresh`
 
-推荐流程：
+## 10. Browser / Web 页面上下文
 
-1. `packages/browser-extension/src/content/index.ts` 采集 `url`、`title`、selection、visible summary、DOM hints。
-2. content script 调用 `@nine1bot/platform-<id>/browser` 的 `build<Page>ContextPayload()`。
-3. sidepanel / Web 在发送消息前请求一次 page context。
-4. Web 把 payload 放进 Controller message 的 `context.page`。
-5. Runtime 按当前启用的平台 adapter normalize / 写 context event。
+Browser extension 的职责是请求式采集页面事实：
 
-Web 侧 create session 可以带 page context，用于 session-create 模板推导：
+1. Web iframe 在发送消息前请求 active page context。
+2. sidepanel 查询当前 active tab。
+3. content script 采集 `url`、`title`、selection、visible summary、DOM hints。
+4. 平台包的 `./browser` helper 生成浏览器安全 payload。
+5. Web 把 payload 放入 Controller message 的 `context.page`。
+6. Runtime 通过当前启用的平台 adapter normalize / 写 context event。
 
-```ts
-POST /nine1bot/agent/sessions
+创建 session 时可以携带 page，用于推导 session template：
+
+```json
 {
   "entry": {
     "source": "browser-extension",
     "platform": "example",
     "mode": "browser-sidepanel",
-    "templateIds": ["default-user-template", "browser-generic", "browser-example"]
+    "templateIds": ["web-chat", "browser-generic"]
   },
   "page": {
     "platform": "example",
@@ -484,10 +475,9 @@ POST /nine1bot/agent/sessions
 }
 ```
 
-发送消息时：
+发送消息时携带 page：
 
-```ts
-POST /nine1bot/agent/sessions/:id/messages
+```json
 {
   "parts": [{ "type": "text", "text": "帮我看一下这个页面" }],
   "entry": {
@@ -511,21 +501,183 @@ POST /nine1bot/agent/sessions/:id/messages
 }
 ```
 
-平台禁用时，即使前端继续发送 `platform: "example"`，后端也会按 registry disabled marker 过滤平台贡献。
+如果平台被禁用，后端会按 disabled marker 跳过平台 adapter，并在 audit/debug 中写 `platform-disabled-by-current-config`。
 
-## Web 多平台设置页
+## 11. 平台 Resources
 
-Web 设置页已经通过 `/nine1bot/platforms` API 消费 descriptor：
+平台资源贡献发生在 session 创建阶段：
 
-- `GET /nine1bot/platforms`：平台列表。
-- `GET /nine1bot/platforms/:id`：平台详情、配置 descriptor、状态、actions。
-- `PATCH /nine1bot/platforms/:id`：保存 `enabled/features/settings`。
-- `POST /nine1bot/platforms/:id/health`：刷新状态。
-- `POST /nine1bot/platforms/:id/actions/:actionId`：执行平台 action。
+```text
+ControllerTemplateResolver
+  -> RuntimePlatformAdapterRegistry.resourceContributions()
+  -> profileSnapshot.resources
+  -> RuntimeResourceResolver live gate
+```
 
-新增平台通常不需要写 Vue 专属页面。只要 descriptor 中提供 `config`、`detailPage`、`actions`，`PlatformManager.vue` 会用通用 renderer 展示。
+语义：
 
-需要复杂交互时再增加：
+- 平台 template 和 `sessionChoice.resources` 只能 add-only。
+- `profileSnapshot.resources` 冻结的是资源身份，不冻结 MCP 连接配置或 skill 文件内容。
+- 当前用户配置仍是 live gate。
+- 旧 session 只允许继续使用 profile 中声明过的资源。
+- 配置新增的 MCP / skill 只影响新 session，不自动进入旧 session。
+- 配置禁用的 MCP / skill 会立即影响旧 session 后续 turn。
+
+平台 adapter 贡献平台 skills 时，应只声明平台 skill 名称：
+
+```ts
+resourceContributions(input) {
+  if (!input.templateIds.includes('example-workflow')) return undefined
+  return {
+    builtinTools: {
+      enabledGroups: ['example-context'],
+    },
+    mcp: {
+      servers: ['example-readonly'],
+      lifecycle: 'session',
+      mergeMode: 'additive-only',
+    },
+    skills: {
+      skills: ['platform.example.workflow-guidance'],
+      lifecycle: 'session',
+      mergeMode: 'additive-only',
+    },
+  }
+}
+```
+
+## 12. 平台 Skills
+
+平台可以自带 skills，但默认不进入普通会话。
+
+目录示例：
+
+```text
+packages/platform-example/skills/
+  workflow-guidance/
+    SKILL.md
+  output-formatting/
+    SKILL.md
+```
+
+注册 source：
+
+```ts
+runtime: {
+  sources: {
+    skills: [
+      {
+        id: 'example-skills',
+        directory: new URL('../skills', import.meta.url).pathname,
+        namespace: 'platform.example',
+        visibility: 'declared-only',
+        lifecycle: 'platform-enabled',
+      },
+    ],
+  },
+}
+```
+
+当前实现语义：
+
+- `Skill.all()` 默认只返回默认可见技能。
+- `Skill.all({ includeDeclaredOnly: true })` 会返回 declared-only 平台技能。
+- `compileProfileResources()` 只继承默认可见 skills。
+- `RuntimeResourceResolver.resolveSkills()` 使用完整 registry，因此显式声明的平台 skill 可以解析。
+- `SkillTool` 只使用 resolver 传入的 `availableSkills`，不会自行暴露所有平台技能。
+- 平台禁用或 source 注销后，旧 profile 中声明的平台 skill 会变为 unavailable，并走 `runtime.resource.failed` / audit 路径。
+
+推荐命名：
+
+```text
+platform.<platform-id>.<skill-name>
+```
+
+这样可以避免覆盖用户或内置技能。
+
+## 13. 平台 Agents
+
+平台可以自带 agents，用于平台特定工作流。agent 会影响系统提示词和权限边界，因此只能在 session 创建时选择并冻结。
+
+目录示例：
+
+```text
+packages/platform-example/agents/
+  coordinator.agent.md
+  reviewer.agent.md
+```
+
+agent 文件示例：
+
+```md
+---
+name: platform.example.coordinator
+description: Coordinates an Example platform workflow.
+mode: primary
+hidden: true
+permission:
+  read: allow
+  skill: allow
+---
+
+You are the Example platform coordinator.
+```
+
+注册 source：
+
+```ts
+runtime: {
+  sources: {
+    agents: [
+      {
+        id: 'example-agents',
+        directory: new URL('../agents', import.meta.url).pathname,
+        namespace: 'platform.example',
+        visibility: 'recommendable',
+        lifecycle: 'platform-enabled',
+      },
+    ],
+  },
+}
+```
+
+可见性语义：
+
+- `declared-only`：普通 agent 列表不展示，只能由 sessionChoice 或模板显式引用。
+- `recommendable`：普通 agent 列表不展示，但平台 adapter 可以返回 `recommendedAgent`，供 UI 推荐。
+- `user-selectable`：平台启用时可以在支持 agent 选择的 UI 中展示。
+
+当前实现规则：
+
+- `Agent.defaultAgent()` 不会返回平台 agent。
+- `sessionChoice.agent` 可以选择 `user-selectable`、`recommendable`、`declared-only` 平台 agent。
+- `ControllerTemplateResolver` 会校验 `recommendedAgent` 是否存在；不存在则 fallback，并写 audit。
+- `recommendedAgent` 只作为推荐，不静默覆盖用户选择。
+- 每轮 `body.agent` override 继续忽略，只 audit，不改变 `profileSnapshot.agent`。
+- 平台禁用后，旧 session 如果 profile 中冻结的是该平台 agent，本轮会 fail closed，并发出 `runtime.agent.unavailable`。
+
+## 14. Web 多平台设置页
+
+Web 通过 `/nine1bot/platforms` API 消费 descriptor：
+
+- `GET /nine1bot/platforms`
+- `GET /nine1bot/platforms/:id`
+- `PATCH /nine1bot/platforms/:id`
+- `POST /nine1bot/platforms/:id/health`
+- `POST /nine1bot/platforms/:id/actions/:actionId`
+
+第一版平台通常不需要写专属 Vue 页面。`PlatformManager.vue` 会根据 descriptor 渲染：
+
+- 平台列表
+- 启用状态
+- runtime status cards
+- capability chips
+- settings form
+- action list
+- recent events
+- runtime sources 摘要
+
+如果平台需要复杂 UI，可以在 descriptor 中声明 custom section：
 
 ```ts
 detailPage: {
@@ -542,41 +694,54 @@ detailPage: {
 
 自定义组件仍应通过统一 Platform API 保存配置、执行 action、刷新状态。
 
-## Runtime Live Gate
+## 15. Live Gate 与禁用语义
 
-平台启用状态会影响三个入口：
+平台禁用后：
 
-1. 会话创建：`ControllerTemplateResolver` 只让启用平台贡献 template/context/resource。
-2. 消息发送：`RuntimeContextEvents` 只让启用平台解释 page payload。
-3. 资源执行：`RuntimeResourceResolver` 继续用当前配置作为 live gate。
+- Manager 注销 runtime adapter。
+- Manager 注销 runtime sources。
+- Manager 在 `RuntimePlatformAdapterRegistry` 里登记 disabled marker。
+- 新 session 不会使用该平台 template/context/resource contribution。
+- 旧 session 历史 context event 不删除。
+- 旧 session 后续 turn 携带该平台 page payload 时，平台 adapter 不参与解释。
+- 旧 session 后续 turn 使用该平台 skill 时，resolver 返回 unavailable。
+- 旧 session 后续 turn 使用该平台 agent 时，compiler fail closed 并发 `runtime.agent.unavailable`。
 
-当前 disabled 行为由 `RuntimePlatformAdapterRegistry` 支持：
-
-- `markDisabled({ id, templateIds, reason })`
-- `unmarkDisabled(id)`
-- `activeTemplateIds(templateIds)`
-- `disabledAudits({ page, templateIds })`
-
-Platform Manager 在平台禁用时调用 `markDisabled`，启用时调用 `unmarkDisabled` 并注册 adapter。
-
-禁用平台的 audit 标准 reason：
+标准 audit reason：
 
 ```text
 platform-disabled-by-current-config
 ```
 
-这个 reason 会进入：
+这个 reason 应出现在：
 
-- template resolver audit 的 `skippedPlatforms`
-- page context event 的 `audit`
-- fallback context block 文本
-- debug API 中的 context events
+- template resolver audit
+- page context event audit
+- resource resolver audit
+- runtime debug
+- 相关 runtime event
 
-## 测试清单
+## 16. 新增平台开发步骤
 
-新增平台至少补这些测试：
+建议按这个顺序做：
+
+1. 创建 `packages/platform-<id>`。
+2. 实现 `shared.ts`：URL parser、pageType、objectKey、normalize。
+3. 实现 `browser.ts`：浏览器安全 payload builder。
+4. 实现 `runtime.ts`：descriptor、adapter、contribution。
+5. 按需增加 `agents/` 和 `skills/`，并在 contribution 中声明 runtime sources。
+6. 在 `packages/nine1bot/src/platform/builtin.ts` 注册 contribution。
+7. 补平台包 parser / adapter 测试。
+8. 补 Manager enable / disable / status / source 测试。
+9. 补 Controller template / page context / resource live gate 测试。
+10. 补 Web API / browser extension 请求路径测试。
+11. 跑完整回归。
+
+## 17. 测试清单
 
 ### 平台包测试
+
+建议文件：
 
 ```text
 packages/platform-<id>/test/<id>-platform.test.ts
@@ -584,23 +749,17 @@ packages/platform-<id>/test/<id>-platform.test.ts
 
 覆盖：
 
-- URL parser：repo/file/issue/MR/doc 等主要页面。
-- page payload builder：稳定 `platform/pageType/objectKey/raw`。
+- URL parser 主要页面类型。
+- page payload builder。
 - template id 推导。
-- template context block。
+- template context blocks。
 - resource contribution。
-- runtime page context block。
+- runtime page context blocks。
+- runtime source descriptor 路径与可见性。
 
-命令：
+### Platform Manager 测试
 
-```bash
-bun run --cwd packages/platform-<id> typecheck
-bun test packages/platform-<id>
-```
-
-### Manager 测试
-
-文件：
+建议文件：
 
 ```text
 packages/nine1bot/src/platform/manager.test.ts
@@ -611,54 +770,50 @@ packages/nine1bot/src/platform/manager.test.ts
 - 默认启用平台会注册 adapter。
 - `enabled: false` 会跳过注册并登记 disabled marker。
 - 重新启用会恢复注册。
-- settings/features/secrets 会传给 contribution context。
-- status/action 失败不会影响其他平台。
+- settings / features / secrets 会传给 contribution context。
+- status / action 失败不会影响其它平台。
+- runtime sources 随平台 enabled / disabled 注册和注销。
 
-### Runtime 边界测试
+### Runtime 测试
 
-文件：
+建议文件：
 
 ```text
 opencode/packages/opencode/test/platform/runtime-core-boundary.test.ts
-```
-
-这个测试会扫描 runtime core，确保没有直接 import 具体平台包。新增平台时，如果这个测试失败，说明平台语义写错了层。
-
-### Template / Context 测试
-
-文件：
-
-```text
 opencode/packages/opencode/test/controller/template-resolver.test.ts
-opencode/packages/opencode/test/session/platform-page-context.test.ts
+opencode/packages/opencode/test/skill/platform-skill-source.test.ts
+opencode/packages/opencode/test/agent/platform-agent-source.test.ts
 ```
 
 覆盖：
 
+- runtime core 不 import 具体平台包。
 - 启用平台能贡献 template/context/resource。
 - 禁用平台不会贡献 template/resource。
-- 禁用平台 page payload 会 fallback 或跳过，并写 `platform-disabled-by-current-config`。
-- 旧 page context history 不删除。
-- 同一 page payload 连续发送去重仍然有效。
+- 平台 skill 默认不进入普通列表，显式声明后可解析。
+- 平台 agent 默认不进入 defaultAgent，显式选择后可冻结。
+- 平台禁用后旧 session 的平台 agent fail closed。
 
 ### Web / Extension 测试
 
-文件：
+建议文件：
 
 ```text
 web/test/config-api.test.ts
 web/test/controller-message-page-context.test.ts
+web/test/runtime-events.test.ts
 packages/browser-extension/test/<id>-page-context.test.ts
 ```
 
 覆盖：
 
-- 平台配置页仍走 `/nine1bot/platforms`。
+- 平台设置走 `/nine1bot/platforms` API。
 - 普通 Web 对话不携带 page context。
 - browser extension 环境发送消息时携带 `context.page`。
-- browser parser 不依赖 Chrome API 也能测试。
+- disabled 平台不会影响普通 Web 对话。
+- runtime event 能表达 resource / agent unavailable。
 
-## 回归命令
+## 18. 推荐回归命令
 
 平台适配改动建议至少跑：
 
@@ -667,7 +822,9 @@ bun run --cwd packages/platform-protocol typecheck
 bun run --cwd packages/platform-<id> typecheck
 bun test packages/platform-<id>
 bun test packages/nine1bot/src/platform packages/nine1bot/src/config packages/nine1bot/src/engine
-bun test opencode/packages/opencode/test/controller opencode/packages/opencode/test/resource opencode/packages/opencode/test/platform opencode/packages/opencode/test/session/platform-page-context.test.ts
+bun run --cwd packages/nine1bot typecheck
+bun run --cwd opencode/packages/opencode typecheck
+bun test opencode/packages/opencode/test/controller opencode/packages/opencode/test/platform opencode/packages/opencode/test/skill opencode/packages/opencode/test/agent
 bun test web/test/config-api.test.ts web/test/controller-message-page-context.test.ts web/test/runtime-events.test.ts
 bun run --cwd packages/browser-extension typecheck
 bun run --cwd packages/browser-extension build
@@ -675,21 +832,34 @@ bun run build:web
 git diff --check
 ```
 
-如果改动涉及 Controller API、权限、资源解析或 session profile，还要补跑相关 `opencode/packages/opencode/test/server` 与 `opencode/packages/opencode/test/session` 回归。
+如果平台改动涉及 session profile、权限、MCP、artifact、interaction 或 legacy API，还要补跑对应的 session / server 测试。
 
-## 开发 Checklist
+## 19. PR Checklist
 
 新增平台 PR 合入前确认：
 
 - 平台代码位于 `packages/platform-<id>`。
-- 平台包导出了 `./browser` 和 `./runtime`。
-- descriptor 中 `id`、`capabilities.templates`、`config`、`detailPage`、`actions` 完整。
+- 平台包导出 `./browser` 和 `./runtime`。
+- descriptor 中 `id`、`capabilities.templates`、`config`、`detailPage`、`actions` 清晰。
 - contribution 不反向依赖 Nine1Bot 产品层。
 - Nine1Bot 只在 `builtinPlatformContributions` 注册 contribution。
 - runtime core 没有 import 具体平台包。
 - Browser extension 只请求式采集页面，不后台轮询。
 - Web 普通对话不受平台适配影响。
-- 禁用平台后不会贡献 template/resource/context。
-- 禁用后重新启用能恢复 adapter 注册。
+- 禁用平台后不会贡献 template/resource/context/source。
+- 禁用后重新启用能恢复 adapter 和 sources 注册。
+- 平台 skills 默认不进入普通会话。
+- 平台 agents 不进入 `defaultAgent()`。
 - Secret 字段不进入 config 明文、profileSnapshot、turn snapshot、runtime event、debug payload。
 - 测试覆盖 parser、template、context、resource、manager、web/extension 请求路径。
+
+## 20. 常见错误
+
+- 把 GitLab / Jira / GitHub 等平台逻辑写进 runtime core。
+- 在平台包里直接注册 runtime adapter。
+- 把平台 skill 放进全局 built-in skills，导致普通会话默认继承。
+- 用平台 template 静默切换用户模型。
+- 每轮消息用 `body.agent` 切换平台 agent。
+- 平台禁用后只隐藏 Web 设置页，没有注销 adapter/source。
+- 将 token 明文写进 config、audit、debug 或 runtime event。
+- browser extension 做后台页面同步，造成 context 污染和 busy 语义不一致。

--- a/opencode/packages/opencode/src/agent/agent.ts
+++ b/opencode/packages/opencode/src/agent/agent.ts
@@ -24,6 +24,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Log } from "@/util/log"
 import { BusEvent } from "@/bus/bus-event"
 import { NamedError } from "@opencode-ai/util/error"
+import { GlobalBus } from "@/bus/global"
 
 export namespace Agent {
   const log = Log.create({ service: "agent" })
@@ -102,6 +103,12 @@ export namespace Agent {
   const PLATFORM_AGENT_GLOB = new Bun.Glob("**/*.agent.md")
   let cachedAgents: Record<string, Info> | undefined
   let cachedAgentKey: string | undefined
+
+  GlobalBus.on("event", (event) => {
+    if (event.payload?.type !== "server.instance.disposed") return
+    cachedAgents = undefined
+    cachedAgentKey = undefined
+  })
 
   async function loadAgents(): Promise<Record<string, Info>> {
     const cfg = await Config.get()
@@ -334,8 +341,8 @@ export namespace Agent {
           ? md.data.name.trim()
           : path.basename(match, ".agent.md")
         const config = {
-          name,
           ...md.data,
+          name,
           prompt: md.content.trim(),
         }
         const parsed = Config.Agent.safeParse(config)
@@ -432,10 +439,16 @@ export namespace Agent {
     return agent.source?.owner.kind === "platform"
   }
 
-  export async function get(agent: string, options?: ListOptions): Promise<Info> {
+  export async function get(agent: string, options?: ListOptions): Promise<Info | undefined> {
     const item = await state().then((x) => x[agent])
-    if (!item) return undefined as unknown as Info
-    return isVisible(item, options) ? item : undefined as unknown as Info
+    if (!item) return undefined
+    return isVisible(item, options) ? item : undefined
+  }
+
+  export async function mustGet(agent: string, options?: ListOptions): Promise<Info> {
+    const item = await get(agent, options)
+    if (!item) throw new Error(`Agent not found: ${agent}`)
+    return item
   }
 
   export async function list(options?: ListOptions) {

--- a/opencode/packages/opencode/src/agent/agent.ts
+++ b/opencode/packages/opencode/src/agent/agent.ts
@@ -18,8 +18,26 @@ import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Global } from "@/global"
 import path from "path"
 import { Plugin } from "@/plugin"
+import { RuntimeSourceRegistry } from "@/runtime/source/registry"
+import { ConfigMarkdown } from "@/config/markdown"
+import { Filesystem } from "@/util/filesystem"
+import { Log } from "@/util/log"
+import { BusEvent } from "@/bus/bus-event"
+import { NamedError } from "@opencode-ai/util/error"
 
 export namespace Agent {
+  const log = Log.create({ service: "agent" })
+
+  export const Source = z.object({
+    owner: z.object({
+      id: z.string(),
+      kind: z.enum(["core", "user", "project", "platform", "capability"]),
+    }),
+    sourceID: z.string(),
+    visibility: z.enum(["declared-only", "recommendable", "user-selectable"]),
+  })
+  export type Source = z.infer<typeof Source>
+
   export const Info = z
     .object({
       name: z.string(),
@@ -40,13 +58,52 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      source: Source.optional(),
     })
     .meta({
       ref: "Agent",
     })
   export type Info = z.infer<typeof Info>
+  export type ListOptions = {
+    includeRecommendable?: boolean
+    includeDeclaredOnly?: boolean
+  }
 
-  const state = Instance.state(async () => {
+  export const Unavailable = BusEvent.define(
+    "runtime.agent.unavailable",
+    z.object({
+      sessionID: z.string(),
+      turnSnapshotId: z.string().optional(),
+      agent: z.string(),
+      owner: z.string().optional(),
+      sourceID: z.string().optional(),
+      status: z.literal("unavailable"),
+      reason: z.enum(["disabled-by-current-config", "missing-source", "invalid-agent"]),
+      message: z.string(),
+      recoverable: z.boolean(),
+      action: z
+        .object({
+          type: z.enum(["open-settings", "new-session"]),
+          label: z.string(),
+        })
+        .optional(),
+    }),
+  )
+
+  export const UnavailableError = NamedError.create(
+    "AgentUnavailableError",
+    z.object({
+      agent: z.string(),
+      reason: z.enum(["disabled-by-current-config", "missing-source", "invalid-agent"]),
+      message: z.string(),
+    }),
+  )
+
+  const PLATFORM_AGENT_GLOB = new Bun.Glob("**/*.agent.md")
+  let cachedAgents: Record<string, Info> | undefined
+  let cachedAgentKey: string | undefined
+
+  async function loadAgents(): Promise<Record<string, Info>> {
     const cfg = await Config.get()
 
     const defaults = PermissionNext.fromConfig({
@@ -200,32 +257,10 @@ export namespace Agent {
     }
 
     for (const [key, value] of Object.entries(cfg.agent ?? {})) {
-      if (value.disable) {
-        delete result[key]
-        continue
-      }
-      let item = result[key]
-      if (!item)
-        item = result[key] = {
-          name: key,
-          mode: "all",
-          permission: PermissionNext.merge(defaults, user),
-          options: {},
-          native: false,
-        }
-      if (value.model) item.model = Provider.parseModel(value.model)
-      item.prompt = value.prompt ?? item.prompt
-      item.description = value.description ?? item.description
-      item.temperature = value.temperature ?? item.temperature
-      item.topP = value.top_p ?? item.topP
-      item.mode = value.mode ?? item.mode
-      item.color = value.color ?? item.color
-      item.hidden = value.hidden ?? item.hidden
-      item.name = value.name ?? item.name
-      item.steps = value.steps ?? item.steps
-      item.options = mergeDeep(item.options, value.options ?? {})
-      item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
+      applyConfigAgent(result, key, value, defaults, user)
     }
+
+    await scanRuntimeAgentSources(result, defaults, user)
 
     // Ensure Truncate.DIR is allowed unless explicitly configured
     for (const name in result) {
@@ -244,17 +279,171 @@ export namespace Agent {
     }
 
     return result
-  })
-
-  export async function get(agent: string) {
-    return state().then((x) => x[agent])
   }
 
-  export async function list() {
+  async function scanRuntimeAgentSources(
+    result: Record<string, Info>,
+    defaults: PermissionNext.Ruleset,
+    user: PermissionNext.Ruleset,
+  ) {
+    for (const runtimeSource of RuntimeSourceRegistry.list().agents) {
+      if (!runtimeSource.owner.enabled) continue
+      if (!(await Filesystem.isDir(runtimeSource.directory))) {
+        log.debug("skip missing runtime agent source directory", {
+          owner: runtimeSource.owner.id,
+          source: runtimeSource.id,
+          directory: runtimeSource.directory,
+        })
+        continue
+      }
+
+      const matches = await Array.fromAsync(
+        PLATFORM_AGENT_GLOB.scan({
+          cwd: runtimeSource.directory,
+          absolute: true,
+          onlyFiles: true,
+          followSymlinks: true,
+        }),
+      ).catch((error) => {
+        log.error("failed runtime agent source directory scan", {
+          owner: runtimeSource.owner.id,
+          source: runtimeSource.id,
+          directory: runtimeSource.directory,
+          error,
+        })
+        return []
+      })
+
+      const source: Source = {
+        owner: {
+          id: runtimeSource.owner.id,
+          kind: runtimeSource.owner.kind,
+        },
+        sourceID: runtimeSource.id,
+        visibility: runtimeSource.visibility,
+      }
+
+      for (const match of matches) {
+        const md = await ConfigMarkdown.parse(match).catch((error) => {
+          log.error("failed to load runtime agent source item", { agent: match, error })
+          return undefined
+        })
+        if (!md) continue
+
+        const name = typeof md.data.name === "string" && md.data.name.trim()
+          ? md.data.name.trim()
+          : path.basename(match, ".agent.md")
+        const config = {
+          name,
+          ...md.data,
+          prompt: md.content.trim(),
+        }
+        const parsed = Config.Agent.safeParse(config)
+        if (!parsed.success) {
+          log.error("invalid runtime agent source item", { agent: match, issues: parsed.error.issues })
+          continue
+        }
+
+        const existing = result[name]
+        if (existing && existing.source?.owner.kind !== "platform") {
+          log.debug("skip platform agent override over non-platform agent", {
+            name,
+            existing: existing.name,
+            skipped: match,
+          })
+          continue
+        }
+        if (existing) {
+          log.debug("platform agent override", {
+            name,
+            previous: existing.name,
+            newLocation: match,
+          })
+        }
+
+        applyConfigAgent(result, name, parsed.data, defaults, user, source)
+      }
+    }
+  }
+
+  function applyConfigAgent(
+    result: Record<string, Info>,
+    key: string,
+    value: Config.Agent,
+    defaults: PermissionNext.Ruleset,
+    user: PermissionNext.Ruleset,
+    source?: Source,
+  ) {
+    if (value.disable) {
+      delete result[key]
+      return
+    }
+    let item = result[key]
+    if (!item) {
+      item = result[key] = {
+        name: key,
+        mode: "all",
+        permission: PermissionNext.merge(defaults, user),
+        options: {},
+        native: false,
+        source,
+      }
+    }
+    if (source) item.source = source
+    if (value.model) item.model = Provider.parseModel(value.model)
+    item.prompt = value.prompt ?? item.prompt
+    item.description = value.description ?? item.description
+    item.temperature = value.temperature ?? item.temperature
+    item.topP = value.top_p ?? item.topP
+    item.mode = value.mode ?? item.mode
+    item.color = value.color ?? item.color
+    item.hidden = value.hidden ?? item.hidden
+    item.name = value.name ?? item.name
+    item.steps = value.steps ?? item.steps
+    item.options = mergeDeep(item.options, value.options ?? {})
+    item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
+  }
+
+  async function state() {
+    const cacheKey = agentCacheKey()
+    if (cachedAgents && cachedAgentKey === cacheKey) return cachedAgents
+    cachedAgents = await loadAgents()
+    cachedAgentKey = cacheKey
+    return cachedAgents
+  }
+
+  function agentCacheKey() {
+    return JSON.stringify({
+      directory: Instance.directory,
+      worktree: Instance.worktree,
+      config: RuntimeSourceRegistry.version(),
+    })
+  }
+
+  function isVisible(agent: Info, options?: ListOptions) {
+    const visibility = agent.source?.visibility
+    if (!visibility || visibility === "user-selectable") return true
+    if (visibility === "recommendable") return options?.includeRecommendable || options?.includeDeclaredOnly
+    if (visibility === "declared-only") return options?.includeDeclaredOnly
+    return false
+  }
+
+  function isPlatformAgent(agent: Info) {
+    return agent.source?.owner.kind === "platform"
+  }
+
+  export async function get(agent: string, options?: ListOptions): Promise<Info> {
+    const item = await state().then((x) => x[agent])
+    if (!item) return undefined as unknown as Info
+    return isVisible(item, options) ? item : undefined as unknown as Info
+  }
+
+  export async function list(options?: ListOptions) {
     const cfg = await Config.get()
     return pipe(
       await state(),
       values(),
+      (items) => items.filter((item) => isVisible(item, options)),
       sortBy([(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"]),
     )
   }
@@ -266,12 +455,15 @@ export namespace Agent {
     if (cfg.default_agent) {
       const agent = agents[cfg.default_agent]
       if (!agent) throw new Error(`default agent "${cfg.default_agent}" not found`)
+      if (isPlatformAgent(agent)) throw new Error(`default agent "${cfg.default_agent}" is a platform agent`)
       if (agent.mode === "subagent") throw new Error(`default agent "${cfg.default_agent}" is a subagent`)
       if (agent.hidden === true) throw new Error(`default agent "${cfg.default_agent}" is hidden`)
       return agent.name
     }
 
-    const primaryVisible = Object.values(agents).find((a) => a.mode !== "subagent" && a.hidden !== true)
+    const primaryVisible = Object.values(agents).find(
+      (a) => a.mode !== "subagent" && a.hidden !== true && !isPlatformAgent(a),
+    )
     if (!primaryVisible) throw new Error("no primary visible agent found")
     return primaryVisible.name
   }

--- a/opencode/packages/opencode/src/runtime/controller/agent-run-compiler.ts
+++ b/opencode/packages/opencode/src/runtime/controller/agent-run-compiler.ts
@@ -17,6 +17,7 @@ import { SessionRuntimeProfile } from "@/runtime/session/profile"
 import type { Session } from "@/session"
 import type { SessionPrompt } from "@/session/prompt"
 import { Log } from "@/util/log"
+import { Bus } from "@/bus"
 import { ulid } from "ulid"
 
 export namespace ControllerAgentRunCompiler {
@@ -42,7 +43,7 @@ export namespace ControllerAgentRunCompiler {
             source: "legacy-resumed",
           })
         : undefined)
-    const agent = await resolveAgent(input.session, profile)
+    const agent = await resolveAgent(input.session, profile, input.turnSnapshotId)
     const ignoredAgentOverride =
       body.agent && body.agent !== agent.name
         ? {
@@ -171,10 +172,35 @@ export namespace ControllerAgentRunCompiler {
     return RuntimePromptBridgeCompiler.compilePrompt(await compileTurnSnapshot(input))
   }
 
-  async function resolveAgent(session: Session.Info, profile?: SessionProfileSnapshot) {
+  async function resolveAgent(session: Session.Info, profile: SessionProfileSnapshot | undefined, turnSnapshotId: string) {
     const name = profile?.agent.name ?? session.runtime?.agent ?? (await Agent.defaultAgent())
-    const agent = await Agent.get(name)
-    if (!agent) throw new Error(`Agent not found: ${name}`)
+    const agent = await Agent.get(name, { includeDeclaredOnly: true, includeRecommendable: true })
+    if (!agent) {
+      if (profile?.agent.name ?? session.runtime?.agent) {
+        const message = `Agent "${name}" is disabled or missing in the current runtime sources.`
+        await Bus.publish(Agent.Unavailable, {
+          sessionID: session.id,
+          turnSnapshotId,
+          agent: name,
+          status: "unavailable",
+          reason: "disabled-by-current-config",
+          message,
+          recoverable: true,
+          action: {
+            type: "open-settings",
+            label: "Open platform settings",
+          },
+        }).catch((error) => {
+          log.warn("failed to publish agent unavailable event", { error, sessionID: session.id, agent: name })
+        })
+        throw new Agent.UnavailableError({
+          agent: name,
+          reason: "disabled-by-current-config",
+          message,
+        })
+      }
+      throw new Error(`Agent not found: ${name}`)
+    }
     return agent
   }
 

--- a/opencode/packages/opencode/src/runtime/controller/agent-run-compiler.ts
+++ b/opencode/packages/opencode/src/runtime/controller/agent-run-compiler.ts
@@ -177,13 +177,14 @@ export namespace ControllerAgentRunCompiler {
     const agent = await Agent.get(name, { includeDeclaredOnly: true, includeRecommendable: true })
     if (!agent) {
       if (profile?.agent.name ?? session.runtime?.agent) {
-        const message = `Agent "${name}" is disabled or missing in the current runtime sources.`
+        const reason = "missing-source" as const
+        const message = `Agent "${name}" is unavailable in the current runtime sources. It may have been removed, failed to load, or belongs to a disabled platform.`
         await Bus.publish(Agent.Unavailable, {
           sessionID: session.id,
           turnSnapshotId,
           agent: name,
           status: "unavailable",
-          reason: "disabled-by-current-config",
+          reason,
           message,
           recoverable: true,
           action: {
@@ -195,7 +196,7 @@ export namespace ControllerAgentRunCompiler {
         })
         throw new Agent.UnavailableError({
           agent: name,
-          reason: "disabled-by-current-config",
+          reason,
           message,
         })
       }

--- a/opencode/packages/opencode/src/runtime/controller/events.ts
+++ b/opencode/packages/opencode/src/runtime/controller/events.ts
@@ -422,6 +422,15 @@ export namespace RuntimeControllerEvents {
           }),
         ]
         break
+      case "runtime.agent.unavailable":
+        projected = [
+          envelope({
+            ...base,
+            type: "runtime.agent.unavailable",
+            data: properties,
+          }),
+        ]
+        break
       case "runtime.resources.resolved":
         projected = [
           envelope({

--- a/opencode/packages/opencode/src/runtime/controller/protocol.ts
+++ b/opencode/packages/opencode/src/runtime/controller/protocol.ts
@@ -198,6 +198,7 @@ export namespace RuntimeControllerProtocol {
     "runtime.interaction.answered",
     "runtime.artifact.available",
     "runtime.artifact.closed",
+    "runtime.agent.unavailable",
     "runtime.resource.failed",
     "runtime.resources.resolved",
     "runtime.context.compiled",

--- a/opencode/packages/opencode/src/runtime/controller/template-resolver.ts
+++ b/opencode/packages/opencode/src/runtime/controller/template-resolver.ts
@@ -40,6 +40,13 @@ export namespace ControllerTemplateResolver {
     skippedPlatforms: RuntimePlatformAdapterRegistry.PlatformSkipAudit[]
     resourceMergeMode: "additive-only"
     contextBlocks: Array<{ id: string; source: string; enabled: boolean }>
+    agentRecommendation?: {
+      requested?: string
+      resolved: string
+      accepted: boolean
+      platform?: string
+      reason?: "not-found"
+    }
     resources: {
       builtinGroups: string[]
       builtinTools: string[]
@@ -100,6 +107,7 @@ export namespace ControllerTemplateResolver {
     })
     const templateIds = RuntimePlatformAdapterRegistry.activeTemplateIds(rawTemplateIds)
     const agent = await resolveAgent(input.sessionChoice?.agent)
+    const agentRecommendation = await recommendedAgent(templateIds, agent.name)
     const defaultModel = agent.model ?? (await Provider.defaultModel())
     const resources = (await RuntimeFeatureFlags.resourceResolverEnabled())
       ? mergeResources(
@@ -123,6 +131,7 @@ export namespace ControllerTemplateResolver {
         source: block.source,
         enabled: block.enabled,
       })),
+      agentRecommendation: agentRecommendation.audit,
       resources: {
         builtinGroups: resources.builtinTools.enabledGroups ?? [],
         builtinTools: resources.builtinTools.enabledTools ?? [],
@@ -138,7 +147,7 @@ export namespace ControllerTemplateResolver {
         name: agent.name,
         source: input.sessionChoice?.agent ? "session-choice" : "default-user-template",
       },
-      recommendedAgent: recommendedAgent(templateIds, agent.name),
+      recommendedAgent: agentRecommendation.value,
       defaultModel: {
         providerID: defaultModel.providerID,
         modelID: defaultModel.modelID,
@@ -175,7 +184,7 @@ export namespace ControllerTemplateResolver {
 
   async function resolveAgent(agentName?: string) {
     const name = agentName ?? (await Agent.defaultAgent())
-    const agent = await Agent.get(name)
+    const agent = await Agent.get(name, agentName ? { includeDeclaredOnly: true, includeRecommendable: true } : undefined)
     if (!agent) throw new Error(`Agent not found: ${name}`)
     return agent
   }
@@ -332,8 +341,41 @@ export namespace ControllerTemplateResolver {
     return page ? RuntimeContextEvents.normalizePagePayload(page) : undefined
   }
 
-  function recommendedAgent(templateIds: string[], fallback: string) {
-    return RuntimePlatformAdapterRegistry.recommendedAgent({ templateIds, fallback })
+  async function recommendedAgent(templateIds: string[], fallback: string) {
+    const recommendation = RuntimePlatformAdapterRegistry.recommendAgent({ templateIds, fallback })
+    if (!recommendation.requested) {
+      return {
+        value: fallback,
+        audit: undefined,
+      }
+    }
+
+    const agent = await Agent.get(recommendation.requested, {
+      includeDeclaredOnly: true,
+      includeRecommendable: true,
+    })
+    if (agent) {
+      return {
+        value: agent.name,
+        audit: {
+          requested: recommendation.requested,
+          resolved: agent.name,
+          accepted: true,
+          platform: recommendation.platform,
+        },
+      }
+    }
+
+    return {
+      value: fallback,
+      audit: {
+        requested: recommendation.requested,
+        resolved: fallback,
+        accepted: false,
+        platform: recommendation.platform,
+        reason: "not-found" as const,
+      },
+    }
   }
 
   function dedupeBlocks(blocks: ContextBlock[]) {

--- a/opencode/packages/opencode/src/runtime/platform/adapter.ts
+++ b/opencode/packages/opencode/src/runtime/platform/adapter.ts
@@ -130,13 +130,29 @@ export namespace RuntimePlatformAdapterRegistry {
     })
   }
 
-  export function recommendedAgent(input: { templateIds: string[]; fallback: string }): string {
+  export function recommendAgent(input: { templateIds: string[]; fallback: string }): {
+    requested?: string
+    fallback: string
+    platform?: string
+  } {
     const templateIds = activeTemplateIds(input.templateIds)
     for (const adapter of adapters.values()) {
       const recommended = adapter.recommendedAgent?.({ ...input, templateIds })
-      if (recommended) return recommended
+      if (recommended) {
+        return {
+          requested: recommended,
+          fallback: input.fallback,
+          platform: adapter.id,
+        }
+      }
     }
-    return input.fallback
+    return {
+      fallback: input.fallback,
+    }
+  }
+
+  export function recommendedAgent(input: { templateIds: string[]; fallback: string }): string {
+    return recommendAgent(input).requested ?? input.fallback
   }
 
   export function activeTemplateIds(templateIds: string[]) {

--- a/opencode/packages/opencode/src/runtime/resource/resolver.ts
+++ b/opencode/packages/opencode/src/runtime/resource/resolver.ts
@@ -103,9 +103,9 @@ export namespace RuntimeResourceResolver {
     return [...new Set(values)].sort((a, b) => a.localeCompare(b))
   }
 
-  async function listSkills(): Promise<SkillInfo[]> {
+  async function listSkills(options?: { includeDeclaredOnly?: boolean }): Promise<SkillInfo[]> {
     const { Skill } = await import("@/skill")
-    return Skill.all()
+    return Skill.all(options)
   }
 
   export function resourceTemplateId() {
@@ -288,7 +288,7 @@ export namespace RuntimeResourceResolver {
 
   async function resolveSkills(spec: SkillResourceSpec) {
     const declaredSkills = uniqueSorted(spec.skills)
-    const registry = new Map((await listSkills()).map((skill) => [skill.name, skill]))
+    const registry = new Map((await listSkills({ includeDeclaredOnly: true })).map((skill) => [skill.name, skill]))
     const availableSkills: SkillInfo[] = []
     const availability: Record<string, ResourceAvailability> = {}
     const failures: ResourceFailure[] = []

--- a/opencode/packages/opencode/src/runtime/session/profile-compiler.ts
+++ b/opencode/packages/opencode/src/runtime/session/profile-compiler.ts
@@ -89,7 +89,7 @@ export namespace SessionProfileCompiler {
 
   export async function resolveAgent(agentName?: string) {
     const name = agentName ?? (await Agent.defaultAgent())
-    const agent = await Agent.get(name)
+    const agent = await Agent.get(name, agentName ? { includeDeclaredOnly: true, includeRecommendable: true } : undefined)
     if (!agent) throw new Error(`Agent not found: ${name}`)
     return agent
   }

--- a/opencode/packages/opencode/src/runtime/source/registry.ts
+++ b/opencode/packages/opencode/src/runtime/source/registry.ts
@@ -1,0 +1,120 @@
+export namespace RuntimeSourceRegistry {
+  export type SourceOwner = {
+    id: string
+    kind: "platform" | "capability" | "core"
+    enabled: boolean
+  }
+
+  export type AgentSourceVisibility = "declared-only" | "recommendable" | "user-selectable"
+  export type SkillSourceVisibility = "default" | "declared-only"
+  export type SourceLifecycle = "platform-enabled"
+
+  export type AgentSourceInput = {
+    id: string
+    directory: string
+    namespace?: string
+    visibility: AgentSourceVisibility
+    lifecycle: SourceLifecycle
+  }
+
+  export type SkillSourceInput = {
+    id: string
+    directory: string
+    namespace?: string
+    visibility: SkillSourceVisibility
+    lifecycle: SourceLifecycle
+  }
+
+  export type RuntimeSourcesInput = {
+    agents?: AgentSourceInput[]
+    skills?: SkillSourceInput[]
+  }
+
+  export type AgentSource = AgentSourceInput & {
+    owner: SourceOwner
+  }
+
+  export type SkillSource = SkillSourceInput & {
+    owner: SourceOwner
+  }
+
+  export type OwnerSources = {
+    owner?: SourceOwner
+    agents: AgentSource[]
+    skills: SkillSource[]
+  }
+
+  const owners = new Map<string, OwnerSources>()
+
+  export function registerOwner(input: {
+    owner: SourceOwner
+    sources?: RuntimeSourcesInput
+  }) {
+    const owner = { ...input.owner }
+    owners.set(owner.id, {
+      owner,
+      agents: normalizeSources(input.sources?.agents ?? []).map((source) => ({
+        ...source,
+        owner,
+      })),
+      skills: normalizeSources(input.sources?.skills ?? []).map((source) => ({
+        ...source,
+        owner,
+      })),
+    })
+  }
+
+  export function unregisterOwner(ownerID: string) {
+    owners.delete(ownerID)
+  }
+
+  export function list(): OwnerSources {
+    return {
+      agents: Array.from(owners.values()).flatMap((entry) => entry.agents.map(cloneAgentSource)),
+      skills: Array.from(owners.values()).flatMap((entry) => entry.skills.map(cloneSkillSource)),
+    }
+  }
+
+  export function listOwner(ownerID: string): OwnerSources {
+    const entry = owners.get(ownerID)
+    return {
+      owner: entry?.owner ? { ...entry.owner } : undefined,
+      agents: entry?.agents.map(cloneAgentSource) ?? [],
+      skills: entry?.skills.map(cloneSkillSource) ?? [],
+    }
+  }
+
+  export function clearForTesting() {
+    owners.clear()
+  }
+
+  function normalizeSources<T extends { id: string }>(sources: T[]) {
+    const seen = new Set<string>()
+    const result: T[] = []
+    for (const source of sources) {
+      if (!source.id.trim()) continue
+      const key = source.id.trim()
+      if (seen.has(key)) continue
+      seen.add(key)
+      result.push({
+        ...source,
+        id: key,
+      })
+    }
+    return result
+  }
+
+  function cloneAgentSource(source: AgentSource): AgentSource {
+    return {
+      ...source,
+      owner: { ...source.owner },
+    }
+  }
+
+  function cloneSkillSource(source: SkillSource): SkillSource {
+    return {
+      ...source,
+      owner: { ...source.owner },
+    }
+  }
+}

--- a/opencode/packages/opencode/src/runtime/source/registry.ts
+++ b/opencode/packages/opencode/src/runtime/source/registry.ts
@@ -45,6 +45,7 @@ export namespace RuntimeSourceRegistry {
   }
 
   const owners = new Map<string, OwnerSources>()
+  let revision = 0
 
   export function registerOwner(input: {
     owner: SourceOwner
@@ -62,10 +63,17 @@ export namespace RuntimeSourceRegistry {
         owner,
       })),
     })
+    revision++
   }
 
   export function unregisterOwner(ownerID: string) {
-    owners.delete(ownerID)
+    if (owners.delete(ownerID)) {
+      revision++
+    }
+  }
+
+  export function version() {
+    return revision
   }
 
   export function list(): OwnerSources {
@@ -85,7 +93,10 @@ export namespace RuntimeSourceRegistry {
   }
 
   export function clearForTesting() {
-    owners.clear()
+    if (owners.size > 0) {
+      owners.clear()
+      revision++
+    }
   }
 
   function normalizeSources<T extends { id: string }>(sources: T[]) {

--- a/opencode/packages/opencode/src/session/compaction.ts
+++ b/opencode/packages/opencode/src/session/compaction.ts
@@ -115,7 +115,7 @@ export namespace SessionCompaction {
     auto: boolean
   }) {
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
-    const agent = await Agent.get("compaction")
+    const agent = await Agent.mustGet("compaction")
     const model = agent.model
       ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
       : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)

--- a/opencode/packages/opencode/src/session/processor.ts
+++ b/opencode/packages/opencode/src/session/processor.ts
@@ -301,7 +301,7 @@ export namespace SessionProcessor {
                     ) {
                       const doomLoopCount = incrementDoomLoopCount(input.sessionID)
                       const config = await Config.get()
-                      const agent = await Agent.get(input.assistantMessage.agent)
+                      const agent = await Agent.mustGet(input.assistantMessage.agent)
 
                       // In autonomous mode with allowDoomLoop, handle doom loops progressively
                       if (config.autonomous?.enabled !== false && config.autonomous?.allowDoomLoop !== false) {

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -697,7 +697,7 @@ export namespace SessionPrompt {
           { args: taskArgs },
         )
         let executionError: Error | undefined
-        const taskAgent = await Agent.get(task.agent)
+        const taskAgent = await Agent.mustGet(task.agent)
         const taskCtx: Tool.Context = {
           agent: task.agent,
           messageID: assistantMessage.id,
@@ -867,7 +867,7 @@ export namespace SessionPrompt {
       const agent = await RuntimeTiming.measure(
         timing,
         "agent.resolve",
-        () => Agent.get(lastUser.agent, { includeDeclaredOnly: true, includeRecommendable: true }),
+        () => Agent.mustGet(lastUser.agent, { includeDeclaredOnly: true, includeRecommendable: true }),
         {
           step,
           agent: lastUser.agent,
@@ -1311,7 +1311,7 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput, session: Session.Info) {
-    const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()), {
+    const agent = await Agent.mustGet(input.agent ?? (await Agent.defaultAgent()), {
       includeDeclaredOnly: true,
       includeRecommendable: true,
     })
@@ -1721,7 +1721,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     if (session.revert) {
       await SessionRevert.cleanup(session)
     }
-    const agent = await Agent.get(input.agent, { includeDeclaredOnly: true, includeRecommendable: true })
+    const agent = await Agent.mustGet(input.agent, { includeDeclaredOnly: true, includeRecommendable: true })
     const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -864,10 +864,15 @@ export namespace SessionPrompt {
       }
 
       // normal processing
-      const agent = await RuntimeTiming.measure(timing, "agent.resolve", () => Agent.get(lastUser.agent), {
-        step,
-        agent: lastUser.agent,
-      })
+      const agent = await RuntimeTiming.measure(
+        timing,
+        "agent.resolve",
+        () => Agent.get(lastUser.agent, { includeDeclaredOnly: true, includeRecommendable: true }),
+        {
+          step,
+          agent: lastUser.agent,
+        },
+      )
       const maxSteps = agent.steps ?? Infinity
       const isLastStep = step >= maxSteps
       msgs = await RuntimeTiming.measure(
@@ -1306,7 +1311,10 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput, session: Session.Info) {
-    const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
+    const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()), {
+      includeDeclaredOnly: true,
+      includeRecommendable: true,
+    })
     const needsSkillHint = input.parts.some(
       (part) => part.type === "file" && uploadedFileTypeMap[part.mime]?.skill,
     )
@@ -1713,7 +1721,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     if (session.revert) {
       await SessionRevert.cleanup(session)
     }
-    const agent = await Agent.get(input.agent)
+    const agent = await Agent.get(input.agent, { includeDeclaredOnly: true, includeRecommendable: true })
     const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),

--- a/opencode/packages/opencode/src/session/prompt.ts
+++ b/opencode/packages/opencode/src/session/prompt.ts
@@ -1310,11 +1310,23 @@ export namespace SessionPrompt {
     return tools
   }
 
+  async function resolveUserMessageAgent(input: PromptInput, session: Session.Info) {
+    const name = input.agent ?? (await Agent.defaultAgent())
+    const frozenAgentName = input.runtimeProfileSnapshot?.agent.name ?? session.runtime?.agent
+    const isFrozenRuntimeAgent = !!input.agent && input.agent === frozenAgentName
+    return Agent.mustGet(
+      name,
+      isFrozenRuntimeAgent
+        ? {
+            includeDeclaredOnly: true,
+            includeRecommendable: true,
+          }
+        : undefined,
+    )
+  }
+
   async function createUserMessage(input: PromptInput, session: Session.Info) {
-    const agent = await Agent.mustGet(input.agent ?? (await Agent.defaultAgent()), {
-      includeDeclaredOnly: true,
-      includeRecommendable: true,
-    })
+    const agent = await resolveUserMessageAgent(input, session)
     const needsSkillHint = input.parts.some(
       (part) => part.type === "file" && uploadedFileTypeMap[part.mime]?.skill,
     )

--- a/opencode/packages/opencode/src/skill/skill.ts
+++ b/opencode/packages/opencode/src/skill/skill.ts
@@ -10,15 +10,30 @@ import { Filesystem } from "@/util/filesystem"
 import { Flag } from "@/flag/flag"
 import { Bus } from "@/bus"
 import { Session } from "@/session"
+import { RuntimeSourceRegistry } from "@/runtime/source/registry"
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
+  export const Source = z.object({
+    owner: z.object({
+      id: z.string(),
+      kind: z.enum(["core", "user", "project", "platform", "capability"]),
+    }),
+    sourceID: z.string(),
+    visibility: z.enum(["default", "declared-only"]),
+  })
+  export type Source = z.infer<typeof Source>
+
   export const Info = z.object({
     name: z.string(),
     description: z.string(),
     location: z.string(),
+    source: Source.optional(),
   })
   export type Info = z.infer<typeof Info>
+  export type ListOptions = {
+    includeDeclaredOnly?: boolean
+  }
 
   export const InvalidError = NamedError.create(
     "SkillInvalidError",
@@ -45,6 +60,7 @@ export namespace Skill {
   // Skills 热更新缓存
   let cachedSkills: Record<string, Info> | null = null
   let skillsLastLoadTime: number = 0
+  let skillsLastCacheKey: string | undefined
   const SKILLS_CACHE_TTL = 30000 // 30秒
 
   /**
@@ -53,12 +69,14 @@ export namespace Skill {
   async function scanSkillDirectories(): Promise<Record<string, Info>> {
     const skills: Record<string, Info> = {}
 
-    const addSkill = async (match: string) => {
+    const addSkill = async (match: string, source: Source, options?: { emitParseErrors?: boolean }) => {
       const md = await ConfigMarkdown.parse(match).catch((err) => {
         const message = ConfigMarkdown.FrontmatterError.isInstance(err)
           ? err.data.message
           : `Failed to parse skill ${match}`
-        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+        if (options?.emitParseErrors !== false) {
+          Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+        }
         log.error("failed to load skill", { skill: match, err })
         return undefined
       })
@@ -68,12 +86,22 @@ export namespace Skill {
       const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
       if (!parsed.success) return
 
+      const existing = skills[parsed.data.name]
+      if (existing && sourceVisibility(existing) === "default" && source.visibility === "declared-only") {
+        log.debug("skip declared-only skill override over default skill", {
+          name: parsed.data.name,
+          existing: existing.location,
+          skipped: match,
+        })
+        return
+      }
+
       // Later sources override earlier ones (higher priority sources scanned last)
       // No warning for duplicates - this is expected when user overrides builtin skills
-      if (skills[parsed.data.name]) {
+      if (existing) {
         log.debug("skill override", {
           name: parsed.data.name,
-          previous: skills[parsed.data.name].location,
+          previous: existing.location,
           newLocation: match,
         })
       }
@@ -82,6 +110,13 @@ export namespace Skill {
         name: parsed.data.name,
         description: parsed.data.description,
         location: match,
+        source,
+      }
+    }
+
+    const addMatches = async (matches: string[], source: Source, options?: { emitParseErrors?: boolean }) => {
+      for (const match of matches) {
+        await addSkill(match, source, options)
       }
     }
 
@@ -103,10 +138,10 @@ export namespace Skill {
         log.error("failed nine1bot builtin skills directory scan", { dir: nine1botBuiltinSkillsDir, error })
         return []
       })
-      for (const match of matches) {
-        await addSkill(match)
-      }
+      await addMatches(matches, defaultSource("core", "nine1bot-builtin", "nine1bot-builtin"))
     }
+
+    await scanRuntimeSkillSources(skills)
 
     // 2. Scan Nine1Bot global skills (medium priority - user can override builtin)
     // Global: ~/.config/nine1bot/skills/
@@ -123,9 +158,7 @@ export namespace Skill {
         log.error("failed nine1bot global skills directory scan", { dir: nine1botGlobalSkillsDir, error })
         return []
       })
-      for (const match of matches) {
-        await addSkill(match)
-      }
+      await addMatches(matches, defaultSource("user", "nine1bot-global", "nine1bot-global"))
     }
 
     // 3. Project-level: .nine1bot/skills/ (highest priority)
@@ -142,9 +175,7 @@ export namespace Skill {
         log.error("failed nine1bot project skills directory scan", { dir: nine1botProjectSkillsDir, error })
         return []
       })
-      for (const match of matches) {
-        await addSkill(match)
-      }
+      await addMatches(matches, defaultSource("project", "nine1bot-project", "nine1bot-project"))
     }
 
     // Scan .claude/skills/ directories (project-level)
@@ -176,9 +207,7 @@ export namespace Skill {
           return []
         })
 
-        for (const match of matches) {
-          await addSkill(match)
-        }
+        await addMatches(matches, defaultSource("user", "claude-code", "claude-code"))
       }
     }
 
@@ -191,7 +220,7 @@ export namespace Skill {
           onlyFiles: true,
           followSymlinks: true,
         })) {
-          await addSkill(match)
+          await addSkill(match, defaultSource("core", "opencode", "opencode"))
         }
       }
     }
@@ -199,14 +228,94 @@ export namespace Skill {
     return skills
   }
 
+  async function scanRuntimeSkillSources(skills: Record<string, Info>) {
+    const addSkill = async (match: string, source: Source) => {
+      const md = await ConfigMarkdown.parse(match).catch((err) => {
+        log.error("failed to load runtime skill source item", { skill: match, err })
+        return undefined
+      })
+      if (!md) return
+
+      const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
+      if (!parsed.success) return
+
+      const existing = skills[parsed.data.name]
+      if (existing && sourceVisibility(existing) === "default" && source.visibility === "declared-only") {
+        log.debug("skip declared-only runtime skill override over default skill", {
+          name: parsed.data.name,
+          existing: existing.location,
+          skipped: match,
+        })
+        return
+      }
+      if (existing) {
+        log.debug("skill override", {
+          name: parsed.data.name,
+          previous: existing.location,
+          newLocation: match,
+        })
+      }
+
+      skills[parsed.data.name] = {
+        name: parsed.data.name,
+        description: parsed.data.description,
+        location: match,
+        source,
+      }
+    }
+
+    for (const runtimeSource of RuntimeSourceRegistry.list().skills) {
+      if (!runtimeSource.owner.enabled) continue
+      if (!(await Filesystem.isDir(runtimeSource.directory))) {
+        log.debug("skip missing runtime skill source directory", {
+          owner: runtimeSource.owner.id,
+          source: runtimeSource.id,
+          directory: runtimeSource.directory,
+        })
+        continue
+      }
+
+      const matches = await Array.fromAsync(
+        NINE1BOT_SKILL_GLOB.scan({
+          cwd: runtimeSource.directory,
+          absolute: true,
+          onlyFiles: true,
+          followSymlinks: true,
+        }),
+      ).catch((error) => {
+        log.error("failed runtime skill source directory scan", {
+          owner: runtimeSource.owner.id,
+          source: runtimeSource.id,
+          directory: runtimeSource.directory,
+          error,
+        })
+        return []
+      })
+
+      const source: Source = {
+        owner: {
+          id: runtimeSource.owner.id,
+          kind: runtimeSource.owner.kind,
+        },
+        sourceID: runtimeSource.id,
+        visibility: runtimeSource.visibility,
+      }
+
+      for (const match of matches) {
+        await addSkill(match, source)
+      }
+    }
+  }
+
   /**
    * 获取技能列表（带定时缓存，支持热更新）
    */
   async function getSkillsWithCache(): Promise<Record<string, Info>> {
     const now = Date.now()
+    const cacheKey = getCacheKey()
 
     // 检查缓存是否有效
-    if (cachedSkills !== null && now - skillsLastLoadTime < SKILLS_CACHE_TTL) {
+    if (cachedSkills !== null && skillsLastCacheKey === cacheKey && now - skillsLastLoadTime < SKILLS_CACHE_TTL) {
       return cachedSkills
     }
 
@@ -214,9 +323,46 @@ export namespace Skill {
     log.info("Scanning skill directories...")
     cachedSkills = await scanSkillDirectories()
     skillsLastLoadTime = now
+    skillsLastCacheKey = cacheKey
     log.info("Skills loaded", { count: Object.keys(cachedSkills).length })
 
     return cachedSkills
+  }
+
+  function defaultSource(ownerKind: Source["owner"]["kind"], ownerID: string, sourceID: string): Source {
+    return {
+      owner: {
+        id: ownerID,
+        kind: ownerKind,
+      },
+      sourceID,
+      visibility: "default",
+    }
+  }
+
+  function sourceVisibility(skill: Info) {
+    return skill.source?.visibility ?? "default"
+  }
+
+  function getCacheKey() {
+    return JSON.stringify({
+      directory: Instance.directory,
+      worktree: Instance.worktree,
+      builtin: process.env.NINE1BOT_BUILTIN_SKILLS_DIR,
+      global: process.env.NINE1BOT_SKILLS_DIR,
+      home: process.env.OPENCODE_TEST_HOME,
+      configDir: Flag.OPENCODE_CONFIG_DIR,
+      globalConfig: Flag.OPENCODE_DISABLE_GLOBAL_CONFIG,
+      projectConfig: Flag.OPENCODE_DISABLE_PROJECT_CONFIG,
+      claude: Flag.OPENCODE_DISABLE_CLAUDE_CODE_SKILLS,
+      opencode: Flag.OPENCODE_DISABLE_OPENCODE_SKILLS,
+      runtimeSources: RuntimeSourceRegistry.version(),
+    })
+  }
+
+  function filterByVisibility(skills: Info[], options?: ListOptions) {
+    if (options?.includeDeclaredOnly) return skills
+    return skills.filter((skill) => sourceVisibility(skill) === "default")
   }
 
   // 保留原 state() 用于向后兼容
@@ -224,13 +370,20 @@ export namespace Skill {
     return getSkillsWithCache()
   })
 
-  export async function get(name: string) {
+  export async function get(name: string, options?: ListOptions) {
     const skills = await getSkillsWithCache()
-    return skills[name]
+    const skill = skills[name]
+    if (!skill) return undefined
+    if (!options?.includeDeclaredOnly && sourceVisibility(skill) === "declared-only") return undefined
+    return skill
   }
 
-  export async function all() {
+  export async function all(options?: ListOptions) {
     const skills = await getSkillsWithCache()
-    return Object.values(skills)
+    return filterByVisibility(Object.values(skills), options)
+  }
+
+  export async function defaultVisible() {
+    return all()
   }
 }

--- a/opencode/packages/opencode/test/agent/agent.test.ts
+++ b/opencode/packages/opencode/test/agent/agent.test.ts
@@ -1,8 +1,30 @@
-import { test, expect } from "bun:test"
+import { afterAll, beforeAll, test, expect } from "bun:test"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
 import { PermissionNext } from "../../src/permission/next"
+import path from "path"
+
+const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+const originalDisableGlobalConfig = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+
+beforeAll(() => {
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+  process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+})
+
+afterAll(() => {
+  restoreEnv("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", originalDisablePluginInstall)
+  restoreEnv("OPENCODE_DISABLE_GLOBAL_CONFIG", originalDisableGlobalConfig)
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
 
 // Helper to evaluate permission for a tool with wildcard pattern
 function evalPerm(agent: Agent.Info | undefined, permission: string): PermissionNext.Action | undefined {
@@ -53,7 +75,9 @@ test("plan agent denies edits except .opencode/plans/*", async () => {
       // Wildcard is denied
       expect(evalPerm(plan, "edit")).toBe("deny")
       // But specific path is allowed
-      expect(PermissionNext.evaluate("edit", ".opencode/plans/foo.md", plan!.permission).action).toBe("allow")
+      expect(PermissionNext.evaluate("edit", path.join(".opencode", "plans", "foo.md"), plan!.permission).action).toBe(
+        "allow",
+      )
     },
   })
 })

--- a/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
+++ b/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
@@ -1,0 +1,353 @@
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
+import path from "path"
+import { Agent } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { ControllerAgentRunCompiler } from "../../src/runtime/controller/agent-run-compiler"
+import { RuntimePlatformAdapterRegistry } from "../../src/runtime/platform/adapter"
+import { ControllerTemplateResolver } from "../../src/runtime/controller/template-resolver"
+import { RuntimeSourceRegistry } from "../../src/runtime/source/registry"
+import { SessionProfileCompiler } from "../../src/runtime/session/profile-compiler"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+const originalDisableGlobalConfig = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+
+beforeAll(() => {
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+  process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+})
+
+afterAll(() => {
+  restoreEnv("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", originalDisablePluginInstall)
+  restoreEnv("OPENCODE_DISABLE_GLOBAL_CONFIG", originalDisableGlobalConfig)
+})
+
+afterEach(() => {
+  RuntimeSourceRegistry.clearForTesting()
+  RuntimePlatformAdapterRegistry.clearForTesting()
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+async function writeAgent(root: string, file: string, input: {
+  name: string
+  description: string
+  mode?: "primary" | "subagent" | "all"
+}) {
+  await Bun.write(
+    path.join(root, file),
+    `---
+name: ${input.name}
+description: ${input.description}
+mode: ${input.mode ?? "primary"}
+permission:
+  read: allow
+---
+
+You are ${input.name}.
+`,
+  )
+}
+
+function registerAgentSource(input: {
+  id: string
+  directory: string
+  visibility: "declared-only" | "recommendable" | "user-selectable"
+}) {
+  RuntimeSourceRegistry.registerOwner({
+    owner: {
+      id: "gitlab",
+      kind: "platform",
+      enabled: true,
+    },
+    sources: {
+      agents: [{
+        id: input.id,
+        directory: input.directory,
+        namespace: "gitlab",
+        visibility: input.visibility,
+        lifecycle: "platform-enabled",
+      }],
+    },
+  })
+}
+
+test("platform agent visibility keeps declared and recommendable agents out of the default list", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const declaredDir = path.join(dir, "agents-declared")
+      const recommendableDir = path.join(dir, "agents-recommendable")
+      const selectableDir = path.join(dir, "agents-selectable")
+      await writeAgent(declaredDir, "declared.agent.md", {
+        name: "gitlab.declared",
+        description: "Declared GitLab agent.",
+      })
+      await writeAgent(recommendableDir, "recommendable.agent.md", {
+        name: "gitlab.recommendable",
+        description: "Recommendable GitLab agent.",
+      })
+      await writeAgent(selectableDir, "selectable.agent.md", {
+        name: "gitlab.selectable",
+        description: "Selectable GitLab agent.",
+      })
+      return { declaredDir, recommendableDir, selectableDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      RuntimeSourceRegistry.registerOwner({
+        owner: { id: "gitlab", kind: "platform", enabled: true },
+        sources: {
+          agents: [
+            {
+              id: "declared",
+              directory: tmp.extra.declaredDir,
+              visibility: "declared-only",
+              lifecycle: "platform-enabled",
+            },
+            {
+              id: "recommendable",
+              directory: tmp.extra.recommendableDir,
+              visibility: "recommendable",
+              lifecycle: "platform-enabled",
+            },
+            {
+              id: "selectable",
+              directory: tmp.extra.selectableDir,
+              visibility: "user-selectable",
+              lifecycle: "platform-enabled",
+            },
+          ],
+        },
+      })
+
+      expect((await Agent.list()).map((agent) => agent.name)).toContain("gitlab.selectable")
+      expect((await Agent.list()).map((agent) => agent.name)).not.toContain("gitlab.recommendable")
+      expect((await Agent.list()).map((agent) => agent.name)).not.toContain("gitlab.declared")
+      expect((await Agent.list({ includeRecommendable: true })).map((agent) => agent.name)).toContain(
+        "gitlab.recommendable",
+      )
+      expect((await Agent.list({ includeDeclaredOnly: true })).map((agent) => agent.name)).toEqual(
+        expect.arrayContaining(["gitlab.declared", "gitlab.recommendable", "gitlab.selectable"]),
+      )
+      expect(await Agent.get("gitlab.declared")).toBeUndefined()
+      expect(await Agent.get("gitlab.declared", { includeDeclaredOnly: true })).toMatchObject({
+        name: "gitlab.declared",
+        source: {
+          owner: { id: "gitlab", kind: "platform" },
+          sourceID: "declared",
+          visibility: "declared-only",
+        },
+      })
+      expect(await Agent.defaultAgent()).toBe("build")
+    },
+  })
+})
+
+test("platform agent source unregister invalidates agent lookup cache", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+
+      expect(await Agent.get("gitlab.review", { includeDeclaredOnly: true })).toMatchObject({
+        name: "gitlab.review",
+      })
+
+      RuntimeSourceRegistry.unregisterOwner("gitlab")
+
+      expect(await Agent.get("gitlab.review", { includeDeclaredOnly: true })).toBeUndefined()
+    },
+  })
+})
+
+test("session choice can freeze a declared-only platform agent into the profile", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+
+      const profile = await SessionProfileCompiler.compile({
+        source: "new-session",
+        agentName: "gitlab.review",
+      })
+
+      expect(profile.agent).toEqual({
+        name: "gitlab.review",
+        source: "session-choice",
+      })
+    },
+  })
+})
+
+test("template resolver validates platform recommended agents", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      RuntimePlatformAdapterRegistry.register({
+        id: "gitlab",
+        recommendedAgent: () => "gitlab.review",
+      })
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "recommendable",
+      })
+
+      const accepted = await ControllerTemplateResolver.resolve({
+        entry: {
+          source: "browser-extension",
+          platform: "gitlab",
+          templateIds: ["browser-gitlab"],
+        },
+      })
+      expect(accepted.recommendedAgent).toBe("gitlab.review")
+      expect(accepted.audit.agentRecommendation).toEqual(expect.objectContaining({
+        requested: "gitlab.review",
+        resolved: "gitlab.review",
+        accepted: true,
+        platform: "gitlab",
+      }))
+
+      RuntimeSourceRegistry.unregisterOwner("gitlab")
+
+      const rejected = await ControllerTemplateResolver.resolve({
+        entry: {
+          source: "browser-extension",
+          platform: "gitlab",
+          templateIds: ["browser-gitlab"],
+        },
+      })
+      expect(rejected.recommendedAgent).toBe("build")
+      expect(rejected.audit.agentRecommendation).toEqual(expect.objectContaining({
+        requested: "gitlab.review",
+        resolved: "build",
+        accepted: false,
+        platform: "gitlab",
+        reason: "not-found",
+      }))
+    },
+  })
+})
+
+test("controller compiler fails closed when a profiled platform agent source is disabled", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+      const profile = await SessionProfileCompiler.compile({
+        source: "new-session",
+        agentName: "gitlab.review",
+      })
+      const session = await Session.createNext({
+        directory: tmp.path,
+        runtimeProfile: profile,
+      })
+      const events: Array<{ type: string; properties: unknown }> = []
+      const unsubscribe = Bus.subscribe(Agent.Unavailable, (event) => {
+        events.push(event)
+      })
+
+      try {
+        RuntimeSourceRegistry.unregisterOwner("gitlab")
+
+        await expect(ControllerAgentRunCompiler.compileSpec({
+          session,
+          turnSnapshotId: "turn_platform_agent_unavailable",
+          body: {
+            parts: [{ type: "text", text: "hello" }],
+            entry: {
+              source: "browser-extension",
+              platform: "gitlab",
+            },
+          },
+        })).rejects.toThrow("AgentUnavailableError")
+
+        expect(events).toEqual([
+          expect.objectContaining({
+            type: "runtime.agent.unavailable",
+            properties: expect.objectContaining({
+              sessionID: session.id,
+              turnSnapshotId: "turn_platform_agent_unavailable",
+              agent: "gitlab.review",
+              reason: "disabled-by-current-config",
+            }),
+          }),
+        ])
+      } finally {
+        unsubscribe()
+      }
+    },
+  })
+})

--- a/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
+++ b/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
@@ -188,6 +188,84 @@ test("platform agent source unregister invalidates agent lookup cache", async ()
   })
 })
 
+test("platform agent source normalizes frontmatter names", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await Bun.write(
+        path.join(agentsDir, "trimmed.agent.md"),
+        `---
+name: " gitlab.trimmed "
+description: Trimmed GitLab agent.
+mode: primary
+permission:
+  read: allow
+---
+
+You are a trimmed platform agent.
+`,
+      )
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+
+      expect(await Agent.get("gitlab.trimmed", { includeDeclaredOnly: true })).toMatchObject({
+        name: "gitlab.trimmed",
+      })
+      expect(await Agent.get(" gitlab.trimmed ", { includeDeclaredOnly: true })).toBeUndefined()
+    },
+  })
+})
+
+test("platform agent cache is cleared when the current instance is disposed", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "First description.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+
+      expect(await Agent.get("gitlab.review", { includeDeclaredOnly: true })).toMatchObject({
+        description: "First description.",
+      })
+
+      await writeAgent(tmp.extra.agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "Second description.",
+      })
+      await Instance.dispose()
+
+      expect(await Agent.get("gitlab.review", { includeDeclaredOnly: true })).toMatchObject({
+        description: "Second description.",
+      })
+    },
+  })
+})
+
 test("session choice can freeze a declared-only platform agent into the profile", async () => {
   await using tmp = await tmpdir({
     git: true,

--- a/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
+++ b/opencode/packages/opencode/test/agent/platform-agent-source.test.ts
@@ -8,6 +8,7 @@ import { ControllerTemplateResolver } from "../../src/runtime/controller/templat
 import { RuntimeSourceRegistry } from "../../src/runtime/source/registry"
 import { SessionProfileCompiler } from "../../src/runtime/session/profile-compiler"
 import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -419,12 +420,106 @@ test("controller compiler fails closed when a profiled platform agent source is 
               sessionID: session.id,
               turnSnapshotId: "turn_platform_agent_unavailable",
               agent: "gitlab.review",
-              reason: "disabled-by-current-config",
+              reason: "missing-source",
             }),
           }),
         ])
       } finally {
         unsubscribe()
+      }
+    },
+  })
+})
+
+test("direct prompt agent override cannot select declared-only platform agents", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+      const session = await Session.createNext({
+        directory: tmp.path,
+      })
+
+      try {
+        await expect(SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "gitlab.review",
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })).rejects.toThrow("Agent not found: gitlab.review")
+
+        expect(await Session.messages({ sessionID: session.id })).toHaveLength(0)
+      } finally {
+        await Session.remove(session.id)
+      }
+    },
+  })
+})
+
+test("controller prompt can persist the frozen declared-only platform agent", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentsDir = path.join(dir, "agents")
+      await writeAgent(agentsDir, "review.agent.md", {
+        name: "gitlab.review",
+        description: "GitLab review agent.",
+      })
+      return { agentsDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      registerAgentSource({
+        id: "gitlab-agents",
+        directory: tmp.extra.agentsDir,
+        visibility: "declared-only",
+      })
+      const profile = await SessionProfileCompiler.compile({
+        source: "new-session",
+        agentName: "gitlab.review",
+      })
+      const session = await Session.createNext({
+        directory: tmp.path,
+        runtimeProfile: profile,
+      })
+
+      try {
+        const prompt = await ControllerAgentRunCompiler.compilePrompt({
+          session,
+          turnSnapshotId: "turn_platform_agent_prompt",
+          body: {
+            noReply: true,
+            parts: [{ type: "text", text: "hello" }],
+            entry: {
+              source: "browser-extension",
+              platform: "gitlab",
+            },
+          },
+        })
+        const message = await SessionPrompt.prompt(prompt)
+
+        expect(message.info.agent).toBe("gitlab.review")
+      } finally {
+        await Session.remove(session.id)
       }
     },
   })

--- a/opencode/packages/opencode/test/platform/runtime-source-registry.test.ts
+++ b/opencode/packages/opencode/test/platform/runtime-source-registry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { RuntimeSourceRegistry } from "../../src/runtime/source/registry"
+
+describe("RuntimeSourceRegistry", () => {
+  beforeEach(() => {
+    RuntimeSourceRegistry.clearForTesting()
+  })
+
+  test("registers agent and skill sources by owner", () => {
+    RuntimeSourceRegistry.registerOwner({
+      owner: {
+        id: "demo",
+        kind: "platform",
+        enabled: true,
+      },
+      sources: {
+        agents: [{
+          id: "demo-agents",
+          directory: "/tmp/demo/agents",
+          namespace: "demo.agent",
+          visibility: "recommendable",
+          lifecycle: "platform-enabled",
+        }],
+        skills: [{
+          id: "demo-skills",
+          directory: "/tmp/demo/skills",
+          namespace: "demo.skill",
+          visibility: "declared-only",
+          lifecycle: "platform-enabled",
+        }],
+      },
+    })
+
+    expect(RuntimeSourceRegistry.listOwner("demo")).toMatchObject({
+      owner: {
+        id: "demo",
+        kind: "platform",
+        enabled: true,
+      },
+      agents: [{
+        id: "demo-agents",
+        directory: "/tmp/demo/agents",
+        namespace: "demo.agent",
+        visibility: "recommendable",
+        lifecycle: "platform-enabled",
+        owner: {
+          id: "demo",
+        },
+      }],
+      skills: [{
+        id: "demo-skills",
+        directory: "/tmp/demo/skills",
+        namespace: "demo.skill",
+        visibility: "declared-only",
+        lifecycle: "platform-enabled",
+        owner: {
+          id: "demo",
+        },
+      }],
+    })
+
+    expect(RuntimeSourceRegistry.list().agents.map((source) => source.id)).toEqual(["demo-agents"])
+    expect(RuntimeSourceRegistry.list().skills.map((source) => source.id)).toEqual(["demo-skills"])
+  })
+
+  test("overwrites an owner registration", () => {
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {
+        agents: [{
+          id: "old-agents",
+          directory: "/tmp/old",
+          visibility: "declared-only",
+          lifecycle: "platform-enabled",
+        }],
+      },
+    })
+
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {
+        skills: [{
+          id: "new-skills",
+          directory: "/tmp/new",
+          visibility: "default",
+          lifecycle: "platform-enabled",
+        }],
+      },
+    })
+
+    expect(RuntimeSourceRegistry.listOwner("demo").agents).toEqual([])
+    expect(RuntimeSourceRegistry.listOwner("demo").skills.map((source) => source.id)).toEqual(["new-skills"])
+  })
+
+  test("unregisters all sources for an owner", () => {
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {
+        agents: [{
+          id: "demo-agents",
+          directory: "/tmp/demo/agents",
+          visibility: "user-selectable",
+          lifecycle: "platform-enabled",
+        }],
+        skills: [{
+          id: "demo-skills",
+          directory: "/tmp/demo/skills",
+          visibility: "declared-only",
+          lifecycle: "platform-enabled",
+        }],
+      },
+    })
+
+    RuntimeSourceRegistry.unregisterOwner("demo")
+
+    expect(RuntimeSourceRegistry.listOwner("demo")).toEqual({
+      owner: undefined,
+      agents: [],
+      skills: [],
+    })
+    expect(RuntimeSourceRegistry.list()).toEqual({
+      agents: [],
+      skills: [],
+    })
+  })
+})

--- a/opencode/packages/opencode/test/platform/runtime-source-registry.test.ts
+++ b/opencode/packages/opencode/test/platform/runtime-source-registry.test.ts
@@ -123,4 +123,37 @@ describe("RuntimeSourceRegistry", () => {
       skills: [],
     })
   })
+
+  test("tracks registry version for cache invalidation", () => {
+    const initial = RuntimeSourceRegistry.version()
+
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {
+        skills: [{
+          id: "demo-skills",
+          directory: "/tmp/demo/skills",
+          visibility: "declared-only",
+          lifecycle: "platform-enabled",
+        }],
+      },
+    })
+    expect(RuntimeSourceRegistry.version()).toBe(initial + 1)
+
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {},
+    })
+    expect(RuntimeSourceRegistry.version()).toBe(initial + 2)
+
+    RuntimeSourceRegistry.unregisterOwner("demo")
+    expect(RuntimeSourceRegistry.version()).toBe(initial + 3)
+
+    RuntimeSourceRegistry.registerOwner({
+      owner: { id: "demo", kind: "platform", enabled: true },
+      sources: {},
+    })
+    RuntimeSourceRegistry.clearForTesting()
+    expect(RuntimeSourceRegistry.version()).toBe(initial + 5)
+  })
 })

--- a/opencode/packages/opencode/test/skill/platform-skill-source.test.ts
+++ b/opencode/packages/opencode/test/skill/platform-skill-source.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test"
+import path from "path"
+import { RuntimeSourceRegistry } from "../../src/runtime/source/registry"
+import { RuntimeResourceResolver } from "../../src/runtime/resource/resolver"
+import type { SessionProfileSnapshot } from "../../src/runtime/protocol/agent-run-spec"
+import { Instance } from "../../src/project/instance"
+import { Skill } from "../../src/skill"
+import { SkillTool } from "../../src/tool/skill"
+import { tmpdir } from "../fixture/fixture"
+
+const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+const originalDisableGlobalConfig = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+
+beforeAll(() => {
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+  process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+})
+
+afterAll(() => {
+  restoreEnv("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", originalDisablePluginInstall)
+  restoreEnv("OPENCODE_DISABLE_GLOBAL_CONFIG", originalDisableGlobalConfig)
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function testProfile(skillNames: string[]): SessionProfileSnapshot {
+  return {
+    id: "profile_platform_skill_test",
+    sessionId: "session_platform_skill_test",
+    createdAt: Date.now(),
+    source: "new-session",
+    sourceTemplateIds: ["test", RuntimeResourceResolver.resourceTemplateId()],
+    agent: {
+      name: "build",
+      source: "default-user-template",
+    },
+    defaultModel: {
+      providerID: "test",
+      modelID: "test",
+      source: "default-user-template",
+    },
+    context: {
+      blocks: [],
+    },
+    resources: {
+      builtinTools: {},
+      mcp: {
+        servers: [],
+        lifecycle: "session",
+        mergeMode: "additive-only",
+      },
+      skills: {
+        skills: skillNames,
+        lifecycle: "session",
+        mergeMode: "additive-only",
+      },
+    },
+    permissions: {
+      rules: {},
+      source: ["test"],
+      mergeMode: "strict",
+    },
+    sessionPermissionGrants: [],
+    orchestration: {
+      mode: "single",
+    },
+  }
+}
+
+async function writeSkill(root: string, name: string, description: string) {
+  await Bun.write(
+    path.join(root, name, "SKILL.md"),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+
+Platform skill instructions.
+`,
+  )
+}
+
+function registerPlatformSkillSource(directory: string) {
+  RuntimeSourceRegistry.registerOwner({
+    owner: {
+      id: "gitlab",
+      kind: "platform",
+      enabled: true,
+    },
+    sources: {
+      skills: [{
+        id: "gitlab-skills",
+        directory,
+        namespace: "gitlab",
+        visibility: "declared-only",
+        lifecycle: "platform-enabled",
+      }],
+    },
+  })
+}
+
+beforeEach(() => {
+  RuntimeSourceRegistry.clearForTesting()
+})
+
+afterEach(() => {
+  RuntimeSourceRegistry.clearForTesting()
+})
+
+test("declared-only platform skills are hidden from default skill lists", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const platformSkills = path.join(dir, "platform-skills")
+      await writeSkill(platformSkills, "gitlab-review", "Review GitLab changes.")
+      return { platformSkills }
+    },
+  })
+
+  const originalHome = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = tmp.path
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        registerPlatformSkillSource(tmp.extra.platformSkills)
+
+        expect(await Skill.get("gitlab-review")).toBeUndefined()
+        expect((await Skill.all()).map((skill) => skill.name)).not.toContain("gitlab-review")
+        expect((await Skill.all({ includeDeclaredOnly: true })).map((skill) => skill.name)).toContain("gitlab-review")
+
+        const resources = await RuntimeResourceResolver.compileProfileResources()
+        expect(resources.skills.skills).not.toContain("gitlab-review")
+      },
+    })
+  } finally {
+    process.env.OPENCODE_TEST_HOME = originalHome
+  }
+})
+
+test("declared-only platform skills resolve when profile explicitly declares them", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const platformSkills = path.join(dir, "platform-skills")
+      await writeSkill(platformSkills, "gitlab-review", "Review GitLab changes.")
+      return { platformSkills }
+    },
+  })
+
+  const originalHome = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = tmp.path
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        registerPlatformSkillSource(tmp.extra.platformSkills)
+
+        const resolved = await RuntimeResourceResolver.resolve({
+          sessionID: "session_platform_skill_test",
+          profile: testProfile(["gitlab-review"]),
+          emitFailures: false,
+          emitResolved: false,
+        })
+
+        expect(resolved.skills.availableSkills.map((skill) => skill.name)).toEqual(["gitlab-review"])
+
+        const skillTool = await SkillTool.init({ skills: resolved.skills.availableSkills })
+        expect(skillTool.description).toContain("gitlab-review")
+
+        const result = await skillTool.execute(
+          { name: "gitlab-review" },
+          {
+            sessionID: "session_platform_skill_test",
+            messageID: "message_platform_skill_test",
+            agent: "build",
+            abort: new AbortController().signal,
+            cwd: tmp.path,
+            messages: [],
+            metadata() {},
+            ask: async () => {},
+          },
+        )
+
+        expect(result.title).toBe("Loaded skill: gitlab-review")
+        expect(result.output).toContain("Platform skill instructions.")
+      },
+    })
+  } finally {
+    process.env.OPENCODE_TEST_HOME = originalHome
+  }
+})
+
+test("unregistered platform skill sources become unavailable for declared profiles", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const platformSkills = path.join(dir, "platform-skills")
+      await writeSkill(platformSkills, "gitlab-review", "Review GitLab changes.")
+      return { platformSkills }
+    },
+  })
+
+  const originalHome = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = tmp.path
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        registerPlatformSkillSource(tmp.extra.platformSkills)
+
+        const profile = testProfile(["gitlab-review"])
+        const first = await RuntimeResourceResolver.resolve({
+          sessionID: "session_platform_skill_test",
+          profile,
+          emitFailures: false,
+          emitResolved: false,
+        })
+        expect(first.skills.availableSkills.map((skill) => skill.name)).toEqual(["gitlab-review"])
+
+        RuntimeSourceRegistry.unregisterOwner("gitlab")
+
+        const second = await RuntimeResourceResolver.resolve({
+          sessionID: "session_platform_skill_test",
+          profile,
+          emitFailures: false,
+          emitResolved: false,
+        })
+        expect(second.skills.availableSkills).toEqual([])
+        expect(second.skills.availability["gitlab-review"].reason).toBe("disabled-by-current-config")
+        expect(second.failures).toContainEqual(expect.objectContaining({
+          resourceType: "skill",
+          resourceID: "gitlab-review",
+          reason: "disabled-by-current-config",
+        }))
+      },
+    })
+  } finally {
+    process.env.OPENCODE_TEST_HOME = originalHome
+  }
+})

--- a/opencode/packages/opencode/test/skill/skill.test.ts
+++ b/opencode/packages/opencode/test/skill/skill.test.ts
@@ -1,9 +1,34 @@
-import { test, expect } from "bun:test"
+import { afterAll, beforeAll, test, expect } from "bun:test"
 import { Skill } from "../../src/skill"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
+
+const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+const originalDisableGlobalConfig = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+
+beforeAll(() => {
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+  process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+})
+
+afterAll(() => {
+  restoreEnv("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", originalDisablePluginInstall)
+  restoreEnv("OPENCODE_DISABLE_GLOBAL_CONFIG", originalDisableGlobalConfig)
+})
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+function normalizePath(value: string) {
+  return value.replaceAll("\\", "/")
+}
 
 async function createGlobalSkill(homeDir: string) {
   const skillDir = path.join(homeDir, ".claude", "skills", "global-test-skill")
@@ -50,7 +75,7 @@ Instructions here.
       const testSkill = skills.find((s) => s.name === "test-skill")
       expect(testSkill).toBeDefined()
       expect(testSkill!.description).toBe("A test skill for verification.")
-      expect(testSkill!.location).toContain("skill/test-skill/SKILL.md")
+      expect(normalizePath(testSkill!.location)).toContain("skill/test-skill/SKILL.md")
     },
   })
 })
@@ -144,7 +169,7 @@ description: A skill in the .claude/skills directory.
       expect(skills.length).toBe(1)
       const claudeSkill = skills.find((s) => s.name === "claude-skill")
       expect(claudeSkill).toBeDefined()
-      expect(claudeSkill!.location).toContain(".claude/skills/claude-skill/SKILL.md")
+      expect(normalizePath(claudeSkill!.location)).toContain(".claude/skills/claude-skill/SKILL.md")
     },
   })
 })
@@ -164,7 +189,7 @@ test("discovers global skills from ~/.claude/skills/ directory", async () => {
         expect(skills.length).toBe(1)
         expect(skills[0].name).toBe("global-test-skill")
         expect(skills[0].description).toBe("A global skill from ~/.claude/skills for testing.")
-        expect(skills[0].location).toContain(".claude/skills/global-test-skill/SKILL.md")
+        expect(normalizePath(skills[0].location)).toContain(".claude/skills/global-test-skill/SKILL.md")
       },
     })
   } finally {

--- a/opencode/packages/opencode/test/tool/read.test.ts
+++ b/opencode/packages/opencode/test/tool/read.test.ts
@@ -146,6 +146,7 @@ describe("tool.read env file permissions", () => {
         directory: tmp.path,
         fn: async () => {
           const agent = await Agent.get(agentName)
+          if (!agent) throw new Error(`Agent not found: ${agentName}`)
           let askedForEnv = false
           const ctxWithPermissions = {
             ...ctx,

--- a/packages/nine1bot/src/platform/manager.test.ts
+++ b/packages/nine1bot/src/platform/manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import type { PlatformAdapterContext, PlatformAdapterContribution, PlatformSecretAccess } from '@nine1bot/platform-protocol'
+import type { PlatformAdapterContext, PlatformAdapterContribution, PlatformRuntimeSourcesDescriptor, PlatformSecretAccess } from '@nine1bot/platform-protocol'
 import { RuntimePlatformAdapterRegistry } from '../../../../opencode/packages/opencode/src/runtime/platform/adapter'
+import { RuntimeSourceRegistry } from '../../../../opencode/packages/opencode/src/runtime/source/registry'
 import { PlatformAdapterManager } from './manager'
 import { registerBuiltinPlatformAdapters, resetBuiltinPlatformManagerForTesting } from './builtin'
 import { registerGitLabPlatformAdapter } from './gitlab'
@@ -8,6 +9,7 @@ import { registerGitLabPlatformAdapter } from './gitlab'
 function resetPlatformState() {
   resetBuiltinPlatformManagerForTesting()
   RuntimePlatformAdapterRegistry.clearForTesting()
+  RuntimeSourceRegistry.clearForTesting()
 }
 
 beforeEach(resetPlatformState)
@@ -17,6 +19,7 @@ function contribution(id: string, options: {
   defaultEnabled?: boolean
   throws?: boolean
   templates?: string[]
+  sources?: PlatformRuntimeSourcesDescriptor
 } = {}): PlatformAdapterContribution {
   return {
     descriptor: {
@@ -39,6 +42,7 @@ function contribution(id: string, options: {
           id,
         }
       },
+      sources: options.sources,
     },
   }
 }
@@ -60,6 +64,25 @@ function memorySecrets() {
     },
   }
   return { access, values }
+}
+
+function runtimeSources(): PlatformRuntimeSourcesDescriptor {
+  return {
+    agents: [{
+      id: 'demo-agents',
+      directory: '/tmp/demo/agents',
+      namespace: 'demo.agent',
+      visibility: 'recommendable',
+      lifecycle: 'platform-enabled',
+    }],
+    skills: [{
+      id: 'demo-skills',
+      directory: '/tmp/demo/skills',
+      namespace: 'demo.skill',
+      visibility: 'declared-only',
+      lifecycle: 'platform-enabled',
+    }],
+  }
 }
 
 describe('PlatformAdapterManager', () => {
@@ -200,6 +223,147 @@ describe('PlatformAdapterManager', () => {
       provider: 'nine1bot-local',
       key: 'demo',
     })).toBe('secret-value')
+  })
+
+  it('registers runtime sources for enabled platforms', async () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [contribution('demo', {
+        defaultEnabled: true,
+        sources: runtimeSources(),
+      })],
+    })
+
+    manager.registerRuntimeAdapters()
+
+    expect(RuntimeSourceRegistry.listOwner('demo')).toMatchObject({
+      owner: {
+        id: 'demo',
+        kind: 'platform',
+        enabled: true,
+      },
+      agents: [{
+        id: 'demo-agents',
+        directory: '/tmp/demo/agents',
+        visibility: 'recommendable',
+      }],
+      skills: [{
+        id: 'demo-skills',
+        directory: '/tmp/demo/skills',
+        visibility: 'declared-only',
+      }],
+    })
+    await expect(manager.getDetail('demo')).resolves.toMatchObject({
+      runtimeSources: {
+        agents: [{
+          id: 'demo-agents',
+          status: 'registered',
+        }],
+        skills: [{
+          id: 'demo-skills',
+          status: 'registered',
+        }],
+      },
+    })
+  })
+
+  it('does not register runtime sources for disabled platforms', async () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [contribution('demo', {
+        defaultEnabled: true,
+        sources: runtimeSources(),
+      })],
+      config: {
+        demo: {
+          enabled: false,
+        },
+      },
+    })
+
+    manager.registerRuntimeAdapters()
+
+    expect(RuntimeSourceRegistry.listOwner('demo')).toEqual({
+      owner: undefined,
+      agents: [],
+      skills: [],
+    })
+    await expect(manager.getDetail('demo')).resolves.toMatchObject({
+      runtimeSources: {
+        agents: [{
+          id: 'demo-agents',
+          status: 'disabled',
+        }],
+        skills: [{
+          id: 'demo-skills',
+          status: 'disabled',
+        }],
+      },
+    })
+  })
+
+  it('clears runtime sources when unregistering or reconfiguring platforms', () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [contribution('demo', {
+        defaultEnabled: true,
+        sources: runtimeSources(),
+      })],
+    })
+
+    manager.registerRuntimeAdapters()
+    expect(RuntimeSourceRegistry.listOwner('demo').agents.map((source) => source.id)).toEqual(['demo-agents'])
+
+    manager.unregisterRuntimeAdapters()
+    expect(RuntimeSourceRegistry.listOwner('demo').agents).toEqual([])
+
+    manager.configure({
+      demo: {
+        enabled: true,
+      },
+    })
+    expect(RuntimeSourceRegistry.listOwner('demo').agents).toEqual([])
+  })
+
+  it('does not leave runtime sources behind when adapter creation fails', async () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [
+        contribution('bad', {
+          defaultEnabled: true,
+          throws: true,
+          sources: {
+            agents: [{
+              id: 'bad-agents',
+              directory: '/tmp/bad/agents',
+              visibility: 'recommendable',
+              lifecycle: 'platform-enabled',
+            }],
+          },
+        }),
+        contribution('good', {
+          defaultEnabled: true,
+          sources: {
+            skills: [{
+              id: 'good-skills',
+              directory: '/tmp/good/skills',
+              visibility: 'declared-only',
+              lifecycle: 'platform-enabled',
+            }],
+          },
+        }),
+      ],
+    })
+
+    manager.registerRuntimeAdapters()
+
+    expect(RuntimeSourceRegistry.listOwner('bad').agents).toEqual([])
+    expect(RuntimeSourceRegistry.listOwner('good').skills.map((source) => source.id)).toEqual(['good-skills'])
+    await expect(manager.getDetail('bad')).resolves.toMatchObject({
+      runtimeSources: {
+        agents: [{
+          id: 'bad-agents',
+          status: 'error',
+          error: 'bad failed',
+        }],
+      },
+    })
   })
 
   it('registers built-in GitLab through the manager', () => {

--- a/packages/nine1bot/src/platform/manager.test.ts
+++ b/packages/nine1bot/src/platform/manager.test.ts
@@ -266,6 +266,33 @@ describe('PlatformAdapterManager', () => {
     })
   })
 
+  it('reports enabled registered source drift as error instead of disabled', async () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [contribution('demo', {
+        defaultEnabled: true,
+        sources: runtimeSources(),
+      })],
+    })
+
+    manager.registerRuntimeAdapters()
+    RuntimeSourceRegistry.unregisterOwner('demo')
+
+    await expect(manager.getDetail('demo')).resolves.toMatchObject({
+      runtimeSources: {
+        agents: [{
+          id: 'demo-agents',
+          status: 'error',
+          error: 'Runtime source "demo-agents" was declared but not registered.',
+        }],
+        skills: [{
+          id: 'demo-skills',
+          status: 'error',
+          error: 'Runtime source "demo-skills" was declared but not registered.',
+        }],
+      },
+    })
+  })
+
   it('does not register runtime sources for disabled platforms', async () => {
     const manager = new PlatformAdapterManager({
       contributions: [contribution('demo', {

--- a/packages/nine1bot/src/platform/manager.ts
+++ b/packages/nine1bot/src/platform/manager.ts
@@ -578,7 +578,7 @@ export class PlatformAdapterManager {
         namespace: source.namespace,
         visibility: source.visibility,
         status: registeredAgents.has(source.id) ? 'registered' : status,
-        error: status === 'error' ? record.error : undefined,
+        error: runtimeSourceError(record, source.id, status),
       })),
       skills: (sources.skills ?? []).map((source) => ({
         id: source.id,
@@ -586,7 +586,7 @@ export class PlatformAdapterManager {
         namespace: source.namespace,
         visibility: source.visibility,
         status: registeredSkills.has(source.id) ? 'registered' : status,
-        error: status === 'error' ? record.error : undefined,
+        error: runtimeSourceError(record, source.id, status),
       })),
     }
   }
@@ -791,7 +791,17 @@ function lifecycleStatusFromRuntime(status: PlatformRuntimeStatus['status']): Pl
 function runtimeSourceStatus(record: PlatformManagerRecord): PlatformRuntimeSourceSummary['status'] {
   if (!record.enabled) return 'disabled'
   if (record.lifecycleStatus === 'error') return 'error'
-  return 'disabled'
+  if (!record.registered) return 'disabled'
+  return 'error'
+}
+
+function runtimeSourceError(
+  record: PlatformManagerRecord,
+  sourceID: string,
+  status: PlatformRuntimeSourceSummary['status'],
+): string | undefined {
+  if (status !== 'error') return undefined
+  return record.error ?? `Runtime source "${sourceID}" was declared but not registered.`
 }
 
 function secretFields(config?: PlatformConfigDescriptor): PlatformConfigField[] {

--- a/packages/nine1bot/src/platform/manager.ts
+++ b/packages/nine1bot/src/platform/manager.ts
@@ -8,12 +8,14 @@ import type {
   PlatformConfigDescriptor,
   PlatformConfigField,
   PlatformDescriptor,
+  PlatformRuntimeSourcesDescriptor,
   PlatformRuntimeStatus,
   PlatformSecretAccess,
   PlatformSecretRef,
   PlatformValidationResult,
 } from '@nine1bot/platform-protocol'
 import { RuntimePlatformAdapterRegistry } from '../../../../opencode/packages/opencode/src/runtime/platform/adapter'
+import { RuntimeSourceRegistry } from '../../../../opencode/packages/opencode/src/runtime/source/registry'
 
 export type PlatformLifecycleStatus =
   | 'discovered'
@@ -75,6 +77,21 @@ export type PlatformManagerDetail = PlatformManagerSummary & {
   features: Record<string, boolean>
   settings: Record<string, unknown>
   runtimeStatus: PlatformRuntimeStatus
+  runtimeSources?: PlatformRuntimeSourcesSummary
+}
+
+export type PlatformRuntimeSourceSummary = {
+  id: string
+  directory: string
+  namespace?: string
+  visibility: string
+  status: 'registered' | 'disabled' | 'error'
+  error?: string
+}
+
+export type PlatformRuntimeSourcesSummary = {
+  agents: PlatformRuntimeSourceSummary[]
+  skills: PlatformRuntimeSourceSummary[]
 }
 
 export type PlatformConfigPatch = {
@@ -209,6 +226,7 @@ export class PlatformAdapterManager {
       features: { ...record.features },
       settings: await this.redactSettings(record),
       runtimeStatus: cloneJson(record.runtimeStatus),
+      runtimeSources: this.runtimeSourcesForRecord(record),
     }
   }
 
@@ -223,6 +241,7 @@ export class PlatformAdapterManager {
           reason: 'platform-disabled-by-current-config',
           message: `Platform "${record.descriptor.name}" is disabled by the current configuration.`,
         })
+        RuntimeSourceRegistry.unregisterOwner(record.id)
         continue
       }
       if (record.registered) continue
@@ -235,6 +254,7 @@ export class PlatformAdapterManager {
       try {
         const adapter = contribution.runtime.createAdapter(this.createContext(record))
         RuntimePlatformAdapterRegistry.register(adapter)
+        this.registerRuntimeSources(record, contribution.runtime.sources)
         this.records.set(record.id, {
           ...record,
           registered: true,
@@ -273,6 +293,7 @@ export class PlatformAdapterManager {
       if (record.registered) {
         RuntimePlatformAdapterRegistry.unregister(record.id)
       }
+      RuntimeSourceRegistry.unregisterOwner(record.id)
       RuntimePlatformAdapterRegistry.unmarkDisabled(record.id)
       const nextStatus: PlatformRuntimeStatus = !record.installed
         ? { status: 'missing', message: `Platform package is not installed: ${record.id}` }
@@ -524,6 +545,52 @@ export class PlatformAdapterManager {
     }
   }
 
+  private registerRuntimeSources(record: PlatformManagerRecord, sources?: PlatformRuntimeSourcesDescriptor) {
+    RuntimeSourceRegistry.registerOwner({
+      owner: {
+        id: record.id,
+        kind: 'platform',
+        enabled: record.enabled,
+      },
+      sources: sources
+        ? {
+            agents: sources.agents?.map((source) => ({ ...source })),
+            skills: sources.skills?.map((source) => ({ ...source })),
+          }
+        : undefined,
+    })
+  }
+
+  private runtimeSourcesForRecord(record: PlatformManagerRecord): PlatformRuntimeSourcesSummary | undefined {
+    const contribution = this.contributions.get(record.id)
+    const sources = contribution?.runtime?.sources
+    if (!sources?.agents?.length && !sources?.skills?.length) return undefined
+
+    const registered = RuntimeSourceRegistry.listOwner(record.id)
+    const status = runtimeSourceStatus(record)
+    const registeredAgents = new Set(registered.agents.map((source) => source.id))
+    const registeredSkills = new Set(registered.skills.map((source) => source.id))
+
+    return {
+      agents: (sources.agents ?? []).map((source) => ({
+        id: source.id,
+        directory: source.directory,
+        namespace: source.namespace,
+        visibility: source.visibility,
+        status: registeredAgents.has(source.id) ? 'registered' : status,
+        error: status === 'error' ? record.error : undefined,
+      })),
+      skills: (sources.skills ?? []).map((source) => ({
+        id: source.id,
+        directory: source.directory,
+        namespace: source.namespace,
+        visibility: source.visibility,
+        status: registeredSkills.has(source.id) ? 'registered' : status,
+        error: status === 'error' ? record.error : undefined,
+      })),
+    }
+  }
+
   private async prepareConfigEntry(
     record: PlatformManagerRecord,
     previousEntry: PlatformConfigEntry,
@@ -719,6 +786,12 @@ function lifecycleStatusFromRuntime(status: PlatformRuntimeStatus['status']): Pl
   if (status === 'disabled') return 'disabled'
   if (status === 'error') return 'error'
   return 'degraded'
+}
+
+function runtimeSourceStatus(record: PlatformManagerRecord): PlatformRuntimeSourceSummary['status'] {
+  if (!record.enabled) return 'disabled'
+  if (record.lifecycleStatus === 'error') return 'error'
+  return 'disabled'
 }
 
 function secretFields(config?: PlatformConfigDescriptor): PlatformConfigField[] {

--- a/packages/platform-protocol/src/index.ts
+++ b/packages/platform-protocol/src/index.ts
@@ -148,10 +148,34 @@ export type PlatformActionResult = {
   updatedSettings?: unknown
 }
 
+export type PlatformRuntimeSourceLifecycle = 'platform-enabled'
+
+export type PlatformSkillSourceDescriptor = {
+  id: string
+  directory: string
+  namespace?: string
+  visibility: 'default' | 'declared-only'
+  lifecycle: PlatformRuntimeSourceLifecycle
+}
+
+export type PlatformAgentSourceDescriptor = {
+  id: string
+  directory: string
+  namespace?: string
+  visibility: 'declared-only' | 'recommendable' | 'user-selectable'
+  lifecycle: PlatformRuntimeSourceLifecycle
+}
+
+export type PlatformRuntimeSourcesDescriptor = {
+  agents?: PlatformAgentSourceDescriptor[]
+  skills?: PlatformSkillSourceDescriptor[]
+}
+
 export type PlatformAdapterContribution = {
   descriptor: PlatformDescriptor
   runtime?: {
     createAdapter: (ctx: PlatformAdapterContext) => PlatformRuntimeAdapter
+    sources?: PlatformRuntimeSourcesDescriptor
   }
   getStatus?: (ctx: PlatformAdapterContext) => Promise<PlatformRuntimeStatus>
   validateConfig?: (settings: unknown, ctx: PlatformAdapterContext) => Promise<PlatformValidationResult>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1838,6 +1838,20 @@ export interface PlatformRuntimeStatus {
   recentEvents?: PlatformRecentEvent[]
 }
 
+export interface PlatformRuntimeSourceSummary {
+  id: string
+  directory: string
+  namespace?: string
+  visibility: string
+  status: 'registered' | 'disabled' | 'error'
+  error?: string
+}
+
+export interface PlatformRuntimeSourcesSummary {
+  agents: PlatformRuntimeSourceSummary[]
+  skills: PlatformRuntimeSourceSummary[]
+}
+
 export interface PlatformSecretFieldValue {
   redacted: true
   hasValue: boolean
@@ -1871,6 +1885,7 @@ export interface PlatformDetail extends PlatformSummary {
   features: Record<string, boolean>
   settings: Record<string, unknown>
   runtimeStatus: PlatformRuntimeStatus
+  runtimeSources?: PlatformRuntimeSourcesSummary
 }
 
 export interface PlatformConfigPatch {


### PR DESCRIPTION
﻿## Summary

This PR builds on the managed platform adapter foundation already merged in #42. It adds runtime source support so enabled platform adapters can register their own agents and skills without putting platform-specific resources into the global runtime defaults.

Key changes:

- Adds `RuntimeSourceRegistry` for owner-scoped agent and skill source metadata.
- Wires Platform Adapter Manager to register/unregister runtime sources with platform enable/disable lifecycle.
- Adds declared-only platform skill scanning so platform skills stay hidden from default sessions but can be resolved when explicitly declared by a platform template/profile.
- Adds platform agent source scanning with `declared-only`, `recommendable`, and `user-selectable` visibility.
- Keeps platform agents out of `defaultAgent()` and ignores per-turn `body.agent` overrides after profile creation.
- Emits/project runtime envelopes for `runtime.agent.unavailable` when an old session references a now-disabled/missing platform agent.
- Expands the platform adapter developer guide with the current implementation model for adapter packages, runtime sources, skills, agents, config, secrets, live gate, and tests.

## Why

Platform adapters need to bring their own workflow-specific agents and skills while keeping ordinary Web sessions lightweight. This PR gives platform packages a controlled registration path through the Platform Adapter Manager and runtime registries, so future GitLab/GitHub/Jira/Feishu adapters can provide their own resources without hard-coding platform logic in runtime core.

## Developer Impact

Future platform adapters can now:

- declare `runtime.sources.agents` and `runtime.sources.skills` from `packages/platform-*`
- keep platform skills `declared-only` until a platform template explicitly adds them to the session profile
- expose platform agents as `recommendable` or `user-selectable` without changing the global default agent
- rely on live gate behavior when a platform is disabled after a session was created
- follow `docs/agent-runtime-developer-guide/09-platform-adapter-development-guide.md` as the implementation checklist

## Validation

Ran before rebasing the branch onto latest `origin/main`:

- `bun run --cwd packages/platform-protocol typecheck`
- `bun run --cwd packages/platform-gitlab typecheck`
- `bun run --cwd packages/nine1bot typecheck`
- `bun run --cwd opencode/packages/opencode typecheck`
- `bun test packages/platform-gitlab`
- `bun test packages/nine1bot/src/platform`
- `bun test packages/nine1bot/src/config packages/nine1bot/src/engine`
- `bun test opencode/packages/opencode/test/agent opencode/packages/opencode/test/controller opencode/packages/opencode/test/platform opencode/packages/opencode/test/skill`
- `bun test web/test`
- `bun run build:web`
- `bun run --cwd packages/browser-extension typecheck`
- `bun run --cwd packages/browser-extension build`
- `git diff --check`

After rebase:

- `git diff --check origin/main..HEAD`
- verified PR #43 now contains exactly 4 commits

Notes:

- `build:web` still reports the existing large chunk warning.
- browser extension build still reports the existing dynamic/static import chunking warning.
