### PR TITLE
Improve terminal session stability

### DIFF
--- a/opencode/packages/opencode/src/pty/agent-terminal.ts
+++ b/opencode/packages/opencode/src/pty/agent-terminal.ts
@@ -70,6 +70,15 @@ export namespace AgentTerminal {
 
   export type BufferSnapshot = z.infer<typeof BufferSnapshot>
 
+  export interface ScreenSnapshot {
+    sessionID: string
+    screen: string
+    screenAnsi: string
+    cursor: ScreenBuffer.CursorPosition
+    info: ScreenBuffer.ScreenInfo
+    fullView?: string
+  }
+
   export const CreateInput = z.object({
     name: z.string().optional(),
     sessionID: z.string(),
@@ -172,14 +181,14 @@ export namespace AgentTerminal {
   /**
    * 获取指定终端信息
    */
-  export function get(id: string, sessionID?: string): Info | undefined {
+  export function get(id: string, sessionID: string): Info | undefined {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     return session.info
   }
 
-  function belongsToSession(session: ActiveSession, sessionID?: string) {
-    return Boolean(sessionID && session.info.sessionID === sessionID)
+  function belongsToSession(session: ActiveSession, sessionID: string) {
+    return session.info.sessionID === sessionID
   }
 
   function shellArgs(command: string, inputArgs?: string[]) {
@@ -396,7 +405,7 @@ export namespace AgentTerminal {
   /**
    * 向终端发送输入
    */
-  export function write(id: string, data: string, sessionID?: string): boolean {
+  export function write(id: string, data: string, sessionID: string): boolean {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID) || session.info.status !== "running") {
       return false
@@ -409,7 +418,7 @@ export namespace AgentTerminal {
   /**
    * 获取当前屏幕内容
    */
-  export async function getScreen(id: string, sessionID?: string): Promise<string | undefined> {
+  export async function getScreen(id: string, sessionID: string): Promise<string | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -419,7 +428,7 @@ export namespace AgentTerminal {
   /**
    * 获取带 ANSI 转义序列的屏幕内容
    */
-  export async function getScreenAnsi(id: string, sessionID?: string): Promise<string | undefined> {
+  export async function getScreenAnsi(id: string, sessionID: string): Promise<string | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -429,7 +438,7 @@ export namespace AgentTerminal {
   /**
    * 获取屏幕行数组
    */
-  export async function getScreenLines(id: string, sessionID?: string): Promise<string[] | undefined> {
+  export async function getScreenLines(id: string, sessionID: string): Promise<string[] | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -439,7 +448,7 @@ export namespace AgentTerminal {
   /**
    * 获取滚动历史
    */
-  export async function getScrollback(id: string, lines?: number, sessionID?: string): Promise<string[] | undefined> {
+  export async function getScrollback(id: string, lines: number | undefined, sessionID: string): Promise<string[] | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -449,7 +458,7 @@ export namespace AgentTerminal {
   /**
    * 获取完整视图（历史 + 屏幕）
    */
-  export async function getFullView(id: string, historyLines = 50, sessionID?: string): Promise<string | undefined> {
+  export async function getFullView(id: string, historyLines: number, sessionID: string): Promise<string | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -459,7 +468,7 @@ export namespace AgentTerminal {
   /**
    * 获取光标位置
    */
-  export async function getCursor(id: string, sessionID?: string): Promise<ScreenBuffer.CursorPosition | undefined> {
+  export async function getCursor(id: string, sessionID: string): Promise<ScreenBuffer.CursorPosition | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
@@ -469,11 +478,29 @@ export namespace AgentTerminal {
   /**
    * 获取终端详细信息
    */
-  export async function getScreenInfo(id: string, sessionID?: string): Promise<ScreenBuffer.ScreenInfo | undefined> {
+  export async function getScreenInfo(id: string, sessionID: string): Promise<ScreenBuffer.ScreenInfo | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await session.buffer.flush()
     return session.buffer.getInfo()
+  }
+
+  export async function getScreenSnapshot(
+    id: string,
+    sessionID: string,
+    historyLines?: number,
+  ): Promise<ScreenSnapshot | undefined> {
+    const session = state().get(id)
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
+    return {
+      sessionID: session.info.sessionID,
+      screen: session.buffer.getScreenText(),
+      screenAnsi: session.buffer.getScreenAnsi(),
+      cursor: session.buffer.getCursor(),
+      info: session.buffer.getInfo(),
+      fullView: historyLines === undefined ? undefined : session.buffer.getFullView(historyLines),
+    }
   }
 
   /**
@@ -482,8 +509,8 @@ export namespace AgentTerminal {
   export async function waitFor(
     id: string,
     pattern: string | RegExp,
-    timeout = 30000,
-    sessionID?: string,
+    timeout: number,
+    sessionID: string,
   ): Promise<{ matched: boolean; timedOut: boolean; screen?: string }> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) {
@@ -501,14 +528,14 @@ export namespace AgentTerminal {
   /**
    * 调整终端大小
    */
-  export function resize(id: string, rows: number, cols: number, sessionID?: string): boolean {
+  export async function resize(id: string, rows: number, cols: number, sessionID: string): Promise<boolean> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID) || session.info.status !== "running") {
       return false
     }
 
     session.process.resize(cols, rows)
-    session.buffer.resize(rows, cols)
+    await session.buffer.resize(rows, cols)
     session.info.rows = rows
     session.info.cols = cols
 
@@ -520,7 +547,7 @@ export namespace AgentTerminal {
   /**
    * 关闭终端
    */
-  export async function close(id: string, sessionID?: string): Promise<boolean> {
+  export async function close(id: string, sessionID: string): Promise<boolean> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) {
       return false
@@ -536,6 +563,7 @@ export namespace AgentTerminal {
       session.outputFlushTimer = null
     }
     await flushOutput(session)
+    await session.buffer.flush()
 
     try {
       session.process.kill()
@@ -551,7 +579,7 @@ export namespace AgentTerminal {
   /**
    * 获取原始输出缓冲区
    */
-  export async function getBuffer(id: string, afterSeq?: number, sessionID?: string): Promise<BufferSnapshot | undefined> {
+  export async function getBuffer(id: string, afterSeq: number | undefined, sessionID: string): Promise<BufferSnapshot | undefined> {
     const session = state().get(id)
     if (!session || !belongsToSession(session, sessionID)) return undefined
     await flushOutput(session)

--- a/opencode/packages/opencode/src/pty/agent-terminal.ts
+++ b/opencode/packages/opencode/src/pty/agent-terminal.ts
@@ -179,7 +179,7 @@ export namespace AgentTerminal {
   }
 
   function belongsToSession(session: ActiveSession, sessionID?: string) {
-    return !sessionID || session.info.sessionID === sessionID
+    return Boolean(sessionID && session.info.sessionID === sessionID)
   }
 
   function shellArgs(command: string, inputArgs?: string[]) {

--- a/opencode/packages/opencode/src/pty/agent-terminal.ts
+++ b/opencode/packages/opencode/src/pty/agent-terminal.ts
@@ -9,6 +9,7 @@ import { ProjectEnvironment } from "../project/environment"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { ScreenBuffer } from "./screen-buffer"
+import path from "path"
 
 /**
  * AgentTerminal - Agent 控制的持久化终端会话
@@ -23,6 +24,8 @@ export namespace AgentTerminal {
   const log = Log.create({ service: "agent-terminal" })
 
   const BUFFER_LIMIT = 1024 * 1024 * 2
+  const OUTPUT_FLUSH_INTERVAL = 25 // ms
+  const OUTPUT_FLUSH_BYTES = 64 * 1024
   const SCREEN_UPDATE_THROTTLE = 100 // ms
 
   const pty = lazy(async () => {
@@ -49,6 +52,23 @@ export namespace AgentTerminal {
     .meta({ ref: "AgentTerminal" })
 
   export type Info = z.infer<typeof Info>
+
+  export const OutputChunk = z.object({
+    seq: z.number().int().nonnegative(),
+    data: z.string(),
+  })
+
+  export type OutputChunk = z.infer<typeof OutputChunk>
+
+  export const BufferSnapshot = z.object({
+    buffer: z.string(),
+    chunks: z.array(OutputChunk),
+    latestSeq: z.number().int().nonnegative(),
+    firstSeq: z.number().int().nonnegative(),
+    reset: z.boolean(),
+  })
+
+  export type BufferSnapshot = z.infer<typeof BufferSnapshot>
 
   export const CreateInput = z.object({
     name: z.string().optional(),
@@ -77,6 +97,7 @@ export namespace AgentTerminal {
       "agent-terminal.screen",
       z.object({
         id: Identifier.schema("agt"),
+        sessionID: z.string(),
         screen: z.string(),
         screenAnsi: z.string(),
         cursor: z.object({ row: z.number(), col: z.number() }),
@@ -87,16 +108,18 @@ export namespace AgentTerminal {
       "agent-terminal.output",
       z.object({
         id: Identifier.schema("agt"),
+        sessionID: z.string(),
+        seq: z.number().int().nonnegative(),
         data: z.string(),
       })
     ),
     Exited: BusEvent.define(
       "agent-terminal.exited",
-      z.object({ id: Identifier.schema("agt"), exitCode: z.number() })
+      z.object({ id: Identifier.schema("agt"), sessionID: z.string(), exitCode: z.number() })
     ),
     Closed: BusEvent.define(
       "agent-terminal.closed",
-      z.object({ id: Identifier.schema("agt") })
+      z.object({ id: Identifier.schema("agt"), sessionID: z.string() })
     ),
   }
 
@@ -105,8 +128,15 @@ export namespace AgentTerminal {
     process: IPty
     buffer: ScreenBuffer.Buffer
     rawBuffer: string
+    outputSeq: number
+    outputChunks: OutputChunk[]
+    outputChunkBytes: number
+    pendingOutput: string
+    outputFlushTimer: ReturnType<typeof setTimeout> | null
+    outputPublishChain: Promise<void>
     lastScreenUpdate: number
     screenUpdateTimer: ReturnType<typeof setTimeout> | null
+    screenPublishChain: Promise<void>
   }
 
   const state = Instance.state(
@@ -119,6 +149,9 @@ export namespace AgentTerminal {
         session.buffer.dispose()
         if (session.screenUpdateTimer) {
           clearTimeout(session.screenUpdateTimer)
+        }
+        if (session.outputFlushTimer) {
+          clearTimeout(session.outputFlushTimer)
         }
       }
       sessions.clear()
@@ -139,8 +172,27 @@ export namespace AgentTerminal {
   /**
    * 获取指定终端信息
    */
-  export function get(id: string): Info | undefined {
-    return state().get(id)?.info
+  export function get(id: string, sessionID?: string): Info | undefined {
+    const session = state().get(id)
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    return session.info
+  }
+
+  function belongsToSession(session: ActiveSession, sessionID?: string) {
+    return !sessionID || session.info.sessionID === sessionID
+  }
+
+  function shellArgs(command: string, inputArgs?: string[]) {
+    const args = [...(inputArgs ?? [])]
+    if (args.length > 0) return args
+
+    const basename = (process.platform === "win32" ? path.win32.basename(command) : path.basename(command))
+      .toLowerCase()
+      .replace(/\.exe$/, "")
+
+    if (basename === "bash" || basename === "zsh") return ["-l", "-i"]
+    if (basename === "sh" || basename === "dash") return ["-i"]
+    return args
   }
 
   /**
@@ -149,16 +201,9 @@ export namespace AgentTerminal {
   export async function create(input: CreateInput): Promise<Info> {
     const id = Identifier.create("agt", false)
     const command = input.command || Shell.preferred()
-    const args = input.args || []
+    const args = shellArgs(command, input.args)
     const rows = input.rows || 24
     const cols = input.cols || 120
-
-    if (command.endsWith("sh")) {
-      // 使用交互式登录 shell，确保加载完整用户环境
-      // -l: 登录 shell，加载 .profile/.bash_profile
-      // -i: 交互式 shell，加载 .bashrc/.zshrc
-      args.push("-l", "-i")
-    }
 
     const cwd = input.cwd || Instance.directory
     const projectEnv = await ProjectEnvironment.getAll(Instance.project.id)
@@ -205,8 +250,15 @@ export namespace AgentTerminal {
       process: ptyProcess,
       buffer: screenBuffer,
       rawBuffer: "",
+      outputSeq: 0,
+      outputChunks: [],
+      outputChunkBytes: 0,
+      pendingOutput: "",
+      outputFlushTimer: null,
+      outputPublishChain: Promise.resolve(),
       lastScreenUpdate: 0,
       screenUpdateTimer: null,
+      screenPublishChain: Promise.resolve(),
     }
 
     state().set(id, session)
@@ -215,20 +267,19 @@ export namespace AgentTerminal {
     ptyProcess.onData((data) => {
       session.info.lastActivity = Date.now()
       session.rawBuffer += data
+      session.pendingOutput += data
 
       // 保持原始缓冲区大小限制
       if (session.rawBuffer.length > BUFFER_LIMIT) {
         session.rawBuffer = session.rawBuffer.slice(-BUFFER_LIMIT)
       }
 
-      // 写入屏幕缓冲区
-      session.buffer.writeSync(data)
+      scheduleOutputFlush(session)
 
-      // 发送原始数据输出事件（前端可以用来保持滚动历史）
-      Bus.publish(Event.Output, { id, data })
-
-      // 节流屏幕更新事件
-      scheduleScreenUpdate(session)
+      void session.buffer.write(data).then(
+        () => scheduleScreenUpdate(session),
+        (error) => log.warn("failed to write terminal screen buffer", { id, error }),
+      )
     })
 
     // 处理退出
@@ -240,17 +291,70 @@ export namespace AgentTerminal {
         clearTimeout(session.screenUpdateTimer)
         session.screenUpdateTimer = null
       }
+      if (session.outputFlushTimer) {
+        clearTimeout(session.outputFlushTimer)
+        session.outputFlushTimer = null
+      }
 
-      Bus.publish(Event.Exited, { id, exitCode })
+      void flushOutput(session).finally(() => {
+        Bus.publish(Event.Exited, { id, sessionID: session.info.sessionID, exitCode })
+      })
     })
 
     Bus.publish(Event.Created, { info })
 
     // 等待 shell 启动并发送初始屏幕
     await new Promise((resolve) => setTimeout(resolve, 300))
-    publishScreen(session)
+    await publishScreen(session)
 
     return info
+  }
+
+  function addOutputChunk(session: ActiveSession, chunk: OutputChunk) {
+    session.outputChunks.push(chunk)
+    session.outputChunkBytes += chunk.data.length
+    while (session.outputChunkBytes > BUFFER_LIMIT && session.outputChunks.length > 0) {
+      const removed = session.outputChunks.shift()
+      if (removed) session.outputChunkBytes -= removed.data.length
+    }
+  }
+
+  function scheduleOutputFlush(session: ActiveSession) {
+    if (session.pendingOutput.length >= OUTPUT_FLUSH_BYTES) {
+      void flushOutput(session)
+      return
+    }
+    if (session.outputFlushTimer) return
+    session.outputFlushTimer = setTimeout(() => {
+      session.outputFlushTimer = null
+      void flushOutput(session)
+    }, OUTPUT_FLUSH_INTERVAL)
+  }
+
+  async function flushOutput(session: ActiveSession) {
+    if (session.outputFlushTimer) {
+      clearTimeout(session.outputFlushTimer)
+      session.outputFlushTimer = null
+    }
+    if (!session.pendingOutput) return session.outputPublishChain
+
+    const data = session.pendingOutput
+    session.pendingOutput = ""
+    const seq = ++session.outputSeq
+    addOutputChunk(session, { seq, data })
+
+    session.outputPublishChain = session.outputPublishChain.then(() =>
+      Bus.publish(Event.Output, {
+        id: session.info.id,
+        sessionID: session.info.sessionID,
+        seq,
+        data,
+      }).then(() => undefined),
+    )
+    session.outputPublishChain = session.outputPublishChain.catch((error) => {
+      log.warn("failed to publish terminal output", { id: session.info.id, seq, error })
+    })
+    return session.outputPublishChain
   }
 
   /**
@@ -265,19 +369,24 @@ export namespace AgentTerminal {
     session.screenUpdateTimer = setTimeout(() => {
       session.screenUpdateTimer = null
       session.lastScreenUpdate = Date.now()
-      publishScreen(session)
+      session.screenPublishChain = session.screenPublishChain.then(() => publishScreen(session))
+      session.screenPublishChain = session.screenPublishChain.catch((error) => {
+        log.warn("failed to publish terminal screen", { id: session.info.id, error })
+      })
     }, delay)
   }
 
   /**
    * 发布屏幕更新事件
    */
-  function publishScreen(session: ActiveSession) {
+  async function publishScreen(session: ActiveSession) {
+    await session.buffer.flush()
     const screen = session.buffer.getScreenText()
     const screenAnsi = session.buffer.getScreenAnsi()
     const cursor = session.buffer.getCursor()
-    Bus.publish(Event.Screen, {
+    await Bus.publish(Event.Screen, {
       id: session.info.id,
+      sessionID: session.info.sessionID,
       screen,
       screenAnsi,
       cursor,
@@ -287,9 +396,9 @@ export namespace AgentTerminal {
   /**
    * 向终端发送输入
    */
-  export function write(id: string, data: string): boolean {
+  export function write(id: string, data: string, sessionID?: string): boolean {
     const session = state().get(id)
-    if (!session || session.info.status !== "running") {
+    if (!session || !belongsToSession(session, sessionID) || session.info.status !== "running") {
       return false
     }
     session.process.write(data)
@@ -300,63 +409,70 @@ export namespace AgentTerminal {
   /**
    * 获取当前屏幕内容
    */
-  export function getScreen(id: string): string | undefined {
+  export async function getScreen(id: string, sessionID?: string): Promise<string | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getScreenText()
   }
 
   /**
    * 获取带 ANSI 转义序列的屏幕内容
    */
-  export function getScreenAnsi(id: string): string | undefined {
+  export async function getScreenAnsi(id: string, sessionID?: string): Promise<string | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getScreenAnsi()
   }
 
   /**
    * 获取屏幕行数组
    */
-  export function getScreenLines(id: string): string[] | undefined {
+  export async function getScreenLines(id: string, sessionID?: string): Promise<string[] | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getScreen()
   }
 
   /**
    * 获取滚动历史
    */
-  export function getScrollback(id: string, lines?: number): string[] | undefined {
+  export async function getScrollback(id: string, lines?: number, sessionID?: string): Promise<string[] | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getScrollback(lines)
   }
 
   /**
    * 获取完整视图（历史 + 屏幕）
    */
-  export function getFullView(id: string, historyLines = 50): string | undefined {
+  export async function getFullView(id: string, historyLines = 50, sessionID?: string): Promise<string | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getFullView(historyLines)
   }
 
   /**
    * 获取光标位置
    */
-  export function getCursor(id: string): ScreenBuffer.CursorPosition | undefined {
+  export async function getCursor(id: string, sessionID?: string): Promise<ScreenBuffer.CursorPosition | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getCursor()
   }
 
   /**
    * 获取终端详细信息
    */
-  export function getScreenInfo(id: string): ScreenBuffer.ScreenInfo | undefined {
+  export async function getScreenInfo(id: string, sessionID?: string): Promise<ScreenBuffer.ScreenInfo | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await session.buffer.flush()
     return session.buffer.getInfo()
   }
 
@@ -366,14 +482,16 @@ export namespace AgentTerminal {
   export async function waitFor(
     id: string,
     pattern: string | RegExp,
-    timeout = 30000
+    timeout = 30000,
+    sessionID?: string,
   ): Promise<{ matched: boolean; timedOut: boolean; screen?: string }> {
     const session = state().get(id)
-    if (!session) {
+    if (!session || !belongsToSession(session, sessionID)) {
       return { matched: false, timedOut: false }
     }
 
     const result = await session.buffer.waitForPattern(pattern, timeout)
+    await session.buffer.flush()
     return {
       ...result,
       screen: session.buffer.getScreenText(),
@@ -383,9 +501,9 @@ export namespace AgentTerminal {
   /**
    * 调整终端大小
    */
-  export function resize(id: string, rows: number, cols: number): boolean {
+  export function resize(id: string, rows: number, cols: number, sessionID?: string): boolean {
     const session = state().get(id)
-    if (!session || session.info.status !== "running") {
+    if (!session || !belongsToSession(session, sessionID) || session.info.status !== "running") {
       return false
     }
 
@@ -395,15 +513,16 @@ export namespace AgentTerminal {
     session.info.cols = cols
 
     Bus.publish(Event.Updated, { info: session.info })
+    void publishScreen(session)
     return true
   }
 
   /**
    * 关闭终端
    */
-  export async function close(id: string): Promise<boolean> {
+  export async function close(id: string, sessionID?: string): Promise<boolean> {
     const session = state().get(id)
-    if (!session) {
+    if (!session || !belongsToSession(session, sessionID)) {
       return false
     }
 
@@ -412,6 +531,11 @@ export namespace AgentTerminal {
     if (session.screenUpdateTimer) {
       clearTimeout(session.screenUpdateTimer)
     }
+    if (session.outputFlushTimer) {
+      clearTimeout(session.outputFlushTimer)
+      session.outputFlushTimer = null
+    }
+    await flushOutput(session)
 
     try {
       session.process.kill()
@@ -420,16 +544,37 @@ export namespace AgentTerminal {
     session.buffer.dispose()
     state().delete(id)
 
-    Bus.publish(Event.Closed, { id })
+    Bus.publish(Event.Closed, { id, sessionID: session.info.sessionID })
     return true
   }
 
   /**
    * 获取原始输出缓冲区
    */
-  export function getRawBuffer(id: string): string | undefined {
+  export async function getBuffer(id: string, afterSeq?: number, sessionID?: string): Promise<BufferSnapshot | undefined> {
     const session = state().get(id)
-    if (!session) return undefined
-    return session.rawBuffer
+    if (!session || !belongsToSession(session, sessionID)) return undefined
+    await flushOutput(session)
+
+    const latestSeq = session.outputSeq
+    const firstSeq = session.outputChunks[0]?.seq ?? latestSeq + 1
+    if (afterSeq !== undefined) {
+      const reset = afterSeq < firstSeq - 1
+      return {
+        buffer: reset ? session.rawBuffer : "",
+        chunks: reset ? [] : session.outputChunks.filter((chunk) => chunk.seq > afterSeq),
+        latestSeq,
+        firstSeq,
+        reset,
+      }
+    }
+
+    return {
+      buffer: session.rawBuffer,
+      chunks: [],
+      latestSeq,
+      firstSeq,
+      reset: true,
+    }
   }
 }

--- a/opencode/packages/opencode/src/pty/screen-buffer.ts
+++ b/opencode/packages/opencode/src/pty/screen-buffer.ts
@@ -283,10 +283,14 @@ export namespace ScreenBuffer {
     /**
      * 调整终端大小
      */
-    resize(rows: number, cols: number): void {
-      this.term.resize(cols, rows)
-      this.config.rows = rows
-      this.config.cols = cols
+    async resize(rows: number, cols: number): Promise<void> {
+      const next = this.writeChain.then(() => {
+        this.term.resize(cols, rows)
+        this.config.rows = rows
+        this.config.cols = cols
+      })
+      this.writeChain = next.catch(() => undefined)
+      return next
     }
 
     /**

--- a/opencode/packages/opencode/src/pty/screen-buffer.ts
+++ b/opencode/packages/opencode/src/pty/screen-buffer.ts
@@ -37,6 +37,7 @@ export namespace ScreenBuffer {
   export class Buffer {
     private term: Terminal
     private config: Config
+    private writeChain: Promise<void> = Promise.resolve()
 
     constructor(config: Partial<Config> = {}) {
       this.config = { ...DEFAULT_CONFIG, ...config }
@@ -52,14 +53,28 @@ export namespace ScreenBuffer {
      * 处理 PTY 输出数据
      */
     async write(data: string): Promise<void> {
-      return new Promise((resolve) => this.term.write(data, resolve))
+      const next = this.writeChain.then(
+        () =>
+          new Promise<void>((resolve) => {
+            this.term.write(data, resolve)
+          }),
+      )
+      this.writeChain = next.catch(() => undefined)
+      return next
     }
 
     /**
-     * 同步写入（不等待处理完成）
+     * 兼容旧调用方的写入入口。实际写入仍进入串行队列。
      */
-    writeSync(data: string): void {
-      this.term.write(data)
+    writeSync(data: string): Promise<void> {
+      return this.write(data)
+    }
+
+    /**
+     * 等待所有已提交的数据完成解析。
+     */
+    async flush(): Promise<void> {
+      await this.writeChain
     }
 
     /**
@@ -282,6 +297,7 @@ export namespace ScreenBuffer {
       const startTime = Date.now()
 
       while (Date.now() - startTime < timeout) {
+        await this.flush()
         const screenText = this.getFullView(20)
         if (regex.test(screenText)) {
           return { matched: true, timedOut: false }

--- a/opencode/packages/opencode/src/server/routes/agent-terminal.ts
+++ b/opencode/packages/opencode/src/server/routes/agent-terminal.ts
@@ -49,8 +49,9 @@ export const AgentTerminalRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ id: z.string() })),
+      validator("query", z.object({ sessionID: z.string() })),
       async (c) => {
-        const info = AgentTerminal.get(c.req.valid("param").id, c.req.query("sessionID"))
+        const info = AgentTerminal.get(c.req.valid("param").id, c.req.valid("query").sessionID)
         if (!info) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }
@@ -81,13 +82,13 @@ export const AgentTerminalRoutes = lazy(() =>
         z.object({
           rows: z.number().int().min(1).max(500),
           cols: z.number().int().min(1).max(500),
-          sessionID: z.string().optional(),
+          sessionID: z.string(),
         })
       ),
       async (c) => {
         const { id } = c.req.valid("param")
         const { rows, cols, sessionID } = c.req.valid("json")
-        const success = AgentTerminal.resize(id, rows, cols, sessionID)
+        const success = await AgentTerminal.resize(id, rows, cols, sessionID)
         if (!success) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found or not running" })
         }
@@ -120,19 +121,22 @@ export const AgentTerminalRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ id: z.string() })),
+      validator("query", z.object({ sessionID: z.string() })),
       async (c) => {
         const { id } = c.req.valid("param")
-        const sessionID = c.req.query("sessionID")
-        const info = AgentTerminal.get(id, sessionID)
-        const screen = await AgentTerminal.getScreen(id, sessionID)
-        const screenAnsi = await AgentTerminal.getScreenAnsi(id, sessionID)
-        const cursor = await AgentTerminal.getCursor(id, sessionID)
+        const { sessionID } = c.req.valid("query")
+        const snapshot = await AgentTerminal.getScreenSnapshot(id, sessionID)
 
-        if (!info || screen === undefined || screenAnsi === undefined || cursor === undefined) {
+        if (!snapshot) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }
 
-        return c.json({ sessionID: info.sessionID, screen, screenAnsi, cursor })
+        return c.json({
+          sessionID: snapshot.sessionID,
+          screen: snapshot.screen,
+          screenAnsi: snapshot.screenAnsi,
+          cursor: snapshot.cursor,
+        })
       },
     )
     .get(
@@ -162,14 +166,18 @@ export const AgentTerminalRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ id: z.string() })),
+      validator("query", z.object({
+        sessionID: z.string(),
+        afterSeq: z.string().optional(),
+      })),
       async (c) => {
         const { id } = c.req.valid("param")
-        const afterSeqRaw = c.req.query("afterSeq")
+        const { sessionID, afterSeq: afterSeqRaw } = c.req.valid("query")
         const afterSeq = afterSeqRaw === undefined ? undefined : Number(afterSeqRaw)
         const buffer = await AgentTerminal.getBuffer(
           id,
           Number.isFinite(afterSeq) ? afterSeq : undefined,
-          c.req.query("sessionID"),
+          sessionID,
         )
 
         if (buffer === undefined) {
@@ -202,7 +210,7 @@ export const AgentTerminalRoutes = lazy(() =>
         "json",
         z.object({
           data: z.string(),
-          sessionID: z.string().optional(),
+          sessionID: z.string(),
         })
       ),
       async (c) => {
@@ -234,8 +242,9 @@ export const AgentTerminalRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ id: z.string() })),
+      validator("query", z.object({ sessionID: z.string() })),
       async (c) => {
-        const success = await AgentTerminal.close(c.req.valid("param").id, c.req.query("sessionID"))
+        const success = await AgentTerminal.close(c.req.valid("param").id, c.req.valid("query").sessionID)
         if (!success) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }

--- a/opencode/packages/opencode/src/server/routes/agent-terminal.ts
+++ b/opencode/packages/opencode/src/server/routes/agent-terminal.ts
@@ -50,7 +50,7 @@ export const AgentTerminalRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const info = AgentTerminal.get(c.req.valid("param").id)
+        const info = AgentTerminal.get(c.req.valid("param").id, c.req.query("sessionID"))
         if (!info) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }
@@ -81,12 +81,13 @@ export const AgentTerminalRoutes = lazy(() =>
         z.object({
           rows: z.number().int().min(1).max(500),
           cols: z.number().int().min(1).max(500),
+          sessionID: z.string().optional(),
         })
       ),
       async (c) => {
         const { id } = c.req.valid("param")
-        const { rows, cols } = c.req.valid("json")
-        const success = AgentTerminal.resize(id, rows, cols)
+        const { rows, cols, sessionID } = c.req.valid("json")
+        const success = AgentTerminal.resize(id, rows, cols, sessionID)
         if (!success) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found or not running" })
         }
@@ -106,6 +107,7 @@ export const AgentTerminalRoutes = lazy(() =>
               "application/json": {
                 schema: resolver(
                   z.object({
+                    sessionID: z.string(),
                     screen: z.string(),
                     screenAnsi: z.string(),
                     cursor: z.object({ row: z.number(), col: z.number() }),
@@ -120,15 +122,17 @@ export const AgentTerminalRoutes = lazy(() =>
       validator("param", z.object({ id: z.string() })),
       async (c) => {
         const { id } = c.req.valid("param")
-        const screen = AgentTerminal.getScreen(id)
-        const screenAnsi = AgentTerminal.getScreenAnsi(id)
-        const cursor = AgentTerminal.getCursor(id)
+        const sessionID = c.req.query("sessionID")
+        const info = AgentTerminal.get(id, sessionID)
+        const screen = await AgentTerminal.getScreen(id, sessionID)
+        const screenAnsi = await AgentTerminal.getScreenAnsi(id, sessionID)
+        const cursor = await AgentTerminal.getCursor(id, sessionID)
 
-        if (screen === undefined || screenAnsi === undefined || cursor === undefined) {
+        if (!info || screen === undefined || screenAnsi === undefined || cursor === undefined) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }
 
-        return c.json({ screen, screenAnsi, cursor })
+        return c.json({ sessionID: info.sessionID, screen, screenAnsi, cursor })
       },
     )
     .get(
@@ -145,6 +149,10 @@ export const AgentTerminalRoutes = lazy(() =>
                 schema: resolver(
                   z.object({
                     buffer: z.string(),
+                    chunks: z.array(AgentTerminal.OutputChunk),
+                    latestSeq: z.number(),
+                    firstSeq: z.number(),
+                    reset: z.boolean(),
                   })
                 ),
               },
@@ -156,13 +164,19 @@ export const AgentTerminalRoutes = lazy(() =>
       validator("param", z.object({ id: z.string() })),
       async (c) => {
         const { id } = c.req.valid("param")
-        const buffer = AgentTerminal.getRawBuffer(id)
+        const afterSeqRaw = c.req.query("afterSeq")
+        const afterSeq = afterSeqRaw === undefined ? undefined : Number(afterSeqRaw)
+        const buffer = await AgentTerminal.getBuffer(
+          id,
+          Number.isFinite(afterSeq) ? afterSeq : undefined,
+          c.req.query("sessionID"),
+        )
 
         if (buffer === undefined) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }
 
-        return c.json({ buffer })
+        return c.json(buffer)
       },
     )
     .post(
@@ -188,12 +202,13 @@ export const AgentTerminalRoutes = lazy(() =>
         "json",
         z.object({
           data: z.string(),
+          sessionID: z.string().optional(),
         })
       ),
       async (c) => {
         const { id } = c.req.valid("param")
-        const { data } = c.req.valid("json")
-        const success = AgentTerminal.write(id, data)
+        const { data, sessionID } = c.req.valid("json")
+        const success = AgentTerminal.write(id, data, sessionID)
         if (!success) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found or not running" })
         }
@@ -220,7 +235,7 @@ export const AgentTerminalRoutes = lazy(() =>
       }),
       validator("param", z.object({ id: z.string() })),
       async (c) => {
-        const success = await AgentTerminal.close(c.req.valid("param").id)
+        const success = await AgentTerminal.close(c.req.valid("param").id, c.req.query("sessionID"))
         if (!success) {
           throw new Storage.NotFoundError({ message: "Agent terminal not found" })
         }

--- a/opencode/packages/opencode/src/server/routes/global.ts
+++ b/opencode/packages/opencode/src/server/routes/global.ts
@@ -61,47 +61,54 @@ export const GlobalRoutes = lazy(() =>
             },
           },
         },
-      }),
-      async (c) => {
-        log.info("global event connected")
-        return streamSSE(c, async (stream) => {
-          stream.writeSSE({
-            data: JSON.stringify({
+        }),
+        async (c) => {
+          log.info("global event connected")
+          c.header("Cache-Control", "no-cache, no-transform")
+          c.header("X-Accel-Buffering", "no")
+          c.header("Connection", "keep-alive")
+          return streamSSE(c, async (stream) => {
+            let writeChain = Promise.resolve()
+            const writeQueued = (data: unknown) => {
+              writeChain = writeChain
+                .then(() => stream.writeSSE({ data: JSON.stringify(data) }))
+                .catch((error) => {
+                  log.warn("failed to write global event stream", { error })
+                })
+              return writeChain
+            }
+
+            await writeQueued({
               payload: {
                 type: "server.connected",
                 properties: {},
               },
-            }),
-          })
-          async function handler(event: any) {
-            await stream.writeSSE({
-              data: JSON.stringify(event),
             })
-          }
-          GlobalBus.on("event", handler)
+            function handler(event: any) {
+              void writeQueued(event)
+            }
+            GlobalBus.on("event", handler)
 
-          // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
-          const heartbeat = setInterval(() => {
-            stream.writeSSE({
-              data: JSON.stringify({
+            // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
+            const heartbeat = setInterval(() => {
+              void writeQueued({
                 payload: {
                   type: "server.heartbeat",
                   properties: {},
                 },
-              }),
-            })
-          }, 30000)
+              })
+            }, 30000)
 
-          await new Promise<void>((resolve) => {
-            stream.onAbort(() => {
-              clearInterval(heartbeat)
-              GlobalBus.off("event", handler)
-              resolve()
-              log.info("global event disconnected")
+            await new Promise<void>((resolve) => {
+              stream.onAbort(() => {
+                clearInterval(heartbeat)
+                GlobalBus.off("event", handler)
+                resolve()
+                log.info("global event disconnected")
+              })
             })
           })
-        })
-      },
+        },
     )
     .post(
       "/dispose",

--- a/opencode/packages/opencode/src/server/routes/global.ts
+++ b/opencode/packages/opencode/src/server/routes/global.ts
@@ -68,12 +68,29 @@ export const GlobalRoutes = lazy(() =>
           c.header("X-Accel-Buffering", "no")
           c.header("Connection", "keep-alive")
           return streamSSE(c, async (stream) => {
-            let writeChain = Promise.resolve()
+            let writeChain: Promise<unknown> = Promise.resolve()
+            let pendingWrites = 0
+            let closing = false
+            const maxPendingWrites = 1024
             const writeQueued = (data: unknown) => {
+              if (closing) return Promise.resolve()
+              if (pendingWrites >= maxPendingWrites) {
+                closing = true
+                log.warn("global event stream backlog exceeded; closing slow client", { pendingWrites })
+                stream.close()
+                return Promise.resolve()
+              }
+              pendingWrites++
               writeChain = writeChain
-                .then(() => stream.writeSSE({ data: JSON.stringify(data) }))
+                .then(() => {
+                  if (closing) return
+                  return stream.writeSSE({ data: JSON.stringify(data) })
+                })
                 .catch((error) => {
                   log.warn("failed to write global event stream", { error })
+                })
+                .finally(() => {
+                  pendingWrites--
                 })
               return writeChain
             }
@@ -101,6 +118,7 @@ export const GlobalRoutes = lazy(() =>
 
             await new Promise<void>((resolve) => {
               stream.onAbort(() => {
+                closing = true
                 clearInterval(heartbeat)
                 GlobalBus.off("event", handler)
                 resolve()

--- a/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
@@ -670,6 +670,9 @@ export const Nine1BotAgentRoutes = lazy(() =>
         const sessionID = c.req.valid("param").sessionID
         log.info("controller event connected", { sessionID })
         const startedAt = Date.now()
+        c.header("Cache-Control", "no-cache, no-transform")
+        c.header("X-Accel-Buffering", "no")
+        c.header("Connection", "keep-alive")
         return streamSSE(c, async (stream) => {
           await emitControllerMetrics({
             route: "/nine1bot/agent/sessions/:sessionID/events",
@@ -679,17 +682,25 @@ export const Nine1BotAgentRoutes = lazy(() =>
             status: 200,
             accepted: true,
           })
-          await writeEnvelope(stream, RuntimeControllerEvents.connected(sessionID))
-          const unsub = Bus.subscribeAll(async (event) => {
+          let writeChain = Promise.resolve()
+          const writeQueued = (envelope: RuntimeControllerEvents.RuntimeEventEnvelope) => {
+            writeChain = writeChain
+              .then(() => writeEnvelope(stream, envelope))
+              .catch((error) => {
+                log.warn("failed to write controller event", { sessionID, error })
+              })
+            return writeChain
+          }
+
+          await writeQueued(RuntimeControllerEvents.connected(sessionID))
+          const unsub = Bus.subscribeAll((event) => {
             for (const envelope of RuntimeControllerEvents.project(event, { sessionID })) {
-              await writeEnvelope(stream, envelope)
+              void writeQueued(envelope)
             }
           })
 
           const heartbeat = setInterval(() => {
-            writeEnvelope(stream, RuntimeControllerEvents.heartbeat(sessionID)).catch((error) =>
-              log.warn("failed to write heartbeat", { error }),
-            )
+            void writeQueued(RuntimeControllerEvents.heartbeat(sessionID))
           }, 30000)
 
           await new Promise<void>((resolve) => {

--- a/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
@@ -682,12 +682,29 @@ export const Nine1BotAgentRoutes = lazy(() =>
             status: 200,
             accepted: true,
           })
-          let writeChain = Promise.resolve()
+          let writeChain: Promise<unknown> = Promise.resolve()
+          let pendingWrites = 0
+          let closing = false
+          const maxPendingWrites = 1024
           const writeQueued = (envelope: RuntimeControllerEvents.RuntimeEventEnvelope) => {
+            if (closing) return Promise.resolve()
+            if (pendingWrites >= maxPendingWrites) {
+              closing = true
+              log.warn("controller event backlog exceeded; closing slow client", { sessionID, pendingWrites })
+              stream.close()
+              return Promise.resolve()
+            }
+            pendingWrites++
             writeChain = writeChain
-              .then(() => writeEnvelope(stream, envelope))
+              .then(() => {
+                if (closing) return
+                return writeEnvelope(stream, envelope)
+              })
               .catch((error) => {
                 log.warn("failed to write controller event", { sessionID, error })
+              })
+              .finally(() => {
+                pendingWrites--
               })
             return writeChain
           }
@@ -705,6 +722,7 @@ export const Nine1BotAgentRoutes = lazy(() =>
 
           await new Promise<void>((resolve) => {
             stream.onAbort(() => {
+              closing = true
               clearInterval(heartbeat)
               unsub()
               resolve()

--- a/opencode/packages/opencode/src/server/server.ts
+++ b/opencode/packages/opencode/src/server/server.ts
@@ -701,45 +701,52 @@ export namespace Server {
                 },
               },
             },
-          }),
-          async (c) => {
-            log.info("event connected")
-            return streamSSE(c, async (stream) => {
-              stream.writeSSE({
-                data: JSON.stringify({
+            }),
+            async (c) => {
+              log.info("event connected")
+              c.header("Cache-Control", "no-cache, no-transform")
+              c.header("X-Accel-Buffering", "no")
+              c.header("Connection", "keep-alive")
+              return streamSSE(c, async (stream) => {
+                let writeChain = Promise.resolve()
+                const writeQueued = (data: unknown) => {
+                  writeChain = writeChain
+                    .then(() => stream.writeSSE({ data: JSON.stringify(data) }))
+                    .catch((error) => {
+                      log.warn("failed to write event stream", { error })
+                    })
+                  return writeChain
+                }
+
+                await writeQueued({
                   type: "server.connected",
                   properties: {},
-                }),
-              })
-              const unsub = Bus.subscribeAll(async (event) => {
-                await stream.writeSSE({
-                  data: JSON.stringify(event),
                 })
-                if (event.type === Bus.InstanceDisposed.type) {
-                  stream.close()
-                }
-              })
+                const unsub = Bus.subscribeAll((event) => {
+                  void writeQueued(event)
+                  if (event.type === Bus.InstanceDisposed.type) {
+                    void writeChain.finally(() => stream.close())
+                  }
+                })
 
-              // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
-              const heartbeat = setInterval(() => {
-                stream.writeSSE({
-                  data: JSON.stringify({
+                // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
+                const heartbeat = setInterval(() => {
+                  void writeQueued({
                     type: "server.heartbeat",
                     properties: {},
-                  }),
-                })
-              }, 30000)
+                  })
+                }, 30000)
 
-              await new Promise<void>((resolve) => {
-                stream.onAbort(() => {
-                  clearInterval(heartbeat)
-                  unsub()
-                  resolve()
-                  log.info("event disconnected")
+                await new Promise<void>((resolve) => {
+                  stream.onAbort(() => {
+                    clearInterval(heartbeat)
+                    unsub()
+                    resolve()
+                    log.info("event disconnected")
+                  })
                 })
               })
-            })
-          },
+            },
         )
         .all("/*", async (c) => {
           const requestPath = c.req.path

--- a/opencode/packages/opencode/src/server/server.ts
+++ b/opencode/packages/opencode/src/server/server.ts
@@ -708,12 +708,29 @@ export namespace Server {
               c.header("X-Accel-Buffering", "no")
               c.header("Connection", "keep-alive")
               return streamSSE(c, async (stream) => {
-                let writeChain = Promise.resolve()
+                let writeChain: Promise<unknown> = Promise.resolve()
+                let pendingWrites = 0
+                let closing = false
+                const maxPendingWrites = 1024
                 const writeQueued = (data: unknown) => {
+                  if (closing) return Promise.resolve()
+                  if (pendingWrites >= maxPendingWrites) {
+                    closing = true
+                    log.warn("event stream backlog exceeded; closing slow client", { pendingWrites })
+                    stream.close()
+                    return Promise.resolve()
+                  }
+                  pendingWrites++
                   writeChain = writeChain
-                    .then(() => stream.writeSSE({ data: JSON.stringify(data) }))
+                    .then(() => {
+                      if (closing) return
+                      return stream.writeSSE({ data: JSON.stringify(data) })
+                    })
                     .catch((error) => {
                       log.warn("failed to write event stream", { error })
+                    })
+                    .finally(() => {
+                      pendingWrites--
                     })
                   return writeChain
                 }
@@ -739,6 +756,7 @@ export namespace Server {
 
                 await new Promise<void>((resolve) => {
                   stream.onAbort(() => {
+                    closing = true
                     clearInterval(heartbeat)
                     unsub()
                     resolve()

--- a/opencode/packages/opencode/src/tool/terminal/close.ts
+++ b/opencode/packages/opencode/src/tool/terminal/close.ts
@@ -20,7 +20,7 @@ use terminal_write to send "exit" or Ctrl+D first, then close.`,
   }),
 
   async execute(params, ctx) {
-    const info = AgentTerminal.get(params.id)
+    const info = AgentTerminal.get(params.id, ctx.sessionID)
     if (!info) {
       throw new Error(`Terminal session not found: ${params.id}`)
     }
@@ -28,7 +28,7 @@ use terminal_write to send "exit" or Ctrl+D first, then close.`,
     const name = info.name
     const wasRunning = info.status === "running"
 
-    const success = await AgentTerminal.close(params.id)
+    const success = await AgentTerminal.close(params.id, ctx.sessionID)
     if (!success) {
       throw new Error(`Failed to close terminal: ${params.id}`)
     }

--- a/opencode/packages/opencode/src/tool/terminal/create.ts
+++ b/opencode/packages/opencode/src/tool/terminal/create.ts
@@ -36,8 +36,8 @@ Example usage:
       cols: params.cols,
     })
 
-    const screen = AgentTerminal.getScreen(terminal.id) || ""
-    const info = AgentTerminal.getScreenInfo(terminal.id)
+    const screen = (await AgentTerminal.getScreen(terminal.id, ctx.sessionID)) || ""
+    const info = await AgentTerminal.getScreenInfo(terminal.id, ctx.sessionID)
 
     return {
       title: `Created terminal: ${terminal.name}`,

--- a/opencode/packages/opencode/src/tool/terminal/create.ts
+++ b/opencode/packages/opencode/src/tool/terminal/create.ts
@@ -36,8 +36,9 @@ Example usage:
       cols: params.cols,
     })
 
-    const screen = (await AgentTerminal.getScreen(terminal.id, ctx.sessionID)) || ""
-    const info = await AgentTerminal.getScreenInfo(terminal.id, ctx.sessionID)
+    const snapshot = await AgentTerminal.getScreenSnapshot(terminal.id, ctx.sessionID)
+    const screen = snapshot?.screen || ""
+    const info = snapshot?.info
 
     return {
       title: `Created terminal: ${terminal.name}`,

--- a/opencode/packages/opencode/src/tool/terminal/view.ts
+++ b/opencode/packages/opencode/src/tool/terminal/view.ts
@@ -27,21 +27,21 @@ If the output is too large, the latest terminal content is kept and older histor
   }),
 
   async execute(params, ctx) {
-    const info = AgentTerminal.get(params.id)
+    const info = AgentTerminal.get(params.id, ctx.sessionID)
     if (!info) {
       throw new Error(`Terminal session not found: ${params.id}`)
     }
 
-    const screenInfo = AgentTerminal.getScreenInfo(params.id)
+    const screenInfo = await AgentTerminal.getScreenInfo(params.id, ctx.sessionID)
     let content: string
 
     if (params.includeHistory) {
-      content = AgentTerminal.getFullView(params.id, params.historyLines || 50) || ""
+      content = (await AgentTerminal.getFullView(params.id, params.historyLines || 50, ctx.sessionID)) || ""
     } else {
-      content = AgentTerminal.getScreen(params.id) || ""
+      content = (await AgentTerminal.getScreen(params.id, ctx.sessionID)) || ""
     }
 
-    const cursor = AgentTerminal.getCursor(params.id)
+    const cursor = await AgentTerminal.getCursor(params.id, ctx.sessionID)
     const width = Math.min(screenInfo?.cols || 80, 80)
 
     const stateInfo = [

--- a/opencode/packages/opencode/src/tool/terminal/view.ts
+++ b/opencode/packages/opencode/src/tool/terminal/view.ts
@@ -32,16 +32,18 @@ If the output is too large, the latest terminal content is kept and older histor
       throw new Error(`Terminal session not found: ${params.id}`)
     }
 
-    const screenInfo = await AgentTerminal.getScreenInfo(params.id, ctx.sessionID)
-    let content: string
-
-    if (params.includeHistory) {
-      content = (await AgentTerminal.getFullView(params.id, params.historyLines || 50, ctx.sessionID)) || ""
-    } else {
-      content = (await AgentTerminal.getScreen(params.id, ctx.sessionID)) || ""
+    const snapshot = await AgentTerminal.getScreenSnapshot(
+      params.id,
+      ctx.sessionID,
+      params.includeHistory ? params.historyLines || 50 : undefined,
+    )
+    if (!snapshot) {
+      throw new Error(`Terminal session not found: ${params.id}`)
     }
 
-    const cursor = await AgentTerminal.getCursor(params.id, ctx.sessionID)
+    const screenInfo = snapshot.info
+    const cursor = snapshot.cursor
+    const content = params.includeHistory ? snapshot.fullView || "" : snapshot.screen
     const width = Math.min(screenInfo?.cols || 80, 80)
 
     const stateInfo = [

--- a/opencode/packages/opencode/src/tool/terminal/wait.ts
+++ b/opencode/packages/opencode/src/tool/terminal/wait.ts
@@ -35,7 +35,7 @@ Examples:
   }),
 
   async execute(params, ctx) {
-    const info = AgentTerminal.get(params.id)
+    const info = AgentTerminal.get(params.id, ctx.sessionID)
     if (!info) {
       throw new Error(`Terminal session not found: ${params.id}`)
     }
@@ -52,9 +52,9 @@ Examples:
       },
     })
 
-    const result = await AgentTerminal.waitFor(params.id, params.pattern, timeout)
+    const result = await AgentTerminal.waitFor(params.id, params.pattern, timeout, ctx.sessionID)
 
-    const screenInfo = AgentTerminal.getScreenInfo(params.id)
+    const screenInfo = await AgentTerminal.getScreenInfo(params.id, ctx.sessionID)
     const width = Math.min(screenInfo?.cols || 80, 80)
 
     if (result.matched) {

--- a/opencode/packages/opencode/src/tool/terminal/wait.ts
+++ b/opencode/packages/opencode/src/tool/terminal/wait.ts
@@ -54,8 +54,9 @@ Examples:
 
     const result = await AgentTerminal.waitFor(params.id, params.pattern, timeout, ctx.sessionID)
 
-    const screenInfo = await AgentTerminal.getScreenInfo(params.id, ctx.sessionID)
-    const width = Math.min(screenInfo?.cols || 80, 80)
+    const snapshot = await AgentTerminal.getScreenSnapshot(params.id, ctx.sessionID)
+    const width = Math.min(snapshot?.info.cols || 80, 80)
+    const screen = snapshot?.screen || result.screen || ""
 
     if (result.matched) {
       return {
@@ -64,7 +65,7 @@ Examples:
 
 Current screen:
 ${"─".repeat(width)}
-${result.screen || ""}
+${screen}
 ${"─".repeat(width)}`,
         metadata: {
           terminalId: params.id,
@@ -80,7 +81,7 @@ ${"─".repeat(width)}`,
 
 Current screen:
 ${"─".repeat(width)}
-${result.screen || ""}
+${screen}
 ${"─".repeat(width)}
 
 The pattern was not found. You can:

--- a/opencode/packages/opencode/src/tool/terminal/write.ts
+++ b/opencode/packages/opencode/src/tool/terminal/write.ts
@@ -43,7 +43,7 @@ Examples:
   }),
 
   async execute(params, ctx) {
-    const info = AgentTerminal.get(params.id)
+    const info = AgentTerminal.get(params.id, ctx.sessionID)
     if (!info) {
       throw new Error(`Terminal session not found: ${params.id}`)
     }
@@ -98,7 +98,7 @@ Examples:
       }
     }
 
-    const success = AgentTerminal.write(params.id, input)
+    const success = AgentTerminal.write(params.id, input, ctx.sessionID)
     if (!success) {
       throw new Error(`Failed to write to terminal: ${params.id}`)
     }
@@ -107,7 +107,7 @@ Examples:
     await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Get current screen for feedback
-    const screen = AgentTerminal.getScreen(params.id) || ""
+    const screen = (await AgentTerminal.getScreen(params.id, ctx.sessionID)) || ""
 
     return {
       title: `Sent to ${info.name}`,

--- a/opencode/packages/opencode/src/tool/terminal/write.ts
+++ b/opencode/packages/opencode/src/tool/terminal/write.ts
@@ -107,7 +107,7 @@ Examples:
     await new Promise((resolve) => setTimeout(resolve, 50))
 
     // Get current screen for feedback
-    const screen = (await AgentTerminal.getScreen(params.id, ctx.sessionID)) || ""
+    const screen = (await AgentTerminal.getScreenSnapshot(params.id, ctx.sessionID))?.screen || ""
 
     return {
       title: `Sent to ${info.name}`,

--- a/opencode/packages/opencode/test/tool/screen-buffer.test.ts
+++ b/opencode/packages/opencode/test/tool/screen-buffer.test.ts
@@ -55,4 +55,18 @@ describe("ScreenBuffer", () => {
     expect(ansi).toContain("new3")
     expect(ansi).not.toContain("old1")
   })
+
+  test("serializes overlapping writes before reads and waits", async () => {
+    const buffer = createBuffer({ rows: 3, cols: 40, scrollback: 100 })
+
+    const first = buffer.write("first")
+    const second = buffer.write("\r\nsecond")
+    await Promise.all([first, second])
+
+    expect(buffer.getScreen()).toEqual(["first", "second", ""])
+    await expect(buffer.waitForPattern("second", 100)).resolves.toEqual({
+      matched: true,
+      timedOut: false,
+    })
+  })
 })

--- a/opencode/packages/opencode/test/tool/screen-buffer.test.ts
+++ b/opencode/packages/opencode/test/tool/screen-buffer.test.ts
@@ -69,4 +69,36 @@ describe("ScreenBuffer", () => {
       timedOut: false,
     })
   })
+
+  test("serializes resize after pending writes", async () => {
+    const buffer = createBuffer({ rows: 3, cols: 20, scrollback: 100 })
+    const term = (buffer as unknown as {
+      term: {
+        rows: number
+        cols: number
+        write(data: string, callback: () => void): void
+      }
+    }).term
+    const originalWrite = term.write.bind(term)
+    let finishWrite: (() => void) | undefined
+
+    term.write = (data: string, callback: () => void) => {
+      originalWrite(data, () => {
+        finishWrite = callback
+      })
+    }
+
+    const write = buffer.write("wrapped text that should parse before resize")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const resize = buffer.resize(4, 10)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(term.rows).toBe(3)
+    expect(term.cols).toBe(20)
+
+    finishWrite?.()
+    await Promise.all([write, resize])
+    expect(term.rows).toBe(4)
+    expect(term.cols).toBe(10)
+  })
 })

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -7,7 +7,7 @@ import { useAppMode } from './composables/useAppMode'
 import { useSessionMode } from './composables/useSessionMode'
 import { useProjects } from './composables/useProjects'
 import { useGlobalRecentSessions } from './composables/useGlobalRecentSessions'
-import { api, type GlobalSSEEventEnvelope, type Session } from './api/client'
+import { api, type EventStreamSubscription, type GlobalSSEEventEnvelope, type Session } from './api/client'
 import Header from './components/Header.vue'
 import Sidebar from './components/Sidebar.vue'
 import ChatPanel from './components/ChatPanel.vue'
@@ -79,7 +79,7 @@ const {
 } = useSession()
 
 // Agent 终端
-const { handleSSEEvent: handleTerminalEvent } = useAgentTerminal()
+const { handleSSEEvent: handleTerminalEvent, setSessionContext: setTerminalSessionContext } = useAgentTerminal()
 
 // 文件预览
 const { handleSSEEvent: handlePreviewEvent } = useFilePreview()
@@ -198,7 +198,7 @@ async function handleSelectModel(providerId: string, modelId: string) {
 let stopSessionWatch: (() => void) | null = null
 let unregisterTerminalHandler: (() => void) | null = null
 let unregisterPreviewHandler: (() => void) | null = null
-let globalEventSource: EventSource | null = null
+let globalEventSource: EventStreamSubscription | null = null
 let projectsRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
 async function refreshGlobalRecentsIfAgent() {
@@ -262,10 +262,11 @@ onMounted(async () => {
 
   // 设置会话切换的 watch
   stopSessionWatch = watch(currentSession, async () => {
+    setTerminalSessionContext(currentSession.value?.id || null)
     if (currentSession.value) {
       await loadPendingRequests()
     }
-  })
+  }, { immediate: true })
 
   // Sync parallel session status from backend (for page refresh recovery)
   await syncSessionStatus()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1113,13 +1113,17 @@ export const api = {
   },
 
   // 订阅事件流（带自动重连）
-  subscribeEvents(onEvent: (event: SSEEvent) => void): EventSource {
-    let eventSource: EventSource
+  subscribeEvents(onEvent: (event: SSEEvent) => void): EventStreamSubscription {
+    let eventSource: EventSource | null = null
     let reconnectAttempts = 0
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let closed = false
     const maxReconnectAttempts = 5
     const baseReconnectDelay = 1000 // 1秒
 
-    function connect(): EventSource {
+    function connect(): void {
+      if (closed) return
+      eventSource?.close()
       eventSource = new EventSource(applyDirectoryToUrl(`${BASE_URL}/event`))
 
       eventSource.onopen = () => {
@@ -1141,16 +1145,18 @@ export const api = {
       }
 
       eventSource.onerror = (e) => {
+        if (closed) return
         console.error('EventSource error:', e)
 
         // 尝试重连
-        if (eventSource.readyState === EventSource.CLOSED) {
+        if (eventSource?.readyState === EventSource.CLOSED) {
           if (reconnectAttempts < maxReconnectAttempts) {
             reconnectAttempts++
             const delay = baseReconnectDelay * Math.pow(2, reconnectAttempts - 1) // 指数退避
             console.log(`EventSource disconnected, reconnecting in ${delay}ms (attempt ${reconnectAttempts}/${maxReconnectAttempts})`)
-            setTimeout(() => {
-              if (eventSource.readyState === EventSource.CLOSED) {
+            reconnectTimer = setTimeout(() => {
+              reconnectTimer = null
+              if (!closed && eventSource?.readyState === EventSource.CLOSED) {
                 connect()
               }
             }, delay)
@@ -1160,15 +1166,27 @@ export const api = {
         }
       }
 
-      return eventSource
     }
 
-    return connect()
+    connect()
+    return {
+      close() {
+        closed = true
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer)
+          reconnectTimer = null
+        }
+        eventSource?.close()
+        eventSource = null
+      }
+    }
   },
 
-  subscribeSessionRuntimeEvents(sessionId: string, onEvent: (event: SSEEvent) => void): EventSource {
-    let eventSource: EventSource
+  subscribeSessionRuntimeEvents(sessionId: string, onEvent: (event: SSEEvent) => void): EventStreamSubscription {
+    let eventSource: EventSource | null = null
     let reconnectAttempts = 0
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let closed = false
     const maxReconnectAttempts = 5
     const baseReconnectDelay = 1000
 
@@ -1183,7 +1201,9 @@ export const api = {
       }
     }
 
-    function connect(): EventSource {
+    function connect(): void {
+      if (closed) return
+      eventSource?.close()
       eventSource = new EventSource(
         applyDirectoryToUrl(`${BASE_URL}/nine1bot/agent/sessions/${encodeURIComponent(sessionId)}/events`)
       )
@@ -1203,14 +1223,16 @@ export const api = {
       }
 
       eventSource.onerror = (e) => {
+        if (closed) return
         console.error('Runtime EventSource error:', e)
 
-        if (eventSource.readyState === EventSource.CLOSED) {
+        if (eventSource?.readyState === EventSource.CLOSED) {
           if (reconnectAttempts < maxReconnectAttempts) {
             reconnectAttempts++
             const delay = baseReconnectDelay * Math.pow(2, reconnectAttempts - 1)
-            setTimeout(() => {
-              if (eventSource.readyState === EventSource.CLOSED) {
+            reconnectTimer = setTimeout(() => {
+              reconnectTimer = null
+              if (!closed && eventSource?.readyState === EventSource.CLOSED) {
                 connect()
               }
             }, delay)
@@ -1220,20 +1242,34 @@ export const api = {
         }
       }
 
-      return eventSource
     }
 
-    return connect()
+    connect()
+    return {
+      close() {
+        closed = true
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer)
+          reconnectTimer = null
+        }
+        eventSource?.close()
+        eventSource = null
+      }
+    }
   },
 
   // Subscribe global events (cross-directory / cross-instance updates)
-  subscribeGlobalEvents(onEvent: (event: GlobalSSEEventEnvelope) => void): EventSource {
-    let eventSource: EventSource
+  subscribeGlobalEvents(onEvent: (event: GlobalSSEEventEnvelope) => void): EventStreamSubscription {
+    let eventSource: EventSource | null = null
     let reconnectAttempts = 0
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let closed = false
     const maxReconnectAttempts = 5
     const baseReconnectDelay = 1000
 
-    function connect(): EventSource {
+    function connect(): void {
+      if (closed) return
+      eventSource?.close()
       eventSource = new EventSource(`${BASE_URL}/global/event`)
 
       eventSource.onopen = () => {
@@ -1252,27 +1288,43 @@ export const api = {
       }
 
       eventSource.onerror = () => {
-        if (eventSource.readyState === EventSource.CLOSED && reconnectAttempts < maxReconnectAttempts) {
+        if (closed) return
+        if (eventSource?.readyState === EventSource.CLOSED && reconnectAttempts < maxReconnectAttempts) {
           reconnectAttempts++
           const delay = baseReconnectDelay * Math.pow(2, reconnectAttempts - 1)
-          setTimeout(() => {
-            if (eventSource.readyState === EventSource.CLOSED) {
+          reconnectTimer = setTimeout(() => {
+            reconnectTimer = null
+            if (!closed && eventSource?.readyState === EventSource.CLOSED) {
               connect()
             }
           }, delay)
         }
       }
 
-      return eventSource
     }
 
-    return connect()
+    connect()
+    return {
+      close() {
+        closed = true
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer)
+          reconnectTimer = null
+        }
+        eventSource?.close()
+        eventSource = null
+      }
+    }
   },
 }
 
 export interface SSEEvent {
   type: string
   properties: Record<string, any>
+}
+
+export interface EventStreamSubscription {
+  close(): void
 }
 
 export interface GlobalSSEEventEnvelope {
@@ -2437,6 +2489,19 @@ export interface AgentTerminalInfo {
   lastActivity: number
 }
 
+export interface AgentTerminalOutputChunk {
+  seq: number
+  data: string
+}
+
+export interface AgentTerminalBuffer {
+  buffer: string
+  chunks: AgentTerminalOutputChunk[]
+  latestSeq: number
+  firstSeq: number
+  reset: boolean
+}
+
 export const agentTerminalApi = {
   // 获取终端列表
   async list(sessionID?: string): Promise<AgentTerminalInfo[]> {
@@ -2450,8 +2515,11 @@ export const agentTerminalApi = {
   },
 
   // 获取终端信息
-  async get(id: string): Promise<AgentTerminalInfo> {
-    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}`)
+  async get(id: string, sessionID?: string): Promise<AgentTerminalInfo> {
+    const params = new URLSearchParams()
+    if (sessionID) params.set('sessionID', sessionID)
+    const suffix = params.toString() ? `?${params}` : ''
+    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}${suffix}`)
     if (!res.ok) {
       throw new Error('Failed to fetch agent terminal')
     }
@@ -2459,11 +2527,11 @@ export const agentTerminalApi = {
   },
 
   // 调整终端大小
-  async resize(id: string, rows: number, cols: number): Promise<boolean> {
+  async resize(id: string, rows: number, cols: number, sessionID?: string): Promise<boolean> {
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/resize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rows, cols })
+      body: JSON.stringify({ rows, cols, ...(sessionID ? { sessionID } : {}) })
     })
     if (!res.ok) {
       throw new Error('Failed to resize agent terminal')
@@ -2472,8 +2540,11 @@ export const agentTerminalApi = {
   },
 
   // 获取终端屏幕内容
-  async getScreen(id: string): Promise<{ screen: string; screenAnsi: string; cursor: { row: number; col: number } }> {
-    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/screen`)
+  async getScreen(id: string, sessionID?: string): Promise<{ sessionID: string; screen: string; screenAnsi: string; cursor: { row: number; col: number } }> {
+    const params = new URLSearchParams()
+    if (sessionID) params.set('sessionID', sessionID)
+    const suffix = params.toString() ? `?${params}` : ''
+    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/screen${suffix}`)
     if (!res.ok) {
       throw new Error('Failed to fetch agent terminal screen')
     }
@@ -2481,8 +2552,12 @@ export const agentTerminalApi = {
   },
 
   // 获取终端原始缓冲区（用于初始化时回放历史）
-  async getBuffer(id: string): Promise<{ buffer: string }> {
-    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/buffer`)
+  async getBuffer(id: string, sessionID?: string, afterSeq?: number): Promise<AgentTerminalBuffer> {
+    const params = new URLSearchParams()
+    if (sessionID) params.set('sessionID', sessionID)
+    if (afterSeq !== undefined) params.set('afterSeq', String(afterSeq))
+    const suffix = params.toString() ? `?${params}` : ''
+    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/buffer${suffix}`)
     if (!res.ok) {
       throw new Error('Failed to fetch agent terminal buffer')
     }
@@ -2490,11 +2565,11 @@ export const agentTerminalApi = {
   },
 
   // 向终端发送输入
-  async write(id: string, data: string): Promise<boolean> {
+  async write(id: string, data: string, sessionID?: string): Promise<boolean> {
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/write`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data })
+      body: JSON.stringify({ data, ...(sessionID ? { sessionID } : {}) })
     })
     if (!res.ok) {
       throw new Error('Failed to write to agent terminal')
@@ -2503,8 +2578,11 @@ export const agentTerminalApi = {
   },
 
   // 关闭终端
-  async close(id: string): Promise<boolean> {
-    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}`, {
+  async close(id: string, sessionID?: string): Promise<boolean> {
+    const params = new URLSearchParams()
+    if (sessionID) params.set('sessionID', sessionID)
+    const suffix = params.toString() ? `?${params}` : ''
+    const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}${suffix}`, {
       method: 'DELETE'
     })
     if (!res.ok) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2515,9 +2515,8 @@ export const agentTerminalApi = {
   },
 
   // 获取终端信息
-  async get(id: string, sessionID?: string): Promise<AgentTerminalInfo> {
-    const params = new URLSearchParams()
-    if (sessionID) params.set('sessionID', sessionID)
+  async get(id: string, sessionID: string): Promise<AgentTerminalInfo> {
+    const params = new URLSearchParams({ sessionID })
     const suffix = params.toString() ? `?${params}` : ''
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}${suffix}`)
     if (!res.ok) {
@@ -2527,11 +2526,11 @@ export const agentTerminalApi = {
   },
 
   // 调整终端大小
-  async resize(id: string, rows: number, cols: number, sessionID?: string): Promise<boolean> {
+  async resize(id: string, rows: number, cols: number, sessionID: string): Promise<boolean> {
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/resize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ rows, cols, ...(sessionID ? { sessionID } : {}) })
+      body: JSON.stringify({ rows, cols, sessionID })
     })
     if (!res.ok) {
       throw new Error('Failed to resize agent terminal')
@@ -2540,9 +2539,8 @@ export const agentTerminalApi = {
   },
 
   // 获取终端屏幕内容
-  async getScreen(id: string, sessionID?: string): Promise<{ sessionID: string; screen: string; screenAnsi: string; cursor: { row: number; col: number } }> {
-    const params = new URLSearchParams()
-    if (sessionID) params.set('sessionID', sessionID)
+  async getScreen(id: string, sessionID: string): Promise<{ sessionID: string; screen: string; screenAnsi: string; cursor: { row: number; col: number } }> {
+    const params = new URLSearchParams({ sessionID })
     const suffix = params.toString() ? `?${params}` : ''
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/screen${suffix}`)
     if (!res.ok) {
@@ -2552,9 +2550,8 @@ export const agentTerminalApi = {
   },
 
   // 获取终端原始缓冲区（用于初始化时回放历史）
-  async getBuffer(id: string, sessionID?: string, afterSeq?: number): Promise<AgentTerminalBuffer> {
-    const params = new URLSearchParams()
-    if (sessionID) params.set('sessionID', sessionID)
+  async getBuffer(id: string, sessionID: string, afterSeq?: number): Promise<AgentTerminalBuffer> {
+    const params = new URLSearchParams({ sessionID })
     if (afterSeq !== undefined) params.set('afterSeq', String(afterSeq))
     const suffix = params.toString() ? `?${params}` : ''
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/buffer${suffix}`)
@@ -2565,11 +2562,11 @@ export const agentTerminalApi = {
   },
 
   // 向终端发送输入
-  async write(id: string, data: string, sessionID?: string): Promise<boolean> {
+  async write(id: string, data: string, sessionID: string): Promise<boolean> {
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}/write`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data, ...(sessionID ? { sessionID } : {}) })
+      body: JSON.stringify({ data, sessionID })
     })
     if (!res.ok) {
       throw new Error('Failed to write to agent terminal')
@@ -2578,9 +2575,8 @@ export const agentTerminalApi = {
   },
 
   // 关闭终端
-  async close(id: string, sessionID?: string): Promise<boolean> {
-    const params = new URLSearchParams()
-    if (sessionID) params.set('sessionID', sessionID)
+  async close(id: string, sessionID: string): Promise<boolean> {
+    const params = new URLSearchParams({ sessionID })
     const suffix = params.toString() ? `?${params}` : ''
     const res = await fetchWithTimeout(`${BASE_URL}/agent-terminal/${encodeURIComponent(id)}${suffix}`, {
       method: 'DELETE'

--- a/web/src/components/AgentTerminalViewer.vue
+++ b/web/src/components/AgentTerminalViewer.vue
@@ -247,6 +247,23 @@ function updateScreen(screen: string) {
   }
 }
 
+function applyScreenSnapshot(screen: string) {
+  if (!terminal || !screen) return
+
+  terminal.write('\x1b[H\x1b[2J')
+  const lines = screen.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    terminal.write(lines[i])
+    if (i < lines.length - 1) {
+      terminal.write('\r\n')
+    }
+  }
+
+  if (props.cursor) {
+    terminal.write(`\x1b[${props.cursor.row + 1};${props.cursor.col + 1}H`)
+  }
+}
+
 function flushPendingOutput() {
   while (pendingOutput.length > 0) {
     applyOutput(pendingOutput.shift()!)
@@ -257,7 +274,10 @@ function applyOutput(item: { seq?: number; data: string; resetToken?: number }) 
   if (!terminal) return
 
   if (item.resetToken) {
-    updateScreen(item.data || props.screenAnsi)
+    terminal.clear()
+    terminal.reset()
+    if (item.data) terminal.write(item.data)
+    applyScreenSnapshot(props.screenAnsi)
     lastAppliedSeq = item.seq ?? lastAppliedSeq
     return
   }

--- a/web/src/components/AgentTerminalViewer.vue
+++ b/web/src/components/AgentTerminalViewer.vue
@@ -257,9 +257,7 @@ function applyOutput(item: { seq?: number; data: string; resetToken?: number }) 
   if (!terminal) return
 
   if (item.resetToken) {
-    terminal.clear()
-    terminal.reset()
-    if (item.data) terminal.write(item.data)
+    updateScreen(item.data || props.screenAnsi)
     lastAppliedSeq = item.seq ?? lastAppliedSeq
     return
   }

--- a/web/src/components/AgentTerminalViewer.vue
+++ b/web/src/components/AgentTerminalViewer.vue
@@ -7,6 +7,7 @@ import { agentTerminalApi } from '../api/client'
 
 const props = defineProps<{
   terminalId: string  // 终端 ID，用于调用 API
+  sessionId: string
   screen: string
   screenAnsi: string
   cursor?: { row: number; col: number }
@@ -15,6 +16,8 @@ const props = defineProps<{
   status?: 'running' | 'exited'  // 终端状态
   /** 原始输出增量数据 - 用于保持滚动历史 */
   outputData?: string
+  outputSeq?: number
+  outputResetToken?: number
 }>()
 
 const emit = defineEmits<{
@@ -33,6 +36,8 @@ let currentBackendRows = props.rows || 24
 let currentBackendCols = props.cols || 120
 // 标记是否已初始化（已加载历史缓冲）
 let isInitialized = false
+let lastAppliedSeq = 0
+const pendingOutput: Array<{ seq?: number; data: string; resetToken?: number }> = []
 
 onMounted(async () => {
   if (!terminalRef.value) return
@@ -96,16 +101,19 @@ onMounted(async () => {
 
   // 从后端加载完整的历史缓冲区
   try {
-    const { buffer } = await agentTerminalApi.getBuffer(props.terminalId)
+    const { buffer, latestSeq } = await agentTerminalApi.getBuffer(props.terminalId, props.sessionId)
     if (buffer && terminal) {
       terminal.write(buffer)
     }
+    lastAppliedSeq = latestSeq
     isInitialized = true
+    flushPendingOutput()
   } catch (e) {
     console.warn('Failed to load terminal buffer, falling back to screen:', e)
     // 回退到屏幕内容
     updateScreen(props.screenAnsi)
     isInitialized = true
+    flushPendingOutput()
   }
 
   // 适应容器大小并设置 ResizeObserver
@@ -130,7 +138,7 @@ onUnmounted(() => {
 // 发送用户输入到后端
 async function sendInput(data: string) {
   try {
-    await agentTerminalApi.write(props.terminalId, data)
+    await agentTerminalApi.write(props.terminalId, data, props.sessionId)
   } catch (error) {
     console.error('Failed to send input to terminal:', error)
   }
@@ -166,7 +174,7 @@ async function fitAndSync() {
   // 如果尺寸有变化，通知后端调整
   if (newRows !== currentBackendRows || newCols !== currentBackendCols) {
     try {
-      await agentTerminalApi.resize(props.terminalId, newRows, newCols)
+      await agentTerminalApi.resize(props.terminalId, newRows, newCols, props.sessionId)
       currentBackendRows = newRows
       currentBackendCols = newCols
       emit('resize', newRows, newCols)
@@ -177,10 +185,14 @@ async function fitAndSync() {
 }
 
 // 监听原始输出增量数据
-watch(() => props.outputData, (newData) => {
-  if (!terminal || !isInitialized || !newData) return
-  // 直接追加新数据，保持滚动历史
-  terminal.write(newData)
+watch([() => props.outputSeq, () => props.outputResetToken, () => props.outputData], ([seq, resetToken, data]) => {
+  if (data === undefined && !resetToken && seq === undefined) return
+  const item = { seq, data: data || '', resetToken }
+  if (!terminal || !isInitialized) {
+    pendingOutput.push(item)
+    return
+  }
+  applyOutput(item)
 })
 
 // 监听屏幕内容变化（仅在没有 outputData 时作为回退）
@@ -233,6 +245,30 @@ function updateScreen(screen: string) {
   if (props.cursor) {
     terminal.write(`\x1b[${props.cursor.row + 1};${props.cursor.col + 1}H`)
   }
+}
+
+function flushPendingOutput() {
+  while (pendingOutput.length > 0) {
+    applyOutput(pendingOutput.shift()!)
+  }
+}
+
+function applyOutput(item: { seq?: number; data: string; resetToken?: number }) {
+  if (!terminal) return
+
+  if (item.resetToken) {
+    terminal.clear()
+    terminal.reset()
+    if (item.data) terminal.write(item.data)
+    lastAppliedSeq = item.seq ?? lastAppliedSeq
+    return
+  }
+
+  if (item.seq !== undefined) {
+    if (item.seq <= lastAppliedSeq) return
+    lastAppliedSeq = item.seq
+  }
+  if (item.data) terminal.write(item.data)
 }
 
 // 聚焦终端

--- a/web/src/components/TerminalContent.vue
+++ b/web/src/components/TerminalContent.vue
@@ -83,8 +83,10 @@ defineExpose({ fit })
           </button>
         </div>
         <AgentTerminalViewer
+          :key="activeTerminal.id"
           ref="terminalViewerRef"
           :terminal-id="activeTerminal.id"
+          :session-id="activeTerminal.sessionID"
           :screen="activeScreen.screen"
           :screen-ansi="activeScreen.screenAnsi"
           :cursor="activeScreen.cursor"
@@ -92,6 +94,8 @@ defineExpose({ fit })
           :cols="activeTerminal.cols"
           :status="activeTerminal.status"
           :output-data="activeScreen.outputData"
+          :output-seq="activeScreen.outputSeq"
+          :output-reset-token="activeScreen.outputResetToken"
         />
       </template>
       <template v-else-if="terminals.length === 0">

--- a/web/src/components/TerminalPanel.vue
+++ b/web/src/components/TerminalPanel.vue
@@ -160,14 +160,19 @@ watch(panelWidth, () => {
           </button>
         </div>
         <AgentTerminalViewer
+          :key="activeTerminal.id"
           ref="terminalViewerRef"
           :terminal-id="activeTerminal.id"
+          :session-id="activeTerminal.sessionID"
           :screen="activeScreen.screen"
           :screen-ansi="activeScreen.screenAnsi"
           :cursor="activeScreen.cursor"
           :rows="activeTerminal.rows"
           :cols="activeTerminal.cols"
           :status="activeTerminal.status"
+          :output-data="activeScreen.outputData"
+          :output-seq="activeScreen.outputSeq"
+          :output-reset-token="activeScreen.outputResetToken"
         />
       </template>
       <template v-else-if="terminals.length === 0">

--- a/web/src/composables/useAgentTerminal.ts
+++ b/web/src/composables/useAgentTerminal.ts
@@ -15,77 +15,188 @@ export interface AgentTerminalInfo {
 
 export interface TerminalScreen {
   id: string
+  sessionID: string
   screen: string
   screenAnsi: string
   cursor: { row: number; col: number }
-  /** 原始输出增量数据 */
   outputData?: string
+  outputSeq?: number
+  outputResetToken?: number
+  latestSeq?: number
 }
 
 const terminals = ref<Map<string, AgentTerminalInfo>>(new Map())
 const terminalScreens = ref<Map<string, TerminalScreen>>(new Map())
-const activeTerminalId = ref<string | null>(null)
+const activeTerminalBySession = ref<Map<string, string>>(new Map())
+const currentSessionID = ref<string | null>(null)
 const isPanelOpen = ref(false)
-const isInitialized = ref(false)
 
-export function useAgentTerminal() {
-  const terminalList = computed(() => Array.from(terminals.value.values()))
+const initializedSessions = new Set<string>()
+const recoveringTerminals = new Set<string>()
+const queuedRecoveries = new Set<string>()
+let resetTokenCounter = 0
 
-  const activeTerminal = computed(() => {
-    if (!activeTerminalId.value) return null
-    return terminals.value.get(activeTerminalId.value) || null
-  })
+function emptyScreen(id: string, sessionID: string): TerminalScreen {
+  return {
+    id,
+    sessionID,
+    screen: '',
+    screenAnsi: '',
+    cursor: { row: 0, col: 0 },
+    outputSeq: 0,
+    latestSeq: 0,
+  }
+}
 
-  const activeScreen = computed(() => {
-    if (!activeTerminalId.value) return null
-    return terminalScreens.value.get(activeTerminalId.value) || null
-  })
+function isVisibleSession(sessionID?: string) {
+  return Boolean(sessionID && currentSessionID.value && sessionID === currentSessionID.value)
+}
 
-  const hasTerminals = computed(() => terminals.value.size > 0)
+function visibleTerminalList() {
+  const sessionID = currentSessionID.value
+  if (!sessionID) return []
+  return terminalListForSession(sessionID)
+}
 
-  /**
-   * 初始化：从后端加载现有终端列表
-   * 应该在 SSE 连接建立后调用
-   * @param force 强制重新初始化，忽略 isInitialized 标志
-   */
-  async function initialize(force = false) {
-    if (isInitialized.value && !force) {
-      console.log('[AgentTerminal] Already initialized, skipping')
+function terminalListForSession(sessionID: string) {
+  return Array.from(terminals.value.values()).filter((terminal) => terminal.sessionID === sessionID)
+}
+
+function currentActiveTerminalId() {
+  const sessionID = currentSessionID.value
+  if (!sessionID) return null
+  const active = activeTerminalBySession.value.get(sessionID)
+  if (active && terminals.value.get(active)?.sessionID === sessionID) return active
+  return visibleTerminalList()[0]?.id || null
+}
+
+async function refreshScreen(id: string, sessionID: string) {
+  try {
+    const screenData = await agentTerminalApi.getScreen(id, sessionID)
+    const existing = terminalScreens.value.get(id)
+    terminalScreens.value.set(id, {
+      ...emptyScreen(id, screenData.sessionID || sessionID),
+      ...existing,
+      ...screenData,
+      outputData: existing?.outputData,
+      outputSeq: existing?.outputSeq,
+      outputResetToken: existing?.outputResetToken,
+      latestSeq: existing?.latestSeq,
+    })
+  } catch (error) {
+    console.warn(`[AgentTerminal] Failed to refresh screen for terminal ${id}:`, error)
+  }
+}
+
+async function recoverTerminalOutput(id: string, afterSeq?: number) {
+  if (recoveringTerminals.has(id)) {
+    queuedRecoveries.add(id)
+    return
+  }
+  const terminal = terminals.value.get(id)
+  const sessionID = terminal?.sessionID || currentSessionID.value
+  if (!sessionID) return
+
+  recoveringTerminals.add(id)
+  try {
+    const snapshot = await agentTerminalApi.getBuffer(id, sessionID, afterSeq)
+    const existing = terminalScreens.value.get(id) || emptyScreen(id, sessionID)
+    if (snapshot.reset) {
+      terminalScreens.value.set(id, {
+        ...existing,
+        sessionID,
+        outputData: snapshot.buffer,
+        outputSeq: snapshot.latestSeq,
+        outputResetToken: ++resetTokenCounter,
+        latestSeq: snapshot.latestSeq,
+      })
+      await refreshScreen(id, sessionID)
       return
     }
 
-    console.log('[AgentTerminal] Initializing...')
+    const data = snapshot.chunks.map((chunk) => chunk.data).join('')
+    terminalScreens.value.set(id, {
+      ...existing,
+      sessionID,
+      outputData: data,
+      outputSeq: snapshot.latestSeq,
+      latestSeq: snapshot.latestSeq,
+    })
+    await refreshScreen(id, sessionID)
+  } catch (error) {
+    console.warn(`[AgentTerminal] Failed to recover terminal ${id}:`, error)
+  } finally {
+    recoveringTerminals.delete(id)
+    if (queuedRecoveries.delete(id)) {
+      const latestSeq = terminalScreens.value.get(id)?.latestSeq
+      void recoverTerminalOutput(id, latestSeq ?? afterSeq)
+    }
+  }
+}
+
+export function useAgentTerminal() {
+  const terminalList = computed(() => visibleTerminalList())
+
+  const activeTerminalId = computed(() => currentActiveTerminalId())
+
+  const activeTerminal = computed(() => {
+    const id = activeTerminalId.value
+    return id ? terminals.value.get(id) || null : null
+  })
+
+  const activeScreen = computed(() => {
+    const id = activeTerminalId.value
+    return id ? terminalScreens.value.get(id) || null : null
+  })
+
+  const hasTerminals = computed(() => terminalList.value.length > 0)
+
+  function setSessionContext(sessionID?: string | null) {
+    const next = sessionID || null
+    if (currentSessionID.value === next) return
+    currentSessionID.value = next
+    if (!next) {
+      isPanelOpen.value = false
+      return
+    }
+    void initialize(false)
+  }
+
+  async function initialize(force = false) {
+    const sessionID = currentSessionID.value
+    if (!sessionID) return
+    if (initializedSessions.has(sessionID) && !force) return
 
     try {
-      const list = await agentTerminalApi.list()
-      console.log('[AgentTerminal] Fetched terminals:', list.length)
-
-      for (const info of list) {
-        terminals.value.set(info.id, info)
-        // 获取每个终端的屏幕内容
-        try {
-          const screenData = await agentTerminalApi.getScreen(info.id)
-          terminalScreens.value.set(info.id, {
-            id: info.id,
-            ...screenData
-          })
-          console.log(`[AgentTerminal] Loaded screen for terminal ${info.id}`)
-        } catch (e) {
-          console.warn(`[AgentTerminal] Failed to get screen for terminal ${info.id}:`, e)
+      const list = await agentTerminalApi.list(sessionID)
+      const ids = new Set(list.map((info) => info.id))
+      for (const [id, info] of terminals.value) {
+        if (info.sessionID === sessionID && !ids.has(id)) {
+          terminals.value.delete(id)
+          terminalScreens.value.delete(id)
         }
       }
 
-      // 如果有终端，选中第一个并打开面板
-      if (list.length > 0) {
-        activeTerminalId.value = list[0].id
-        isPanelOpen.value = true
-        console.log('[AgentTerminal] Auto-selected terminal:', list[0].id)
+      for (const info of list) {
+        terminals.value.set(info.id, info)
+        const existing = terminalScreens.value.get(info.id)
+        await refreshScreen(info.id, sessionID)
+        if (existing?.latestSeq !== undefined) {
+          await recoverTerminalOutput(info.id, existing.latestSeq)
+        }
       }
 
-      isInitialized.value = true
-      console.log('[AgentTerminal] Initialization complete')
-    } catch (e) {
-      console.error('[AgentTerminal] Failed to initialize:', e)
+      const visible = visibleTerminalList()
+      const active = activeTerminalBySession.value.get(sessionID)
+      if (!active || !ids.has(active)) {
+        activeTerminalBySession.value.set(sessionID, visible[0]?.id || '')
+      }
+      if (visible.length > 0) {
+        isPanelOpen.value = true
+      }
+      initializedSessions.add(sessionID)
+    } catch (error) {
+      console.error('[AgentTerminal] Failed to initialize:', error)
     }
   }
 
@@ -94,18 +205,18 @@ export function useAgentTerminal() {
 
     switch (type) {
       case 'server.connected': {
-        // SSE 连接建立后，初始化终端列表
-        console.log('[AgentTerminal] Received server.connected, triggering initialize')
-        initialize()
+        void initialize(true)
         break
       }
 
       case 'agent-terminal.created': {
         const info = properties.info as AgentTerminalInfo
         terminals.value.set(info.id, info)
-        // 自动选中新创建的终端并打开面板
-        activeTerminalId.value = info.id
-        isPanelOpen.value = true
+        if (isVisibleSession(info.sessionID)) {
+          activeTerminalBySession.value.set(info.sessionID, info.id)
+          isPanelOpen.value = true
+          void refreshScreen(info.id, info.sessionID)
+        }
         break
       }
 
@@ -117,60 +228,66 @@ export function useAgentTerminal() {
 
       case 'agent-terminal.screen': {
         const screen = properties as TerminalScreen
-        // 保留已有的 outputData，只更新其他字段
+        if (!isVisibleSession(screen.sessionID)) break
         const existing = terminalScreens.value.get(screen.id)
         terminalScreens.value.set(screen.id, {
           ...screen,
-          outputData: existing?.outputData
+          outputData: existing?.outputData,
+          outputSeq: existing?.outputSeq,
+          outputResetToken: existing?.outputResetToken,
+          latestSeq: existing?.latestSeq,
         })
         break
       }
 
       case 'agent-terminal.output': {
-        // 原始输出增量事件
-        const { id, data } = properties as { id: string; data: string }
-        const existing = terminalScreens.value.get(id)
-        if (existing) {
-          // 更新 outputData，触发前端追加
-          terminalScreens.value.set(id, {
-            ...existing,
-            outputData: data
-          })
-        } else {
-          // 终端尚未初始化，创建占位
-          terminalScreens.value.set(id, {
-            id,
-            screen: '',
-            screenAnsi: '',
-            cursor: { row: 0, col: 0 },
-            outputData: data
-          })
+        const { id, sessionID, seq, data } = properties as {
+          id: string
+          sessionID: string
+          seq: number
+          data: string
         }
+        if (!isVisibleSession(sessionID)) break
+
+        const existing = terminalScreens.value.get(id) || emptyScreen(id, sessionID)
+        const lastSeq = existing.latestSeq ?? existing.outputSeq ?? 0
+        if (seq <= lastSeq) break
+        if (seq > lastSeq + 1) {
+          void recoverTerminalOutput(id, lastSeq)
+          break
+        }
+
+        terminalScreens.value.set(id, {
+          ...existing,
+          sessionID,
+          outputData: data,
+          outputSeq: seq,
+          latestSeq: seq,
+        })
         break
       }
 
       case 'agent-terminal.exited': {
-        const { id } = properties as { id: string; exitCode: number }
+        const { id, sessionID } = properties as { id: string; sessionID: string; exitCode: number }
         const terminal = terminals.value.get(id)
         if (terminal) {
-          terminal.status = 'exited'
-          terminals.value.set(id, { ...terminal })
+          terminals.value.set(id, { ...terminal, status: 'exited' })
         }
-        // 不自动清理，让用户决定是否关闭
+        if (isVisibleSession(sessionID)) {
+          void refreshScreen(id, sessionID)
+        }
         break
       }
 
       case 'agent-terminal.closed': {
-        const { id } = properties as { id: string }
+        const { id, sessionID } = properties as { id: string; sessionID: string }
         terminals.value.delete(id)
         terminalScreens.value.delete(id)
-        // 如果关闭的是当前活跃终端，切换到其他终端
-        if (activeTerminalId.value === id) {
-          const remaining = Array.from(terminals.value.keys())
-          activeTerminalId.value = remaining[0] || null
+        if (activeTerminalBySession.value.get(sessionID) === id) {
+          const remaining = terminalListForSession(sessionID)
+          activeTerminalBySession.value.set(sessionID, remaining[0]?.id || '')
         }
-        // 如果没有终端了，关闭面板
-        if (terminals.value.size === 0) {
+        if (isVisibleSession(sessionID) && visibleTerminalList().length === 0) {
           isPanelOpen.value = false
         }
         break
@@ -179,8 +296,9 @@ export function useAgentTerminal() {
   }
 
   function selectTerminal(id: string) {
-    if (terminals.value.has(id)) {
-      activeTerminalId.value = id
+    const terminal = terminals.value.get(id)
+    if (terminal && isVisibleSession(terminal.sessionID)) {
+      activeTerminalBySession.value.set(terminal.sessionID, id)
     }
   }
 
@@ -189,33 +307,29 @@ export function useAgentTerminal() {
   }
 
   function openPanel() {
-    isPanelOpen.value = true
+    if (hasTerminals.value) isPanelOpen.value = true
   }
 
   function closePanel() {
     isPanelOpen.value = false
   }
 
-  /**
-   * 向终端发送输入
-   */
   async function writeToTerminal(id: string, data: string): Promise<boolean> {
     try {
-      return await agentTerminalApi.write(id, data)
-    } catch (e) {
-      console.error('Failed to write to terminal:', e)
+      const terminal = terminals.value.get(id)
+      return await agentTerminalApi.write(id, data, terminal?.sessionID || currentSessionID.value || undefined)
+    } catch (error) {
+      console.error('Failed to write to terminal:', error)
       return false
     }
   }
 
-  /**
-   * 关闭指定终端
-   */
   async function closeTerminal(id: string): Promise<boolean> {
     try {
-      return await agentTerminalApi.close(id)
-    } catch (e) {
-      console.error('Failed to close terminal:', e)
+      const terminal = terminals.value.get(id)
+      return await agentTerminalApi.close(id, terminal?.sessionID || currentSessionID.value || undefined)
+    } catch (error) {
+      console.error('Failed to close terminal:', error)
       return false
     }
   }
@@ -223,22 +337,26 @@ export function useAgentTerminal() {
   function clearTerminals() {
     terminals.value.clear()
     terminalScreens.value.clear()
-    activeTerminalId.value = null
-    isInitialized.value = false
+    activeTerminalBySession.value.clear()
+    currentSessionID.value = null
+    initializedSessions.clear()
+    recoveringTerminals.clear()
+    queuedRecoveries.clear()
+    isPanelOpen.value = false
   }
 
   return {
-    // State
     terminals: terminalList,
     activeTerminalId,
     activeTerminal,
     activeScreen,
     isPanelOpen,
     hasTerminals,
-
-    // Actions
+    currentSessionID,
+    setSessionContext,
     initialize,
     handleSSEEvent,
+    recoverTerminalOutput,
     selectTerminal,
     togglePanel,
     openPanel,

--- a/web/src/composables/useAgentTerminal.ts
+++ b/web/src/composables/useAgentTerminal.ts
@@ -113,7 +113,7 @@ async function recoverTerminalOutput(id: string, afterSeq?: number) {
         ...current,
         ...(screenData || {}),
         sessionID,
-        outputData: screenData?.screenAnsi ?? snapshot.buffer,
+        outputData: snapshot.buffer,
         outputSeq: snapshot.latestSeq,
         outputResetToken: ++resetTokenCounter,
         latestSeq: snapshot.latestSeq,
@@ -339,7 +339,9 @@ export function useAgentTerminal() {
   async function writeToTerminal(id: string, data: string): Promise<boolean> {
     try {
       const terminal = terminals.value.get(id)
-      return await agentTerminalApi.write(id, data, terminal?.sessionID || currentSessionID.value || undefined)
+      const sessionID = terminal?.sessionID || currentSessionID.value
+      if (!sessionID) return false
+      return await agentTerminalApi.write(id, data, sessionID)
     } catch (error) {
       console.error('Failed to write to terminal:', error)
       return false
@@ -349,7 +351,9 @@ export function useAgentTerminal() {
   async function closeTerminal(id: string): Promise<boolean> {
     try {
       const terminal = terminals.value.get(id)
-      return await agentTerminalApi.close(id, terminal?.sessionID || currentSessionID.value || undefined)
+      const sessionID = terminal?.sessionID || currentSessionID.value
+      if (!sessionID) return false
+      return await agentTerminalApi.close(id, sessionID)
     } catch (error) {
       console.error('Failed to close terminal:', error)
       return false

--- a/web/src/composables/useAgentTerminal.ts
+++ b/web/src/composables/useAgentTerminal.ts
@@ -114,6 +114,16 @@ async function recoverTerminalOutput(id: string, afterSeq?: number) {
       return
     }
 
+    if (snapshot.chunks.length === 0) {
+      terminalScreens.value.set(id, {
+        ...existing,
+        sessionID,
+        latestSeq: snapshot.latestSeq,
+      })
+      await refreshScreen(id, sessionID)
+      return
+    }
+
     const data = snapshot.chunks.map((chunk) => chunk.data).join('')
     terminalScreens.value.set(id, {
       ...existing,
@@ -159,7 +169,7 @@ export function useAgentTerminal() {
       isPanelOpen.value = false
       return
     }
-    void initialize(false)
+    void initialize(true)
   }
 
   async function initialize(force = false) {
@@ -181,17 +191,15 @@ export function useAgentTerminal() {
         terminals.value.set(info.id, info)
         const existing = terminalScreens.value.get(info.id)
         await refreshScreen(info.id, sessionID)
-        if (existing?.latestSeq !== undefined) {
-          await recoverTerminalOutput(info.id, existing.latestSeq)
-        }
+        await recoverTerminalOutput(info.id, existing?.latestSeq ?? 0)
       }
 
-      const visible = visibleTerminalList()
+      const visible = terminalListForSession(sessionID)
       const active = activeTerminalBySession.value.get(sessionID)
       if (!active || !ids.has(active)) {
         activeTerminalBySession.value.set(sessionID, visible[0]?.id || '')
       }
-      if (visible.length > 0) {
+      if (currentSessionID.value === sessionID && visible.length > 0) {
         isPanelOpen.value = true
       }
       initializedSessions.add(sessionID)

--- a/web/src/composables/useAgentTerminal.ts
+++ b/web/src/composables/useAgentTerminal.ts
@@ -70,7 +70,7 @@ function currentActiveTerminalId() {
   return visibleTerminalList()[0]?.id || null
 }
 
-async function refreshScreen(id: string, sessionID: string) {
+async function refreshScreen(id: string, sessionID: string): Promise<TerminalScreen | undefined> {
   try {
     const screenData = await agentTerminalApi.getScreen(id, sessionID)
     const existing = terminalScreens.value.get(id)
@@ -83,8 +83,13 @@ async function refreshScreen(id: string, sessionID: string) {
       outputResetToken: existing?.outputResetToken,
       latestSeq: existing?.latestSeq,
     })
+    return {
+      ...emptyScreen(id, screenData.sessionID || sessionID),
+      ...screenData,
+    }
   } catch (error) {
     console.warn(`[AgentTerminal] Failed to refresh screen for terminal ${id}:`, error)
+    return undefined
   }
 }
 
@@ -102,35 +107,43 @@ async function recoverTerminalOutput(id: string, afterSeq?: number) {
     const snapshot = await agentTerminalApi.getBuffer(id, sessionID, afterSeq)
     const existing = terminalScreens.value.get(id) || emptyScreen(id, sessionID)
     if (snapshot.reset) {
+      const screenData = await refreshScreen(id, sessionID)
+      const current = terminalScreens.value.get(id) || existing
       terminalScreens.value.set(id, {
-        ...existing,
+        ...current,
+        ...(screenData || {}),
         sessionID,
-        outputData: snapshot.buffer,
+        outputData: screenData?.screenAnsi ?? snapshot.buffer,
         outputSeq: snapshot.latestSeq,
         outputResetToken: ++resetTokenCounter,
         latestSeq: snapshot.latestSeq,
       })
-      await refreshScreen(id, sessionID)
       return
     }
 
-    if (snapshot.chunks.length === 0) {
+    const current = terminalScreens.value.get(id) || existing
+    const currentLatestSeq = current.latestSeq ?? current.outputSeq ?? afterSeq ?? 0
+    const chunks = snapshot.chunks.filter((chunk) => chunk.seq > currentLatestSeq)
+
+    if (chunks.length === 0) {
       terminalScreens.value.set(id, {
-        ...existing,
+        ...current,
         sessionID,
-        latestSeq: snapshot.latestSeq,
+        latestSeq: Math.max(currentLatestSeq, snapshot.latestSeq),
       })
       await refreshScreen(id, sessionID)
       return
     }
 
-    const data = snapshot.chunks.map((chunk) => chunk.data).join('')
+    const data = chunks.map((chunk) => chunk.data).join('')
+    const latestChunkSeq = chunks[chunks.length - 1]?.seq ?? snapshot.latestSeq
     terminalScreens.value.set(id, {
-      ...existing,
+      ...current,
       sessionID,
       outputData: data,
-      outputSeq: snapshot.latestSeq,
-      latestSeq: snapshot.latestSeq,
+      outputSeq: latestChunkSeq,
+      outputResetToken: undefined,
+      latestSeq: Math.max(latestChunkSeq, snapshot.latestSeq),
     })
     await refreshScreen(id, sessionID)
   } catch (error) {
@@ -270,6 +283,7 @@ export function useAgentTerminal() {
           sessionID,
           outputData: data,
           outputSeq: seq,
+          outputResetToken: undefined,
           latestSeq: seq,
         })
         break

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue'
-import { api, type Session, type Message, type SSEEvent, type MessagePart, type QuestionRequest, type PermissionRequest, type TodoItem, type ContextEnrichmentSummary, questionApi, permissionApi, SessionBusyError, setApiDirectory } from '../api/client'
+import { api, type EventStreamSubscription, type Session, type Message, type SSEEvent, type MessagePart, type QuestionRequest, type PermissionRequest, type TodoItem, type ContextEnrichmentSummary, questionApi, permissionApi, SessionBusyError, setApiDirectory } from '../api/client'
 import { collectActivePageContext } from '../api/page-context'
 import { useParallelSessions, MAX_PARALLEL_AGENTS } from './useParallelSessions'
 
@@ -51,8 +51,8 @@ export function useSession() {
   const isSummarizing = ref(false)
 
   // 事件源订阅
-  let eventSource: EventSource | null = null
-  let sessionEventSource: EventSource | null = null
+  let eventSource: EventStreamSubscription | null = null
+  let sessionEventSource: EventStreamSubscription | null = null
   let subscribedRuntimeSessionId: string | null = null
 
   function reconnectEventsForDirectory() {

--- a/web/test/agent-terminal.test.ts
+++ b/web/test/agent-terminal.test.ts
@@ -4,6 +4,8 @@ import { useAgentTerminal } from '../src/composables/useAgentTerminal'
 const originalFetch = globalThis.fetch
 const mockState = {
   agtBChunks: [] as Array<{ seq: number; data: string }>,
+  pauseAAfterSeq1: false,
+  resumeAAfterSeq1: undefined as (() => void) | undefined,
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -67,6 +69,11 @@ function installFetchMock() {
     }
 
     if (parsed.pathname === '/agent-terminal/agt_a/buffer' && parsed.searchParams.get('afterSeq') === '1') {
+      if (mockState.pauseAAfterSeq1) {
+        await new Promise<void>((resolve) => {
+          mockState.resumeAAfterSeq1 = resolve
+        })
+      }
       return jsonResponse({
         buffer: '',
         chunks: [
@@ -99,7 +106,7 @@ function installFetchMock() {
       })
     }
 
-    return jsonResponse({ buffer: '', chunks: [], latestSeq: 0, firstSeq: 1, reset: true })
+    return jsonResponse({ buffer: 'trimmed-tail', chunks: [], latestSeq: 0, firstSeq: 1, reset: true })
   }) as typeof fetch
 }
 
@@ -111,6 +118,8 @@ async function settle() {
 beforeEach(() => {
   useAgentTerminal().clearTerminals()
   mockState.agtBChunks = []
+  mockState.pauseAAfterSeq1 = false
+  mockState.resumeAAfterSeq1 = undefined
   installFetchMock()
 })
 
@@ -203,5 +212,49 @@ describe('useAgentTerminal', () => {
 
     expect(terminal.activeScreen.value?.outputData).toBe('twothree')
     expect(terminal.activeScreen.value?.latestSeq).toBe(3)
+  })
+
+  it('does not replay recovery chunks that arrived live while recovery was in flight', async () => {
+    const terminal = useAgentTerminal()
+    terminal.setSessionContext('ses_a')
+    await settle()
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 1, data: 'one' },
+    })
+
+    mockState.pauseAAfterSeq1 = true
+    const recovery = terminal.recoverTerminalOutput('agt_a', 1)
+    await settle()
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 2, data: 'two-live' },
+    })
+    mockState.resumeAAfterSeq1?.()
+    await recovery
+
+    expect(terminal.activeScreen.value?.outputData).toBe('three')
+    expect(terminal.activeScreen.value?.latestSeq).toBe(3)
+  })
+
+  it('uses the authoritative screen for reset recovery and clears reset token on later output', async () => {
+    const terminal = useAgentTerminal()
+    terminal.setSessionContext('ses_a')
+    await settle()
+
+    await terminal.recoverTerminalOutput('agt_a', -1)
+
+    expect(terminal.activeScreen.value?.outputData).toBe('ready')
+    expect(terminal.activeScreen.value?.outputResetToken).toBeGreaterThan(0)
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 1, data: 'after-reset' },
+    })
+
+    expect(terminal.activeScreen.value?.outputData).toBe('after-reset')
+    expect(terminal.activeScreen.value?.outputResetToken).toBeUndefined()
   })
 })

--- a/web/test/agent-terminal.test.ts
+++ b/web/test/agent-terminal.test.ts
@@ -239,14 +239,15 @@ describe('useAgentTerminal', () => {
     expect(terminal.activeScreen.value?.latestSeq).toBe(3)
   })
 
-  it('uses the authoritative screen for reset recovery and clears reset token on later output', async () => {
+  it('keeps retained buffer data for reset recovery and clears reset token on later output', async () => {
     const terminal = useAgentTerminal()
     terminal.setSessionContext('ses_a')
     await settle()
 
     await terminal.recoverTerminalOutput('agt_a', -1)
 
-    expect(terminal.activeScreen.value?.outputData).toBe('ready')
+    expect(terminal.activeScreen.value?.screenAnsi).toBe('ready')
+    expect(terminal.activeScreen.value?.outputData).toBe('trimmed-tail')
     expect(terminal.activeScreen.value?.outputResetToken).toBeGreaterThan(0)
 
     terminal.handleSSEEvent({

--- a/web/test/agent-terminal.test.ts
+++ b/web/test/agent-terminal.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { useAgentTerminal } from '../src/composables/useAgentTerminal'
 
 const originalFetch = globalThis.fetch
+const mockState = {
+  agtBChunks: [] as Array<{ seq: number; data: string }>,
+}
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -30,12 +33,36 @@ function installFetchMock() {
       ])
     }
 
+    if (parsed.pathname === '/agent-terminal' && parsed.searchParams.get('sessionID') === 'ses_b') {
+      return jsonResponse([
+        {
+          id: 'agt_b',
+          name: 'B',
+          sessionID: 'ses_b',
+          status: 'running',
+          rows: 24,
+          cols: 80,
+          createdAt: 1,
+          lastActivity: 1,
+        },
+      ])
+    }
+
     if (parsed.pathname === '/agent-terminal/agt_a/screen') {
       return jsonResponse({
         sessionID: 'ses_a',
         screen: 'ready',
         screenAnsi: 'ready',
         cursor: { row: 0, col: 5 },
+      })
+    }
+
+    if (parsed.pathname === '/agent-terminal/agt_b/screen') {
+      return jsonResponse({
+        sessionID: 'ses_b',
+        screen: 'b ready',
+        screenAnsi: 'b ready',
+        cursor: { row: 0, col: 7 },
       })
     }
 
@@ -52,12 +79,38 @@ function installFetchMock() {
       })
     }
 
+    if (parsed.pathname === '/agent-terminal/agt_a/buffer' && parsed.searchParams.get('afterSeq') === '0') {
+      return jsonResponse({
+        buffer: '',
+        chunks: [],
+        latestSeq: 0,
+        firstSeq: 1,
+        reset: false,
+      })
+    }
+
+    if (parsed.pathname === '/agent-terminal/agt_b/buffer' && parsed.searchParams.get('afterSeq') === '0') {
+      return jsonResponse({
+        buffer: '',
+        chunks: mockState.agtBChunks,
+        latestSeq: mockState.agtBChunks.at(-1)?.seq ?? 0,
+        firstSeq: 1,
+        reset: false,
+      })
+    }
+
     return jsonResponse({ buffer: '', chunks: [], latestSeq: 0, firstSeq: 1, reset: true })
   }) as typeof fetch
 }
 
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 beforeEach(() => {
   useAgentTerminal().clearTerminals()
+  mockState.agtBChunks = []
   installFetchMock()
 })
 
@@ -70,7 +123,7 @@ describe('useAgentTerminal', () => {
   it('filters terminals by current session and ignores other session output', async () => {
     const terminal = useAgentTerminal()
     terminal.setSessionContext('ses_a')
-    await terminal.initialize(true)
+    await settle()
 
     expect(terminal.terminals.value.map((item) => item.id)).toEqual(['agt_a'])
     expect(terminal.activeTerminalId.value).toBe('agt_a')
@@ -99,10 +152,36 @@ describe('useAgentTerminal', () => {
     expect(terminal.activeScreen.value?.outputData).toBeUndefined()
   })
 
+  it('refreshes a previously initialized session when switching back after hidden output', async () => {
+    const terminal = useAgentTerminal()
+    terminal.setSessionContext('ses_b')
+    await settle()
+
+    expect(terminal.activeTerminalId.value).toBe('agt_b')
+    expect(terminal.activeScreen.value?.latestSeq).toBe(0)
+
+    terminal.setSessionContext('ses_a')
+    await settle()
+    mockState.agtBChunks = [{ seq: 1, data: 'hidden' }]
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_b', sessionID: 'ses_b', seq: 1, data: 'hidden' },
+    })
+    expect(terminal.activeTerminalId.value).toBe('agt_a')
+
+    terminal.setSessionContext('ses_b')
+    await settle()
+
+    expect(terminal.activeTerminalId.value).toBe('agt_b')
+    expect(terminal.activeScreen.value?.outputData).toBe('hidden')
+    expect(terminal.activeScreen.value?.latestSeq).toBe(1)
+  })
+
   it('deduplicates output seqs and recovers gaps from the ring buffer', async () => {
     const terminal = useAgentTerminal()
     terminal.setSessionContext('ses_a')
-    await terminal.initialize(true)
+    await settle()
 
     terminal.handleSSEEvent({
       type: 'agent-terminal.output',

--- a/web/test/agent-terminal.test.ts
+++ b/web/test/agent-terminal.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { useAgentTerminal } from '../src/composables/useAgentTerminal'
+
+const originalFetch = globalThis.fetch
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function installFetchMock() {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    const parsed = new URL(url, 'http://localhost')
+
+    if (parsed.pathname === '/agent-terminal' && parsed.searchParams.get('sessionID') === 'ses_a') {
+      return jsonResponse([
+        {
+          id: 'agt_a',
+          name: 'A',
+          sessionID: 'ses_a',
+          status: 'running',
+          rows: 24,
+          cols: 80,
+          createdAt: 1,
+          lastActivity: 1,
+        },
+      ])
+    }
+
+    if (parsed.pathname === '/agent-terminal/agt_a/screen') {
+      return jsonResponse({
+        sessionID: 'ses_a',
+        screen: 'ready',
+        screenAnsi: 'ready',
+        cursor: { row: 0, col: 5 },
+      })
+    }
+
+    if (parsed.pathname === '/agent-terminal/agt_a/buffer' && parsed.searchParams.get('afterSeq') === '1') {
+      return jsonResponse({
+        buffer: '',
+        chunks: [
+          { seq: 2, data: 'two' },
+          { seq: 3, data: 'three' },
+        ],
+        latestSeq: 3,
+        firstSeq: 1,
+        reset: false,
+      })
+    }
+
+    return jsonResponse({ buffer: '', chunks: [], latestSeq: 0, firstSeq: 1, reset: true })
+  }) as typeof fetch
+}
+
+beforeEach(() => {
+  useAgentTerminal().clearTerminals()
+  installFetchMock()
+})
+
+afterEach(() => {
+  useAgentTerminal().clearTerminals()
+  globalThis.fetch = originalFetch
+})
+
+describe('useAgentTerminal', () => {
+  it('filters terminals by current session and ignores other session output', async () => {
+    const terminal = useAgentTerminal()
+    terminal.setSessionContext('ses_a')
+    await terminal.initialize(true)
+
+    expect(terminal.terminals.value.map((item) => item.id)).toEqual(['agt_a'])
+    expect(terminal.activeTerminalId.value).toBe('agt_a')
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.created',
+      properties: {
+        info: {
+          id: 'agt_b',
+          name: 'B',
+          sessionID: 'ses_b',
+          status: 'running',
+          rows: 24,
+          cols: 80,
+          createdAt: 1,
+          lastActivity: 1,
+        },
+      },
+    })
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_b', sessionID: 'ses_b', seq: 1, data: 'wrong' },
+    })
+
+    expect(terminal.terminals.value.map((item) => item.id)).toEqual(['agt_a'])
+    expect(terminal.activeScreen.value?.outputData).toBeUndefined()
+  })
+
+  it('deduplicates output seqs and recovers gaps from the ring buffer', async () => {
+    const terminal = useAgentTerminal()
+    terminal.setSessionContext('ses_a')
+    await terminal.initialize(true)
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 1, data: 'one' },
+    })
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 1, data: 'duplicate' },
+    })
+
+    expect(terminal.activeScreen.value?.outputData).toBe('one')
+    expect(terminal.activeScreen.value?.latestSeq).toBe(1)
+
+    terminal.handleSSEEvent({
+      type: 'agent-terminal.output',
+      properties: { id: 'agt_a', sessionID: 'ses_a', seq: 3, data: 'three' },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(terminal.activeScreen.value?.outputData).toBe('twothree')
+    expect(terminal.activeScreen.value?.latestSeq).toBe(3)
+  })
+})


### PR DESCRIPTION
# 描述 / Summary

修复 Agent PTY 终端链路在多会话、Linux 远程部署和 SSE 重连场景下可能出现的终端串台、输出丢失、浏览器终端不刷新、读屏状态滞后的问题。

本次变更主要为终端输出增加 session 隔离、序号化增量、可恢复 buffer、SSE 串行写入和前端补漏逻辑，从而提升高吞吐输出和断线重连时的稳定性。

## 类型 / Type of change

- [ ] 新功能 (feature)
- [x] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

/

## 变更点 / What changed

- 为 `agent-terminal.output/screen/exited/closed` 事件补充 `sessionID`，并为输出事件增加单调递增 `seq`
- 后端 AgentTerminal 增加输出批处理、ring buffer、`afterSeq` 补拉接口和终端归属校验
- `ScreenBuffer` 写入改为串行 async queue，读屏和 `waitForPattern` 前等待 xterm-headless 完成解析
- Web API 和 terminal tools 在 write/view/wait/close/resize 等操作中传递并校验 session 归属
- 前端 `useAgentTerminal` 按当前 session 过滤终端，active terminal 改为按 session 保存
- `AgentTerminalViewer` 初始化期间缓存 pending output，buffer 加载完成后按 seq 去重和 flush
- 终端 viewer 增加 `:key`，避免切换终端时复用旧 xterm 实例导致输出混入
- SSE stream 增加防缓冲响应头和串行写队列，前端 EventSource 改为可关闭 subscription handle

## 如何测试 / How to test

1. 运行目标测试：

```bash
bun test opencode/packages/opencode/test/tool/screen-buffer.test.ts web/test/agent-terminal.test.ts
```

2. 检查 diff 空白问题：

```bash
git diff --check origin/main..HEAD
```

3. 手工验证建议：
   - 开两个会话分别创建终端，连续输出大量内容，例如 `yes | head -n 10000`
   - 切换会话、刷新浏览器、断开/恢复 SSE 连接
   - 确认终端输出不串台，重连后能补齐输出，`terminal_view`/`terminal_wait` 能读到最新屏幕

预期结果：
- 多会话终端只显示当前会话的终端
- 高吞吐输出不会明显卡死或乱序
- 浏览器刷新或 SSE 重连后终端内容可恢复
- terminal tool 无法操作其他 session 的 terminal id

## 截图（UI 变更时提供）/ Screenshots for UI changed

无。

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

重点关注：

- `opencode/packages/opencode/src/pty/agent-terminal.ts`
- `opencode/packages/opencode/src/pty/screen-buffer.ts`
- `web/src/composables/useAgentTerminal.ts`
- `web/src/components/AgentTerminalViewer.vue`
- SSE 相关改动：`server.ts`、`global.ts`、`nine1bot-agent.ts`

补充说明：`build:web` 和 opencode typecheck 在变基到最新 `origin/main` 后受主分支新增 `@nine1bot/platform-protocol` workspace 依赖解析问题影响，未作为本 PR 的最终验证项；本 PR 相关的目标测试已通过。

关联 issue: Fixes #24