### PR TITLE
feat(platform): add Feishu deep adaptation

### DIFF
--- a/opencode/packages/opencode/src/config/config.ts
+++ b/opencode/packages/opencode/src/config/config.ts
@@ -28,6 +28,7 @@ import { existsSync } from "fs"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
+import { State } from "../project/state"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -44,7 +45,7 @@ export namespace Config {
     return merged
   }
 
-  export const state = Instance.state(async () => {
+  async function stateInit() {
     const auth = await Auth.all()
 
     // Load remote/well-known config first as the base layer (lowest precedence)
@@ -222,7 +223,9 @@ export namespace Config {
       config: result,
       directories,
     }
-  })
+  }
+
+  export const state = Instance.state(stateInit)
 
   export async function installDependencies(dir: string) {
     const pkg = path.join(dir, "package.json")
@@ -1326,11 +1329,24 @@ export namespace Config {
     return global()
   }
 
-  export async function update(config: Info) {
+  export type UpdateOptions = {
+    reload?: "dispose" | "refresh" | false
+  }
+
+  export function refresh() {
+    State.invalidate(Instance.directory, stateInit)
+  }
+
+  export async function update(config: Info, options: UpdateOptions = {}) {
     const filepath = path.join(Instance.directory, "config.json")
     const existing = await loadFile(filepath)
     await Bun.write(filepath, JSON.stringify(mergeDeep(existing, config), null, 2))
-    await Instance.dispose()
+    const reload = options.reload ?? "dispose"
+    if (reload === "dispose") {
+      await Instance.dispose()
+      return
+    }
+    if (reload === "refresh") refresh()
   }
 
   function globalConfigFile() {

--- a/opencode/packages/opencode/src/runtime/controller/protocol.ts
+++ b/opencode/packages/opencode/src/runtime/controller/protocol.ts
@@ -148,6 +148,16 @@ export namespace RuntimeControllerProtocol {
   })
   export type MessageSendRequest = z.infer<typeof MessageSendRequest>
 
+  export const ContextEnrichmentSummary = z
+    .object({
+      platform: z.string(),
+      status: z.string(),
+      message: z.string(),
+      tone: z.enum(["neutral", "success", "warning", "danger"]).optional(),
+    })
+    .passthrough()
+  export type ContextEnrichmentSummary = z.infer<typeof ContextEnrichmentSummary>
+
   export const MessageSendResponse = z.object({
     version: z.literal(VERSION),
     accepted: z.boolean(),
@@ -160,6 +170,7 @@ export namespace RuntimeControllerProtocol {
         label: z.string(),
       })
       .optional(),
+    contextEnrichment: ContextEnrichmentSummary.optional(),
   })
   export type MessageSendResponse = z.infer<typeof MessageSendResponse>
 

--- a/opencode/packages/opencode/src/runtime/source/registry.ts
+++ b/opencode/packages/opencode/src/runtime/source/registry.ts
@@ -21,6 +21,7 @@ export namespace RuntimeSourceRegistry {
     id: string
     directory: string
     namespace?: string
+    includeNamePrefix?: string
     visibility: SkillSourceVisibility
     lifecycle: SourceLifecycle
   }

--- a/opencode/packages/opencode/src/server/routes/config.ts
+++ b/opencode/packages/opencode/src/server/routes/config.ts
@@ -46,7 +46,7 @@ async function patchOpencodeRuntimeConfig(patch: Record<string, any>) {
   const opConfigPath = process.env.OPENCODE_CONFIG || ""
   if (!opConfigPath) return
   const opText = await readFile(opConfigPath, "utf-8").catch(() => "{}")
-  const opConfig = JSON.parse(opText)
+  const opConfig = (parseJsonc(opText) || {}) as Record<string, any>
   Object.assign(opConfig, patch)
   await writeFile(opConfigPath, JSON.stringify(opConfig, null, 2))
 }
@@ -127,7 +127,8 @@ export const ConfigRoutes = lazy(() =>
       validator("json", Config.Info),
       async (c) => {
         const config = c.req.valid("json")
-        await Config.update(config)
+        await Config.update(config, { reload: "refresh" })
+        Provider.refresh()
         return c.json(config)
       },
     )
@@ -204,8 +205,7 @@ export const ConfigRoutes = lazy(() =>
           runtimePatch.provider = { ...preserved, ...mapped }
         }
         await patchOpencodeRuntimeConfig(runtimePatch)
-        // 3. 触发 Instance 重建，强制重新加载配置
-        await Config.update(runtimePatch)
+        Config.refresh()
         Provider.refresh()
         return c.json({ success: true })
       } catch (e: any) {
@@ -254,12 +254,7 @@ export const ConfigRoutes = lazy(() =>
               ...mapped,
             },
           })
-          await Config.update({
-            provider: {
-              ...(current.provider || {}),
-              ...mapped,
-            },
-          })
+          Config.refresh()
           Provider.refresh()
           return c.json({ success: true })
         } catch (e: any) {
@@ -297,7 +292,7 @@ export const ConfigRoutes = lazy(() =>
             ...mapped,
           }
           await patchOpencodeRuntimeConfig({ provider: nextProvider })
-          await Config.update({ provider: nextProvider })
+          Config.refresh()
           Provider.refresh()
           return c.json({ success: true })
         } catch (e: any) {

--- a/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
@@ -26,6 +26,7 @@ import { NamedError } from "@opencode-ai/util/error"
 import { Provider } from "@/provider/provider"
 import { Storage } from "@/storage/storage"
 import { ulid } from "ulid"
+import { prepareFeishuControllerMessageContext } from "../../../../../../packages/nine1bot/src/platform/feishu-context"
 
 const log = Log.create({ service: "server.nine1bot-agent" })
 
@@ -272,8 +273,14 @@ async function compileControllerPrompt(input: {
 export async function sendControllerMessage(sessionID: string, body: RuntimeControllerProtocol.MessageSendRequest) {
   const turnSnapshotId = ulid()
   let prompt: SessionPrompt.PromptInput
+  let preparedBody = body
+  let contextEnrichment: RuntimeControllerProtocol.ContextEnrichmentSummary | undefined
   try {
-    prompt = await compileControllerPrompt({ sessionID, body, turnSnapshotId })
+    SessionPrompt.assertNotBusy(sessionID)
+    const prepared = await prepareFeishuControllerMessageContext(body)
+    preparedBody = prepared.body
+    contextEnrichment = prepared.contextEnrichment
+    prompt = await compileControllerPrompt({ sessionID, body: preparedBody, turnSnapshotId })
   } catch (error) {
     if (error instanceof Session.BusyError) {
       return {
@@ -284,7 +291,7 @@ export async function sendControllerMessage(sessionID: string, body: RuntimeCont
           turnSnapshotId,
           busy: true,
           fallbackAction:
-            body.clientCapabilities?.continueInWeb === false
+            preparedBody.clientCapabilities?.continueInWeb === false
               ? undefined
               : {
                   type: "continue-in-web" as const,
@@ -325,7 +332,7 @@ export async function sendControllerMessage(sessionID: string, body: RuntimeCont
           turnSnapshotId,
           busy: true,
           fallbackAction:
-            body.clientCapabilities?.continueInWeb === false
+            preparedBody.clientCapabilities?.continueInWeb === false
               ? undefined
               : {
                   type: "continue-in-web" as const,
@@ -344,6 +351,7 @@ export async function sendControllerMessage(sessionID: string, body: RuntimeCont
       accepted: true,
       sessionId: sessionID,
       turnSnapshotId,
+      contextEnrichment,
     },
     status: 202,
   }

--- a/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-agent.ts
@@ -277,7 +277,9 @@ export async function sendControllerMessage(sessionID: string, body: RuntimeCont
   let contextEnrichment: RuntimeControllerProtocol.ContextEnrichmentSummary | undefined
   try {
     SessionPrompt.assertNotBusy(sessionID)
-    const prepared = await prepareFeishuControllerMessageContext(body)
+    const prepared = await prepareFeishuControllerMessageContext(body, {
+      cacheScope: sessionID,
+    })
     preparedBody = prepared.body
     contextEnrichment = prepared.contextEnrichment
     prompt = await compileControllerPrompt({ sessionID, body: preparedBody, turnSnapshotId })

--- a/opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts
@@ -145,6 +145,7 @@ export const Nine1BotPlatformRoutes = () =>
       }
     })
     .post("/:id/actions/:actionId", async (c) => {
+      let previousConfig
       try {
         const parsed = PlatformActionBodySchema.safeParse(await parseJson(c))
         if (!parsed.success) {
@@ -157,12 +158,21 @@ export const Nine1BotPlatformRoutes = () =>
         }
 
         const manager = getBuiltinPlatformManager()
+        previousConfig = manager.configSnapshot()
         const result = await manager.executeAction(c.req.param("id"), c.req.param("actionId"), parsed.data)
         if (result.updatedSettings !== undefined) {
           await writePlatformManagerConfig(manager.configSnapshot())
         }
         return c.json(result)
       } catch (error) {
+        if (previousConfig) {
+          try {
+            registerBuiltinPlatformAdapters({
+              config: previousConfig,
+              secrets: platformSecrets(),
+            })
+          } catch {}
+        }
         return c.json(errorBody(error), errorStatus(error))
       }
     })

--- a/opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts
+++ b/opencode/packages/opencode/src/server/routes/nine1bot-platforms.ts
@@ -158,6 +158,9 @@ export const Nine1BotPlatformRoutes = () =>
 
         const manager = getBuiltinPlatformManager()
         const result = await manager.executeAction(c.req.param("id"), c.req.param("actionId"), parsed.data)
+        if (result.updatedSettings !== undefined) {
+          await writePlatformManagerConfig(manager.configSnapshot())
+        }
         return c.json(result)
       } catch (error) {
         return c.json(errorBody(error), errorStatus(error))

--- a/opencode/packages/opencode/src/skill/skill.ts
+++ b/opencode/packages/opencode/src/skill/skill.ts
@@ -229,7 +229,7 @@ export namespace Skill {
   }
 
   async function scanRuntimeSkillSources(skills: Record<string, Info>) {
-    const addSkill = async (match: string, source: Source) => {
+    const addSkill = async (match: string, source: Source, options?: { includeNamePrefix?: string }) => {
       const md = await ConfigMarkdown.parse(match).catch((err) => {
         log.error("failed to load runtime skill source item", { skill: match, err })
         return undefined
@@ -238,6 +238,7 @@ export namespace Skill {
 
       const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
       if (!parsed.success) return
+      if (options?.includeNamePrefix && !parsed.data.name.startsWith(options.includeNamePrefix)) return
 
       const existing = skills[parsed.data.name]
       if (existing && sourceVisibility(existing) === "default" && source.visibility === "declared-only") {
@@ -302,7 +303,7 @@ export namespace Skill {
       }
 
       for (const match of matches) {
-        await addSkill(match, source)
+        await addSkill(match, source, { includeNamePrefix: runtimeSource.includeNamePrefix })
       }
     }
   }

--- a/opencode/packages/opencode/test/config/config.test.ts
+++ b/opencode/packages/opencode/test/config/config.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
 import { pathToFileURL } from "url"
+import { GlobalBus } from "../../src/bus/global"
 
 test("loads config with defaults when no files exist", async () => {
   await using tmp = await tmpdir()
@@ -560,13 +561,63 @@ test("updates config and writes to file", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
+      const disposed = collectInstanceDisposedEvents()
       const newConfig = { model: "updated/model" }
-      await Config.update(newConfig as any)
+      try {
+        await Config.update(newConfig as any)
 
-      const writtenConfig = JSON.parse(await Bun.file(path.join(tmp.path, "config.json")).text())
-      expect(writtenConfig.model).toBe("updated/model")
+        const writtenConfig = JSON.parse(await Bun.file(path.join(tmp.path, "config.json")).text())
+        expect(writtenConfig.model).toBe("updated/model")
+        expect(disposed.events).toContainEqual(expect.objectContaining({
+          directory: tmp.path,
+          payload: expect.objectContaining({
+            type: "server.instance.disposed",
+          }),
+        }))
+      } finally {
+        disposed.stop()
+      }
     },
   })
+})
+
+test("updates config with refresh without disposing the current instance", async () => {
+  const originalConfig = process.env.OPENCODE_CONFIG
+  const originalDisableGlobal = process.env.OPENCODE_DISABLE_GLOBAL_CONFIG
+  const originalDisableProject = process.env.OPENCODE_DISABLE_PROJECT_CONFIG
+  const originalDisablePluginInstall = process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL
+
+  try {
+    await using tmp = await tmpdir()
+    process.env.OPENCODE_CONFIG = path.join(tmp.path, "config.json")
+    process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+    process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "true"
+    process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const disposed = collectInstanceDisposedEvents()
+        try {
+          expect((await Config.get()).model).toBeUndefined()
+
+          await Config.update({ model: "updated/model" } as any, { reload: "refresh" })
+
+          const writtenConfig = JSON.parse(await Bun.file(path.join(tmp.path, "config.json")).text())
+          expect(writtenConfig.model).toBe("updated/model")
+          expect(disposed.events).toEqual([])
+          expect((await Config.get()).model).toBe("updated/model")
+        } finally {
+          disposed.stop()
+        }
+      },
+    })
+  } finally {
+    restoreEnv("OPENCODE_CONFIG", originalConfig)
+    restoreEnv("OPENCODE_DISABLE_GLOBAL_CONFIG", originalDisableGlobal)
+    restoreEnv("OPENCODE_DISABLE_PROJECT_CONFIG", originalDisableProject)
+    restoreEnv("OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL", originalDisablePluginInstall)
+  }
 })
 
 test("gets config directories", async () => {
@@ -579,6 +630,28 @@ test("gets config directories", async () => {
     },
   })
 })
+
+function collectInstanceDisposedEvents() {
+  const events: Array<{ directory?: string; payload: any }> = []
+  const handler = (event: { directory?: string; payload: any }) => {
+    if (event.payload?.type === "server.instance.disposed") events.push(event)
+  }
+  GlobalBus.on("event", handler)
+  return {
+    events,
+    stop() {
+      GlobalBus.off("event", handler)
+    },
+  }
+}
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
 
 test("resolves scoped npm plugins in config", async () => {
   await using tmp = await tmpdir({

--- a/opencode/packages/opencode/test/server/config-routes.test.ts
+++ b/opencode/packages/opencode/test/server/config-routes.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { GlobalBus } from "../../src/bus/global"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { Server } from "../../src/server/server"
+import { Log } from "../../src/util/log"
+
+Log.init({ print: false })
+
+const jsonHeaders = {
+  "Content-Type": "application/json",
+}
+
+let envSnapshot: NodeJS.ProcessEnv
+const tempDirs: string[] = []
+
+beforeEach(() => {
+  envSnapshot = { ...process.env }
+})
+
+afterEach(async () => {
+  restoreEnv(envSnapshot)
+  await Instance.disposeAll().catch(() => undefined)
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("config routes reload behavior", () => {
+  test("PATCH /config refreshes config without disposing the current instance", async () => {
+    const setup = await setupProject()
+    const disposed = collectInstanceDisposedEvents()
+
+    try {
+      const response = await request(setup.projectDir, "/config", {
+        method: "PATCH",
+        headers: jsonHeaders,
+        body: JSON.stringify({ model: "updated/model" }),
+      })
+
+      expect(response.status).toBe(200)
+      expect(disposed.events).toEqual([])
+      expect(await configModel(setup.projectDir)).toBe("updated/model")
+    } finally {
+      disposed.stop()
+    }
+  })
+
+  test("PATCH /config/nine1bot refreshes runtime config without disposing the current instance", async () => {
+    const setup = await setupProject()
+    const disposed = collectInstanceDisposedEvents()
+
+    try {
+      const response = await request(setup.projectDir, "/config/nine1bot", {
+        method: "PATCH",
+        headers: jsonHeaders,
+        body: JSON.stringify({ model: "nine1bot/model" }),
+      })
+
+      expect(response.status).toBe(200)
+      expect(disposed.events).toEqual([])
+      expect(JSON.parse(await readFile(setup.runtimeConfigPath, "utf-8")).model).toBe("nine1bot/model")
+      expect(await configModel(setup.projectDir)).toBe("nine1bot/model")
+    } finally {
+      disposed.stop()
+    }
+  })
+
+  test("custom provider upsert and delete refresh providers without disposing the current instance", async () => {
+    const setup = await setupProject()
+    const disposed = collectInstanceDisposedEvents()
+    const provider = {
+      name: "Local Custom",
+      protocol: "openai",
+      baseURL: "https://example.test/v1",
+      models: [{ id: "custom-model" }],
+    }
+
+    try {
+      const upsert = await request(setup.projectDir, "/config/nine1bot/custom-providers/local-custom", {
+        method: "PUT",
+        headers: jsonHeaders,
+        body: JSON.stringify(provider),
+      })
+
+      expect(upsert.status).toBe(200)
+      expect(disposed.events).toEqual([])
+      await Instance.provide({
+        directory: setup.projectDir,
+        fn: async () => {
+          expect((await Config.get()).provider?.["local-custom"]).toBeDefined()
+          expect((await Provider.list())["local-custom"]?.models["custom-model"]).toBeDefined()
+        },
+      })
+
+      const remove = await request(setup.projectDir, "/config/nine1bot/custom-providers/local-custom", {
+        method: "DELETE",
+        headers: jsonHeaders,
+      })
+
+      expect(remove.status).toBe(200)
+      expect(disposed.events).toEqual([])
+      await Instance.provide({
+        directory: setup.projectDir,
+        fn: async () => {
+          expect((await Config.get()).provider?.["local-custom"]).toBeUndefined()
+          expect((await Provider.list())["local-custom"]).toBeUndefined()
+        },
+      })
+    } finally {
+      disposed.stop()
+    }
+  })
+})
+
+async function setupProject() {
+  const projectDir = await mkdtemp(path.join(tmpdir(), "opencode-config-routes-"))
+  tempDirs.push(projectDir)
+  const runtimeConfigPath = path.join(projectDir, "config.json")
+  const nine1botConfigPath = path.join(projectDir, "nine1bot.config.jsonc")
+  await writeFile(runtimeConfigPath, "{}\n", "utf-8")
+  await writeFile(nine1botConfigPath, "{}\n", "utf-8")
+  process.env.OPENCODE_CONFIG = runtimeConfigPath
+  process.env.NINE1BOT_CONFIG_PATH = nine1botConfigPath
+  process.env.OPENCODE_DISABLE_GLOBAL_CONFIG = "true"
+  process.env.OPENCODE_DISABLE_PROJECT_CONFIG = "true"
+  process.env.OPENCODE_DISABLE_PLUGIN_DEPENDENCY_INSTALL = "true"
+  return { projectDir, runtimeConfigPath, nine1botConfigPath }
+}
+
+async function request(projectDir: string, pathname: string, init: RequestInit) {
+  return Server.App().request(pathname, {
+    ...init,
+    headers: {
+      ...Object.fromEntries(new Headers(init.headers).entries()),
+      "x-opencode-directory": projectDir,
+    },
+  })
+}
+
+async function configModel(projectDir: string) {
+  return Instance.provide({
+    directory: projectDir,
+    fn: async () => (await Config.get()).model,
+  })
+}
+
+function collectInstanceDisposedEvents() {
+  const events: Array<{ directory?: string; payload: any }> = []
+  const handler = (event: { directory?: string; payload: any }) => {
+    if (event.payload?.type === "server.instance.disposed") events.push(event)
+  }
+  GlobalBus.on("event", handler)
+  return {
+    events,
+    stop() {
+      GlobalBus.off("event", handler)
+    },
+  }
+}
+
+function restoreEnv(snapshot: NodeJS.ProcessEnv) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) delete process.env[key]
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}

--- a/opencode/packages/opencode/test/server/nine1bot-platforms.test.ts
+++ b/opencode/packages/opencode/test/server/nine1bot-platforms.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
+import { chmod, mkdtemp, readFile, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { Instance } from "../../src/project/instance"
@@ -7,6 +7,7 @@ import { Server } from "../../src/server/server"
 import { RuntimePlatformAdapterRegistry } from "../../src/runtime/platform/adapter"
 import { Log } from "../../src/util/log"
 import {
+  getBuiltinPlatformManager,
   registerBuiltinPlatformAdapters,
   resetBuiltinPlatformManagerForTesting,
 } from "../../../../../packages/nine1bot/src/platform/builtin"
@@ -166,5 +167,29 @@ describe("nine1bot platform api", () => {
       status: "failed",
       message: "Action is not implemented: connection.test",
     })
+  })
+
+  test("restores in-memory platform settings when action persistence fails", async () => {
+    const { configPath } = await setupPlatformConfig({})
+    await chmod(configPath, 0o444)
+
+    try {
+      const response = await request("/nine1bot/platforms/feishu/actions/skills.configureDirectory", {
+        method: "POST",
+        headers: jsonHeaders,
+        body: JSON.stringify({
+          input: {
+            directory: "",
+          },
+        }),
+      })
+
+      expect(response.status).toBe(500)
+      expect(getBuiltinPlatformManager().configSnapshot().feishu).toBeUndefined()
+      const stored = JSON.parse(await readFile(configPath, "utf-8"))
+      expect(stored.platforms).toBeUndefined()
+    } finally {
+      await chmod(configPath, 0o666).catch(() => undefined)
+    }
   })
 })

--- a/opencode/packages/opencode/test/skill/platform-skill-source.test.ts
+++ b/opencode/packages/opencode/test/skill/platform-skill-source.test.ts
@@ -250,3 +250,49 @@ test("unregistered platform skill sources become unavailable for declared profil
     process.env.OPENCODE_TEST_HOME = originalHome
   }
 })
+
+test("runtime skill sources can filter by skill name prefix", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const officialSkills = path.join(dir, "official-skills")
+      await writeSkill(officialSkills, "lark-doc", "Feishu doc operations.")
+      await writeSkill(officialSkills, "custom-tool", "Non-Lark custom tool.")
+      return { officialSkills }
+    },
+  })
+
+  const originalHome = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = tmp.path
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        RuntimeSourceRegistry.registerOwner({
+          owner: {
+            id: "feishu",
+            kind: "platform",
+            enabled: true,
+          },
+          sources: {
+            skills: [{
+              id: "feishu-official-skills",
+              directory: tmp.extra.officialSkills,
+              includeNamePrefix: "lark-",
+              visibility: "default",
+              lifecycle: "platform-enabled",
+            }],
+          },
+        })
+
+        const names = (await Skill.all()).map((skill) => skill.name)
+        expect(names).toContain("lark-doc")
+        expect(names).not.toContain("custom-tool")
+        expect(await Skill.get("custom-tool")).toBeUndefined()
+      },
+    })
+  } finally {
+    process.env.OPENCODE_TEST_HOME = originalHome
+  }
+})

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -15,6 +15,8 @@
     "vite": "^6.0.0"
   },
   "dependencies": {
-    "@nine1bot/platform-gitlab": "workspace:*"
+    "@nine1bot/platform-feishu": "workspace:*",
+    "@nine1bot/platform-gitlab": "workspace:*",
+    "@nine1bot/platform-protocol": "workspace:*"
   }
 }

--- a/packages/browser-extension/src/content/index.ts
+++ b/packages/browser-extension/src/content/index.ts
@@ -5,7 +5,7 @@
  * that need to run in the context of the page.
  */
 
-import { buildPageContextPayload } from '@nine1bot/platform-gitlab/browser'
+import { buildBrowserExtensionPageContextPayload } from './page-context'
 
 console.log('[Nine1Bot Content Script] Loaded on:', window.location.href)
 
@@ -89,14 +89,12 @@ async function handleContentRequest(action: string, params: unknown): Promise<un
 }
 
 function collectPageContext() {
-  return buildPageContextPayload({
+  return buildBrowserExtensionPageContextPayload({
     url: window.location.href,
     title: document.title,
     selection: window.getSelection()?.toString(),
     visibleSummary: collectVisibleTextSummary(),
-    raw: {
-      gitlab: collectGitLabDomHints(),
-    },
+    gitlab: collectGitLabDomHints(),
   })
 }
 

--- a/packages/browser-extension/src/content/page-context.ts
+++ b/packages/browser-extension/src/content/page-context.ts
@@ -1,0 +1,27 @@
+import { buildPageContextPayload as buildFeishuPageContextPayload } from '@nine1bot/platform-feishu/browser'
+import { buildPageContextPayload as buildGitLabPageContextPayload } from '@nine1bot/platform-gitlab/browser'
+import type { PlatformPagePayload } from '@nine1bot/platform-protocol'
+
+export function buildBrowserExtensionPageContextPayload(input: {
+  url: string
+  title: string
+  selection?: string
+  visibleSummary?: string
+  gitlab?: Record<string, unknown>
+}): PlatformPagePayload {
+  const feishu = buildFeishuPageContextPayload({
+    url: input.url,
+    title: input.title,
+    selection: input.selection,
+    visibleSummary: input.visibleSummary,
+  })
+  if (feishu.platform === 'feishu') return feishu
+
+  return buildGitLabPageContextPayload({
+    url: input.url,
+    title: input.title,
+    selection: input.selection,
+    visibleSummary: input.visibleSummary,
+    raw: input.gitlab ? { gitlab: input.gitlab } : undefined,
+  })
+}

--- a/packages/browser-extension/test/feishu-page-context.test.ts
+++ b/packages/browser-extension/test/feishu-page-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import { buildBrowserExtensionPageContextPayload } from '../src/content/page-context'
+
+describe('browser extension platform page context router', () => {
+  it('routes Feishu pages before GitLab and generic fallbacks', () => {
+    expect(
+      buildBrowserExtensionPageContextPayload({
+        url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+        title: 'Wiki Doc',
+        selection: ' selected text ',
+        visibleSummary: 'Wiki overview',
+      }),
+    ).toMatchObject({
+      platform: 'feishu',
+      pageType: 'feishu-wiki',
+      objectKey: 'feishu:wiki:GKw9w6TOliwkBXkqO8UcphiDnUg',
+      selection: 'selected text',
+      visibleSummary: 'Wiki overview',
+    })
+
+    expect(
+      buildBrowserExtensionPageContextPayload({
+        url: 'https://gitlab.com/nine1/nine1bot/-/issues/7',
+        title: 'Issue',
+        gitlab: {
+          status: 'Open',
+        },
+      }),
+    ).toMatchObject({
+      platform: 'gitlab',
+      pageType: 'gitlab-issue',
+      objectKey: 'gitlab.com:nine1/nine1bot:issue:7',
+      raw: {
+        gitlab: {
+          status: 'Open',
+        },
+      },
+    })
+
+    expect(
+      buildBrowserExtensionPageContextPayload({
+        url: 'https://example.com/docs',
+        title: 'Docs',
+        visibleSummary: 'Generic docs page',
+      }),
+    ).toMatchObject({
+      platform: 'generic-browser',
+      url: 'https://example.com/docs',
+      title: 'Docs',
+      visibleSummary: 'Generic docs page',
+    })
+  })
+})

--- a/packages/nine1bot/package.json
+++ b/packages/nine1bot/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
+    "@nine1bot/platform-feishu": "workspace:*",
     "@nine1bot/platform-gitlab": "workspace:*",
     "@nine1bot/platform-protocol": "workspace:*",
     "@hono/node-server": "^1.19.9",

--- a/packages/nine1bot/src/platform/builtin.ts
+++ b/packages/nine1bot/src/platform/builtin.ts
@@ -1,9 +1,11 @@
+import { feishuPlatformContribution } from '@nine1bot/platform-feishu/runtime'
 import { gitlabPlatformContribution } from '@nine1bot/platform-gitlab/runtime'
 import type { PlatformSecretAccess } from '@nine1bot/platform-protocol'
 import { PlatformAdapterManager, type PlatformManagerConfig } from './manager'
 
 export const builtinPlatformContributions = [
   gitlabPlatformContribution,
+  feishuPlatformContribution,
 ]
 
 let builtinPlatformManager: PlatformAdapterManager | undefined

--- a/packages/nine1bot/src/platform/feishu-context.test.ts
+++ b/packages/nine1bot/src/platform/feishu-context.test.ts
@@ -7,14 +7,19 @@ import {
   getBuiltinPlatformManager,
   resetBuiltinPlatformManagerForTesting,
 } from './builtin'
-import { prepareFeishuControllerMessageContext } from './feishu-context'
+import {
+  clearFeishuControllerMessageContextCacheForTesting,
+  prepareFeishuControllerMessageContext,
+} from './feishu-context'
 
 beforeEach(() => {
   resetBuiltinPlatformManagerForTesting()
+  clearFeishuControllerMessageContextCacheForTesting()
 })
 
 afterEach(() => {
   resetBuiltinPlatformManagerForTesting()
+  clearFeishuControllerMessageContextCacheForTesting()
 })
 
 describe('Feishu controller page context enrichment', () => {
@@ -77,6 +82,76 @@ describe('Feishu controller page context enrichment', () => {
     expect(result.body.context?.blocks).toContainEqual(expect.objectContaining({
       id: 'page:feishu-metadata',
       source: 'page-context.feishu.metadata.wiki.spaces.get_node',
+    }))
+  })
+
+  test('reuses Feishu metadata for repeated sends in the same session page scope', async () => {
+    getBuiltinPlatformManager({
+      config: {
+        feishu: {
+          enabled: true,
+          settings: {
+            cliPath: 'lark-cli',
+          },
+        },
+      },
+    })
+    let calls = 0
+    const runner: FeishuCliRunner = async (_command, args, options) => {
+      calls++
+      if (args.join(' ') === 'auth status') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ identity: 'user:ou_123', tokenStatus: 'valid' }),
+          stderr: '',
+        }
+      }
+      const fileArg = args.find((arg) => arg.startsWith('@'))
+      const payload = fileArg && options.cwd
+        ? await Bun.file(join(options.cwd, fileArg.slice(1))).json()
+        : undefined
+      expect(payload).toEqual({
+        token: 'GKw9w6TOliwkBXkqO8UcphiDnUg',
+      })
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          code: 0,
+          data: {
+            node: {
+              title: 'Wiki Doc',
+              obj_type: 'docx',
+              obj_token: 'docx_token',
+              space_id: 'spc_123',
+            },
+          },
+        }),
+        stderr: '',
+      }
+    }
+
+    const first = await prepareFeishuControllerMessageContext(messageBody(), {
+      runner,
+      cacheScope: 'ses_1',
+    })
+    const base = messageBody()
+    const second = await prepareFeishuControllerMessageContext({
+      ...base,
+      context: {
+        ...base.context,
+        blocks: [{ id: 'existing' }],
+      },
+    }, {
+      runner,
+      cacheScope: 'ses_1',
+    })
+
+    expect(calls).toBe(2)
+    expect(first.contextEnrichment?.status).toBe('loaded')
+    expect(second.contextEnrichment?.status).toBe('loaded')
+    expect(second.body.context?.blocks).toContainEqual({ id: 'existing' })
+    expect(second.body.context?.blocks).toContainEqual(expect.objectContaining({
+      id: 'page:feishu-metadata',
     }))
   })
 

--- a/packages/nine1bot/src/platform/feishu-context.test.ts
+++ b/packages/nine1bot/src/platform/feishu-context.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { buildFeishuPageContextPayload } from '@nine1bot/platform-feishu'
 import type { FeishuCliRunner } from '@nine1bot/platform-feishu/node'
@@ -67,7 +69,7 @@ describe('Feishu controller page context enrichment', () => {
     }
 
     const body = messageBody()
-    const result = await prepareFeishuControllerMessageContext(body, { runner })
+    const result = await withFakeCliEnv((env) => prepareFeishuControllerMessageContext(body, { runner, env }))
 
     expect(result.contextEnrichment).toMatchObject({
       platform: 'feishu',
@@ -130,20 +132,25 @@ describe('Feishu controller page context enrichment', () => {
       }
     }
 
-    const first = await prepareFeishuControllerMessageContext(messageBody(), {
-      runner,
-      cacheScope: 'ses_1',
-    })
-    const base = messageBody()
-    const second = await prepareFeishuControllerMessageContext({
-      ...base,
-      context: {
-        ...base.context,
-        blocks: [{ id: 'existing' }],
-      },
-    }, {
-      runner,
-      cacheScope: 'ses_1',
+    const { first, second } = await withFakeCliEnv(async (env) => {
+      const first = await prepareFeishuControllerMessageContext(messageBody(), {
+        runner,
+        env,
+        cacheScope: 'ses_1',
+      })
+      const base = messageBody()
+      const second = await prepareFeishuControllerMessageContext({
+        ...base,
+        context: {
+          ...base.context,
+          blocks: [{ id: 'existing' }],
+        },
+      }, {
+        runner,
+        env,
+        cacheScope: 'ses_1',
+      })
+      return { first, second }
     })
 
     expect(calls).toBe(2)
@@ -209,5 +216,15 @@ function messageBody(url = 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkq
         title: 'Wiki Doc',
       }),
     },
+  }
+}
+
+async function withFakeCliEnv<T>(fn: (env: Record<string, string>) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), 'nine1bot-feishu-cli-'))
+  try {
+    await writeFile(join(directory, 'lark-cli.cmd'), '@echo off\r\n', 'utf8')
+    return await fn({ OS: 'Windows_NT', PATH: directory })
+  } finally {
+    await rm(directory, { recursive: true, force: true })
   }
 }

--- a/packages/nine1bot/src/platform/feishu-context.test.ts
+++ b/packages/nine1bot/src/platform/feishu-context.test.ts
@@ -97,9 +97,30 @@ describe('Feishu controller page context enrichment', () => {
     expect(result.body).toBe(body)
     expect(result.contextEnrichment).toBeUndefined()
   })
+
+  test('keeps unknown Feishu routes visible-only without CLI metadata noise', async () => {
+    getBuiltinPlatformManager({
+      config: {
+        feishu: {
+          enabled: true,
+          settings: {
+            cliPath: 'lark-cli',
+          },
+        },
+      },
+    })
+    const runner: FeishuCliRunner = async () => {
+      throw new Error('CLI should not run for unknown Feishu routes')
+    }
+    const body = messageBody('https://gdut-topview.feishu.cn/space/home')
+    const result = await prepareFeishuControllerMessageContext(body, { runner })
+
+    expect(result.body).toBe(body)
+    expect(result.contextEnrichment).toBeUndefined()
+  })
 })
 
-function messageBody(): RuntimeControllerProtocol.MessageSendRequest {
+function messageBody(url = 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg'): RuntimeControllerProtocol.MessageSendRequest {
   return {
     parts: [{ type: 'text', text: 'hello' }],
     entry: {
@@ -109,7 +130,7 @@ function messageBody(): RuntimeControllerProtocol.MessageSendRequest {
     },
     context: {
       page: buildFeishuPageContextPayload({
-        url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+        url,
         title: 'Wiki Doc',
       }),
     },

--- a/packages/nine1bot/src/platform/feishu-context.test.ts
+++ b/packages/nine1bot/src/platform/feishu-context.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { buildFeishuPageContextPayload } from '@nine1bot/platform-feishu'
+import type { FeishuCliRunner } from '@nine1bot/platform-feishu/node'
+import type { RuntimeControllerProtocol } from '../../../../opencode/packages/opencode/src/runtime/controller/protocol'
+import {
+  getBuiltinPlatformManager,
+  resetBuiltinPlatformManagerForTesting,
+} from './builtin'
+import { prepareFeishuControllerMessageContext } from './feishu-context'
+
+beforeEach(() => {
+  resetBuiltinPlatformManagerForTesting()
+})
+
+afterEach(() => {
+  resetBuiltinPlatformManagerForTesting()
+})
+
+describe('Feishu controller page context enrichment', () => {
+  test('appends Feishu metadata block before prompt compilation', async () => {
+    getBuiltinPlatformManager({
+      config: {
+        feishu: {
+          enabled: true,
+          settings: {
+            cliPath: 'lark-cli',
+          },
+        },
+      },
+    })
+    const runner: FeishuCliRunner = async (_command, args, options) => {
+      if (args.join(' ') === 'auth status') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ identity: 'user:ou_123', tokenStatus: 'valid' }),
+          stderr: '',
+        }
+      }
+      const fileArg = args.find((arg) => arg.startsWith('@'))
+      const payload = fileArg && options.cwd
+        ? await Bun.file(join(options.cwd, fileArg.slice(1))).json()
+        : undefined
+      expect(payload).toEqual({
+        token: 'GKw9w6TOliwkBXkqO8UcphiDnUg',
+      })
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          code: 0,
+          data: {
+            node: {
+              title: 'Wiki Doc',
+              obj_type: 'docx',
+              obj_token: 'docx_token',
+              space_id: 'spc_123',
+            },
+          },
+        }),
+        stderr: '',
+      }
+    }
+
+    const body = messageBody()
+    const result = await prepareFeishuControllerMessageContext(body, { runner })
+
+    expect(result.contextEnrichment).toMatchObject({
+      platform: 'feishu',
+      status: 'loaded',
+    })
+    expect(result.body.context?.page?.raw?.feishu).toMatchObject({
+      enrichment: {
+        status: 'loaded',
+        resolvedObjType: 'docx',
+      },
+    })
+    expect(result.body.context?.blocks).toContainEqual(expect.objectContaining({
+      id: 'page:feishu-metadata',
+      source: 'page-context.feishu.metadata.wiki.spaces.get_node',
+    }))
+  })
+
+  test('skips Feishu metadata when the platform is disabled', async () => {
+    getBuiltinPlatformManager({
+      config: {
+        feishu: {
+          enabled: false,
+        },
+      },
+    })
+    const runner: FeishuCliRunner = async () => {
+      throw new Error('CLI should not run for a disabled platform')
+    }
+    const body = messageBody()
+    const result = await prepareFeishuControllerMessageContext(body, { runner })
+
+    expect(result.body).toBe(body)
+    expect(result.contextEnrichment).toBeUndefined()
+  })
+})
+
+function messageBody(): RuntimeControllerProtocol.MessageSendRequest {
+  return {
+    parts: [{ type: 'text', text: 'hello' }],
+    entry: {
+      source: 'browser-extension',
+      platform: 'feishu',
+      mode: 'browser-sidepanel',
+    },
+    context: {
+      page: buildFeishuPageContextPayload({
+        url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+        title: 'Wiki Doc',
+      }),
+    },
+  }
+}

--- a/packages/nine1bot/src/platform/feishu-context.ts
+++ b/packages/nine1bot/src/platform/feishu-context.ts
@@ -16,7 +16,20 @@ export type FeishuControllerMessageContextResult = {
 export type FeishuControllerMessageContextOptions = {
   env?: Record<string, string | undefined>
   runner?: FeishuCliRunner
+  cacheScope?: string
+  cacheTtlMs?: number
 }
+
+const DEFAULT_ENRICHMENT_CACHE_TTL_MS = 30_000
+type CachedFeishuEnrichment = {
+  page: PlatformPagePayload
+  blocks: unknown[]
+  contextEnrichment?: FeishuContextEnrichmentSummary
+}
+const enrichmentCache = new Map<string, {
+  expiresAt: number
+  value: Promise<CachedFeishuEnrichment>
+}>()
 
 export async function prepareFeishuControllerMessageContext(
   body: RuntimeControllerProtocol.MessageSendRequest,
@@ -31,29 +44,95 @@ export async function prepareFeishuControllerMessageContext(
   if (!record?.enabled) return { body }
   if (!isFeishuMetadataSupportedPage(page)) return { body }
 
+  const cacheKey = options.cacheScope ? cacheKeyFor(options.cacheScope, page, record.settings) : undefined
+  if (cacheKey) {
+    const cached = getCached(cacheKey)
+    if (cached) return applyCachedResult(body, await cached)
+  }
+
+  const enrichment = enrichPage(page, record.settings, options)
+  if (cacheKey) {
+    setCached(cacheKey, enrichment, options.cacheTtlMs ?? DEFAULT_ENRICHMENT_CACHE_TTL_MS)
+  }
+  return applyCachedResult(body, await enrichment)
+}
+
+export function clearFeishuControllerMessageContextCacheForTesting() {
+  enrichmentCache.clear()
+}
+
+async function enrichPage(
+  page: PlatformPagePayload,
+  settings: unknown,
+  options: FeishuControllerMessageContextOptions,
+): Promise<CachedFeishuEnrichment> {
   const result = await enrichFeishuPageContext({
     page,
-    settings: record.settings,
+    settings,
     env: options.env ?? process.env,
     runner: options.runner,
   })
 
   return {
-    body: {
-      ...body,
-      context: {
-        ...(body.context ?? {}),
-        page: result.page,
-        blocks: [
-          ...((body.context?.blocks ?? []) as unknown[]),
-          ...result.blocks,
-        ],
-      },
-    },
+    page: result.page,
+    blocks: result.blocks,
     contextEnrichment: result.summary && result.summary.status !== 'not_applicable'
       ? result.summary
       : undefined,
   }
+}
+
+function getCached(cacheKey: string) {
+  const cached = enrichmentCache.get(cacheKey)
+  if (!cached) return undefined
+  if (cached.expiresAt <= Date.now()) {
+    enrichmentCache.delete(cacheKey)
+    return undefined
+  }
+  return cached.value
+}
+
+function setCached(
+  cacheKey: string,
+  value: Promise<CachedFeishuEnrichment>,
+  ttlMs: number,
+) {
+  const expiresAt = Date.now() + Math.max(0, ttlMs)
+  enrichmentCache.set(cacheKey, { expiresAt, value })
+  value.catch(() => {
+    if (enrichmentCache.get(cacheKey)?.value === value) enrichmentCache.delete(cacheKey)
+  })
+}
+
+function applyCachedResult(
+  body: RuntimeControllerProtocol.MessageSendRequest,
+  cached: CachedFeishuEnrichment,
+): FeishuControllerMessageContextResult {
+  return {
+    body: {
+      ...body,
+      context: {
+        ...(body.context ?? {}),
+        page: cached.page,
+        blocks: [
+          ...((body.context?.blocks ?? []) as unknown[]),
+          ...cached.blocks,
+        ],
+      },
+    },
+    contextEnrichment: cached.contextEnrichment,
+  }
+}
+
+function cacheKeyFor(scope: string, page: PlatformPagePayload, settings: unknown) {
+  const normalized = normalizeFeishuPagePayload(page)
+  return JSON.stringify({
+    scope,
+    url: normalized?.url ?? page.url,
+    objectKey: normalized?.objectKey ?? page.objectKey,
+    pageType: normalized?.pageType ?? page.pageType,
+    settings,
+  })
 }
 
 function shouldEnhance(entry?: RuntimeControllerProtocol.Entry) {

--- a/packages/nine1bot/src/platform/feishu-context.ts
+++ b/packages/nine1bot/src/platform/feishu-context.ts
@@ -3,6 +3,7 @@ import {
   type FeishuContextEnrichmentSummary,
   type FeishuCliRunner,
 } from '@nine1bot/platform-feishu/node'
+import { normalizeFeishuPagePayload } from '@nine1bot/platform-feishu/runtime'
 import { getBuiltinPlatformManager } from './builtin'
 import type { RuntimeControllerProtocol } from '../../../../opencode/packages/opencode/src/runtime/controller/protocol'
 import type { PlatformPagePayload } from '@nine1bot/platform-protocol'
@@ -28,6 +29,7 @@ export async function prepareFeishuControllerMessageContext(
   const manager = getBuiltinPlatformManager()
   const record = manager.get('feishu')
   if (!record?.enabled) return { body }
+  if (!isFeishuMetadataSupportedPage(page)) return { body }
 
   const result = await enrichFeishuPageContext({
     page,
@@ -60,6 +62,16 @@ function shouldEnhance(entry?: RuntimeControllerProtocol.Entry) {
 
 function isFeishuPage(page: PlatformPagePayload) {
   return page.platform === 'feishu' || Boolean(page.url && isFeishuUrl(page.url))
+}
+
+function isFeishuMetadataSupportedPage(page: PlatformPagePayload) {
+  const normalized = normalizeFeishuPagePayload(page)
+  return normalized?.pageType === 'feishu-docx'
+    || normalized?.pageType === 'feishu-wiki'
+    || normalized?.pageType === 'feishu-sheet'
+    || normalized?.pageType === 'feishu-bitable'
+    || normalized?.pageType === 'feishu-folder'
+    || normalized?.pageType === 'feishu-slides'
 }
 
 function isFeishuUrl(input: string) {

--- a/packages/nine1bot/src/platform/feishu-context.ts
+++ b/packages/nine1bot/src/platform/feishu-context.ts
@@ -1,0 +1,75 @@
+import {
+  enrichFeishuPageContext,
+  type FeishuContextEnrichmentSummary,
+  type FeishuCliRunner,
+} from '@nine1bot/platform-feishu/node'
+import { getBuiltinPlatformManager } from './builtin'
+import type { RuntimeControllerProtocol } from '../../../../opencode/packages/opencode/src/runtime/controller/protocol'
+import type { PlatformPagePayload } from '@nine1bot/platform-protocol'
+
+export type FeishuControllerMessageContextResult = {
+  body: RuntimeControllerProtocol.MessageSendRequest
+  contextEnrichment?: FeishuContextEnrichmentSummary
+}
+
+export type FeishuControllerMessageContextOptions = {
+  env?: Record<string, string | undefined>
+  runner?: FeishuCliRunner
+}
+
+export async function prepareFeishuControllerMessageContext(
+  body: RuntimeControllerProtocol.MessageSendRequest,
+  options: FeishuControllerMessageContextOptions = {},
+): Promise<FeishuControllerMessageContextResult> {
+  if (!shouldEnhance(body.entry)) return { body }
+  const page = body.context?.page as PlatformPagePayload | undefined
+  if (!page || !isFeishuPage(page)) return { body }
+
+  const manager = getBuiltinPlatformManager()
+  const record = manager.get('feishu')
+  if (!record?.enabled) return { body }
+
+  const result = await enrichFeishuPageContext({
+    page,
+    settings: record.settings,
+    env: options.env ?? process.env,
+    runner: options.runner,
+  })
+
+  return {
+    body: {
+      ...body,
+      context: {
+        ...(body.context ?? {}),
+        page: result.page,
+        blocks: [
+          ...((body.context?.blocks ?? []) as unknown[]),
+          ...result.blocks,
+        ],
+      },
+    },
+    contextEnrichment: result.summary && result.summary.status !== 'not_applicable'
+      ? result.summary
+      : undefined,
+  }
+}
+
+function shouldEnhance(entry?: RuntimeControllerProtocol.Entry) {
+  return entry?.source === 'browser-extension' || entry?.mode === 'browser-sidepanel'
+}
+
+function isFeishuPage(page: PlatformPagePayload) {
+  return page.platform === 'feishu' || Boolean(page.url && isFeishuUrl(page.url))
+}
+
+function isFeishuUrl(input: string) {
+  try {
+    const hostname = new URL(input).hostname.toLowerCase()
+    return hostname === 'feishu.cn'
+      || hostname.endsWith('.feishu.cn')
+      || hostname === 'larksuite.com'
+      || hostname.endsWith('.larksuite.com')
+  } catch {
+    return false
+  }
+}

--- a/packages/nine1bot/src/platform/manager.test.ts
+++ b/packages/nine1bot/src/platform/manager.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { win32 as win32Path } from 'node:path'
-import type { PlatformAdapterContext, PlatformAdapterContribution, PlatformRuntimeSourcesDescriptor, PlatformSecretAccess } from '@nine1bot/platform-protocol'
+import type {
+  PlatformAdapterContext,
+  PlatformAdapterContribution,
+  PlatformRuntimeSourcesDescriptor,
+  PlatformRuntimeSourcesProvider,
+  PlatformSecretAccess,
+} from '@nine1bot/platform-protocol'
 import { RuntimePlatformAdapterRegistry } from '../../../../opencode/packages/opencode/src/runtime/platform/adapter'
 import { RuntimeSourceRegistry } from '../../../../opencode/packages/opencode/src/runtime/source/registry'
 import { PlatformAdapterManager } from './manager'
@@ -20,7 +26,7 @@ function contribution(id: string, options: {
   defaultEnabled?: boolean
   throws?: boolean
   templates?: string[]
-  sources?: PlatformRuntimeSourcesDescriptor
+  sources?: PlatformRuntimeSourcesProvider
 } = {}): PlatformAdapterContribution {
   return {
     descriptor: {
@@ -267,6 +273,45 @@ describe('PlatformAdapterManager', () => {
     })
   })
 
+  it('registers runtime sources generated from current platform settings', async () => {
+    const manager = new PlatformAdapterManager({
+      contributions: [contribution('demo', {
+        defaultEnabled: true,
+        sources: (ctx) => ({
+          skills: [{
+            id: 'demo-skills',
+            directory: String((ctx.settings as Record<string, unknown>).directory ?? '/tmp/default-skills'),
+            visibility: 'default',
+            lifecycle: 'platform-enabled',
+          }],
+        }),
+      })],
+      config: {
+        demo: {
+          settings: {
+            directory: '/tmp/custom-skills',
+          },
+        },
+      },
+    })
+
+    manager.registerRuntimeAdapters()
+
+    expect(RuntimeSourceRegistry.listOwner('demo').skills).toContainEqual(expect.objectContaining({
+      id: 'demo-skills',
+      directory: '/tmp/custom-skills',
+    }))
+    await expect(manager.getDetail('demo')).resolves.toMatchObject({
+      runtimeSources: {
+        skills: [{
+          id: 'demo-skills',
+          directory: '/tmp/custom-skills',
+          status: 'registered',
+        }],
+      },
+    })
+  })
+
   it('normalizes Windows runtime source paths before registering and reporting details', async () => {
     const manager = new PlatformAdapterManager({
       contributions: [contribution('feishu', {
@@ -458,6 +503,10 @@ describe('PlatformAdapterManager', () => {
     registerBuiltinPlatformAdapters()
 
     expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).toContain('feishu')
+    expect(RuntimeSourceRegistry.listOwner('feishu').skills.map((source) => source.id)).toEqual([
+      'feishu-companion-skills',
+      'feishu-official-skills',
+    ])
   })
 
   it('skips built-in GitLab when config disables it', () => {
@@ -483,6 +532,7 @@ describe('PlatformAdapterManager', () => {
 
     expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).not.toContain('feishu')
     expect(RuntimePlatformAdapterRegistry.activeTemplateIds(['web-chat', 'browser-feishu', 'feishu-docx'])).toEqual(['web-chat'])
+    expect(RuntimeSourceRegistry.listOwner('feishu').skills).toEqual([])
   })
 
   it('keeps the GitLab compatibility registration entry working', () => {
@@ -673,6 +723,79 @@ describe('PlatformAdapterManager', () => {
 
     expect(manager.configSnapshot().demo?.settings).toEqual({
       allowedHosts: ['gitlab.com'],
+    })
+  })
+
+  it('applies action updatedSettings and re-registers runtime sources', async () => {
+    const baseContribution = contribution('demo', {
+      defaultEnabled: true,
+      sources: (ctx) => ({
+        skills: [{
+          id: 'demo-skills',
+          directory: String((ctx.settings as Record<string, unknown>).directory ?? '/tmp/default-skills'),
+          visibility: 'default',
+          lifecycle: 'platform-enabled',
+        }],
+      }),
+    })
+    const manager = new PlatformAdapterManager({
+      contributions: [{
+        ...baseContribution,
+        descriptor: {
+          ...baseContribution.descriptor,
+          config: {
+            sections: [{
+              id: 'settings',
+              title: 'Settings',
+              fields: [{
+                key: 'directory',
+                label: 'Directory',
+                type: 'string',
+              }],
+            }],
+          },
+          actions: [{
+            id: 'directory.configure',
+            label: 'Configure directory',
+            kind: 'button',
+          }],
+        },
+        handleAction: async () => ({
+          status: 'ok',
+          updatedSettings: {
+            directory: '/tmp/action-skills',
+          },
+          updatedStatus: {
+            status: 'available',
+            message: 'directory configured',
+          },
+        }),
+      }],
+    })
+    manager.registerRuntimeAdapters()
+
+    await expect(manager.executeAction('demo', 'directory.configure')).resolves.toMatchObject({
+      status: 'ok',
+      updatedSettings: {
+        directory: '/tmp/action-skills',
+      },
+    })
+
+    expect(manager.configSnapshot().demo?.settings).toEqual({
+      directory: '/tmp/action-skills',
+    })
+    expect(RuntimeSourceRegistry.listOwner('demo').skills).toContainEqual(expect.objectContaining({
+      id: 'demo-skills',
+      directory: '/tmp/action-skills',
+    }))
+    await expect(manager.getDetail('demo')).resolves.toMatchObject({
+      runtimeSources: {
+        skills: [{
+          id: 'demo-skills',
+          directory: '/tmp/action-skills',
+          status: 'registered',
+        }],
+      },
     })
   })
 

--- a/packages/nine1bot/src/platform/manager.test.ts
+++ b/packages/nine1bot/src/platform/manager.test.ts
@@ -507,6 +507,10 @@ describe('PlatformAdapterManager', () => {
       'feishu-companion-skills',
       'feishu-official-skills',
     ])
+    expect(RuntimeSourceRegistry.listOwner('feishu').skills).toContainEqual(expect.objectContaining({
+      id: 'feishu-official-skills',
+      includeNamePrefix: 'lark-',
+    }))
   })
 
   it('skips built-in GitLab when config disables it', () => {

--- a/packages/nine1bot/src/platform/manager.test.ts
+++ b/packages/nine1bot/src/platform/manager.test.ts
@@ -454,6 +454,12 @@ describe('PlatformAdapterManager', () => {
     expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).toContain('gitlab')
   })
 
+  it('registers built-in Feishu through the manager', () => {
+    registerBuiltinPlatformAdapters()
+
+    expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).toContain('feishu')
+  })
+
   it('skips built-in GitLab when config disables it', () => {
     registerBuiltinPlatformAdapters({
       config: {
@@ -464,6 +470,19 @@ describe('PlatformAdapterManager', () => {
     })
 
     expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).not.toContain('gitlab')
+  })
+
+  it('skips built-in Feishu templates when config disables it', () => {
+    registerBuiltinPlatformAdapters({
+      config: {
+        feishu: {
+          enabled: false,
+        },
+      },
+    })
+
+    expect(RuntimePlatformAdapterRegistry.list().map((adapter) => adapter.id)).not.toContain('feishu')
+    expect(RuntimePlatformAdapterRegistry.activeTemplateIds(['web-chat', 'browser-feishu', 'feishu-docx'])).toEqual(['web-chat'])
   })
 
   it('keeps the GitLab compatibility registration entry working', () => {

--- a/packages/nine1bot/src/platform/manager.ts
+++ b/packages/nine1bot/src/platform/manager.ts
@@ -9,6 +9,7 @@ import type {
   PlatformConfigField,
   PlatformDescriptor,
   PlatformRuntimeSourcesDescriptor,
+  PlatformRuntimeSourcesProvider,
   PlatformRuntimeStatus,
   PlatformSecretAccess,
   PlatformSecretRef,
@@ -435,9 +436,26 @@ export class PlatformAdapterManager {
           updatedStatus: record.runtimeStatus,
         }
       }
+      let currentRecord = record
+      if (result.updatedSettings !== undefined) {
+        const previousEntry = this.config[id] ?? {}
+        const nextEntry = await this.prepareConfigEntry(record, previousEntry, {
+          settings: settingsRecord(result.updatedSettings),
+        })
+        const validation = await this.validateConfigEntry(record, nextEntry)
+        if (!validation.ok) {
+          throw new PlatformValidationError(validation.message ?? 'Invalid platform config', validation.fieldErrors ?? {})
+        }
+        this.configure({
+          ...this.config,
+          [id]: nextEntry,
+        })
+        this.registerRuntimeAdapters()
+        currentRecord = this.records.get(id) ?? currentRecord
+      }
       if (result.updatedStatus) {
         this.records.set(id, {
-          ...record,
+          ...currentRecord,
           lifecycleStatus: lifecycleStatusFromRuntime(result.updatedStatus.status),
           runtimeStatus: result.updatedStatus,
           error: result.updatedStatus.status === 'error' ? result.updatedStatus.message : undefined,
@@ -547,20 +565,20 @@ export class PlatformAdapterManager {
     }
   }
 
-  private registerRuntimeSources(record: PlatformManagerRecord, sources?: PlatformRuntimeSourcesDescriptor) {
+  private registerRuntimeSources(record: PlatformManagerRecord, sources?: PlatformRuntimeSourcesProvider) {
     RuntimeSourceRegistry.registerOwner({
       owner: {
         id: record.id,
         kind: 'platform',
         enabled: record.enabled,
       },
-      sources: normalizeRuntimeSources(sources),
+      sources: normalizeRuntimeSources(this.resolveRuntimeSources(record, sources)),
     })
   }
 
   private runtimeSourcesForRecord(record: PlatformManagerRecord): PlatformRuntimeSourcesSummary | undefined {
     const contribution = this.contributions.get(record.id)
-    const sources = contribution?.runtime?.sources
+    const sources = this.resolveRuntimeSources(record, contribution?.runtime?.sources)
     if (!sources?.agents?.length && !sources?.skills?.length) return undefined
 
     const normalizedSources = normalizeRuntimeSources(sources) ?? {}
@@ -587,6 +605,13 @@ export class PlatformAdapterManager {
         error: runtimeSourceError(record, source.id, status),
       })),
     }
+  }
+
+  private resolveRuntimeSources(
+    record: PlatformManagerRecord,
+    sources?: PlatformRuntimeSourcesProvider,
+  ): PlatformRuntimeSourcesDescriptor | undefined {
+    return typeof sources === 'function' ? sources(this.createContext(record)) : sources
   }
 
   private async prepareConfigEntry(

--- a/packages/nine1bot/src/platform/manager.ts
+++ b/packages/nine1bot/src/platform/manager.ts
@@ -87,6 +87,7 @@ export type PlatformRuntimeSourceSummary = {
   id: string
   directory: string
   namespace?: string
+  includeNamePrefix?: string
   visibility: string
   status: 'registered' | 'disabled' | 'error'
   error?: string
@@ -600,6 +601,7 @@ export class PlatformAdapterManager {
         id: source.id,
         directory: source.directory,
         namespace: source.namespace,
+        includeNamePrefix: source.includeNamePrefix,
         visibility: source.visibility,
         status: registeredSkills.has(source.id) ? 'registered' : status,
         error: runtimeSourceError(record, source.id, status),

--- a/packages/platform-feishu/package.json
+++ b/packages/platform-feishu/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nine1bot/platform-feishu",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./browser": "./src/browser.ts",
+    "./runtime": "./src/runtime.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@nine1bot/platform-protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "bun-types": "^1.3.11"
+  }
+}

--- a/packages/platform-feishu/package.json
+++ b/packages/platform-feishu/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./browser": "./src/browser.ts",
-    "./runtime": "./src/runtime.ts"
+    "./runtime": "./src/runtime.ts",
+    "./node": "./src/node.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/packages/platform-feishu/skills/feishu-current-page/SKILL.md
+++ b/packages/platform-feishu/skills/feishu-current-page/SKILL.md
@@ -72,6 +72,23 @@ Use scope hints when available:
 
 Search results are for locating likely context. Do not automatically read every result. Read only the relevant item or ask the user to choose when multiple results look plausible.
 
+## Write Operations
+
+When the user asks you to create, update, move, delete, share, or otherwise modify Feishu/Lark content, first make the intended change explicit:
+
+- Target object: current page, resolved object token/type, or a search result chosen by the user.
+- Action type: create, append, replace, move, delete, permission change, share setting, or another operation.
+- Impact scope: one block, one document, selected records, one folder, or a batch.
+- Current-page dependency: whether the change is based on the active browser page, current selection, or metadata from `page:feishu-metadata`.
+
+Prefer official `lark-cli` shortcuts and raw API commands. If the specific command supports `--dry-run`, run dry-run first, summarize the planned change, and wait for the normal Nine1Bot/tool permission flow or the user's confirmation before executing the real write. Do not invent dry-run behavior for commands that do not support it.
+
+For commands without dry-run, reduce risk by using narrow parameters and explicit object tokens. Do not build a Nine1Bot-specific wrapper, do not reinterpret the entire CLI schema, and do not bypass the official CLI's own prompts or the existing Nine1Bot permission mechanism.
+
+For Wiki pages, writes must use the resolved object type and token from metadata whenever available. If metadata is missing, resolve the wiki node first with `wiki spaces get_node`; never use a wiki node token directly as a docx/file token for writes.
+
+Permission changes, bulk deletes, bulk moves, and public sharing need especially clear impact summaries, but they do not require a separate Nine1Bot high-risk API confirmation layer. Follow the official CLI behavior and existing shell/tool permission flow.
+
 ## Safety
 
 Do not ask the user to copy access tokens, cookies, or CLI private config. The official `lark-cli` owns authentication. If CLI auth is missing, guide the user through official CLI login instead of inventing a separate auth flow.

--- a/packages/platform-feishu/skills/feishu-current-page/SKILL.md
+++ b/packages/platform-feishu/skills/feishu-current-page/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: feishu-current-page
+version: 0.1.0
+description: "Use the current Feishu/Lark browser page context and metadata. Prefer focused document snippets and drive search through official lark-cli skills."
+metadata:
+  requires:
+    bins: ["lark-cli"]
+---
+
+# Feishu Current Page
+
+Use this skill when the user is working from a Feishu/Lark browser side panel and asks about the current page, current document, or nearby Feishu context.
+
+## Context Sources
+
+First inspect the current page context and the `page:feishu-metadata` block if present. Useful fields include:
+
+- Page URL and browser title.
+- `raw.feishu.route`, `raw.feishu.token`, `raw.feishu.objType`.
+- `raw.feishu.tableId` and `raw.feishu.viewId` for Base pages.
+- `raw.feishu.metadata` and `raw.feishu.enrichment.resolvedObjType` / `resolvedObjToken` from metadata enrichment.
+- `raw.feishu.enrichment.spaceId` for Wiki pages.
+
+For Wiki pages, the URL token is a wiki node token. Do not treat it as a document/file token. Prefer the resolved object type and token from metadata. If metadata is unavailable, resolve it first:
+
+```bash
+lark-cli wiki spaces get_node --params @params.json --as user --format json
+```
+
+where `params.json` contains:
+
+```json
+{"token":"<wiki_node_token>"}
+```
+
+## Current Document Snippets
+
+For `docx` pages and Wiki nodes resolved to `docx`, use focused reads with the official docs command:
+
+```bash
+lark-cli docs +fetch --api-version v2 --doc "<url-or-docx-token>" --scope outline --detail simple --doc-format text --as user --format json
+```
+
+Prefer snippet modes before reading a whole document:
+
+- `--scope outline` to inspect structure.
+- `--scope keyword --keyword "<terms>"` to find relevant sections.
+- `--scope range --start-block-id "<block_id>" --end-block-id "<block_id-or--1>"` after IDs are known.
+- `--scope section --start-block-id "<heading_block_id>"` for one section.
+
+Use `--detail simple` and `--doc-format text` by default to keep context small. Only fetch the whole document when the user clearly asks for full content.
+
+For sheets, Base, slides, files, and folders, prefer the matching official skills:
+
+- `lark-sheets` for spreadsheets.
+- `lark-base` for Base / bitable pages.
+- `lark-slides` for slides.
+- `lark-drive` for files and folders.
+
+## Search Related Feishu Context
+
+Use Drive search when the user asks to find related documents or broader Feishu context:
+
+```bash
+lark-cli drive +search --query "<keywords>" --doc-types docx,wiki,sheet,bitable,slides,file --page-size 10 --as user --format json
+```
+
+Use scope hints when available:
+
+- If the current page is a folder, add `--folder-tokens "<folder_token>"`.
+- If the current page metadata has a Wiki space id, add `--space-ids "<space_id>"`.
+
+Search results are for locating likely context. Do not automatically read every result. Read only the relevant item or ask the user to choose when multiple results look plausible.
+
+## Safety
+
+Do not ask the user to copy access tokens, cookies, or CLI private config. The official `lark-cli` owns authentication. If CLI auth is missing, guide the user through official CLI login instead of inventing a separate auth flow.

--- a/packages/platform-feishu/src/browser.ts
+++ b/packages/platform-feishu/src/browser.ts
@@ -1,0 +1,8 @@
+export {
+  buildFeishuPageContextPayload as buildPageContextPayload,
+  buildFeishuPageContextPayload,
+  feishuTemplateIdsForPage,
+  isFeishuPagePayload,
+  parseFeishuUrl,
+} from './shared'
+export type { FeishuUrlInfo, PageContextPayload as BrowserPageContextPayload } from './types'

--- a/packages/platform-feishu/src/cli.ts
+++ b/packages/platform-feishu/src/cli.ts
@@ -1,0 +1,280 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { delimiter, isAbsolute, join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+export type FeishuCliRunResult = {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  timedOut?: boolean
+}
+
+export type FeishuCliRunOptions = {
+  env: Record<string, string | undefined>
+  timeoutMs: number
+  cwd?: string
+}
+
+export type FeishuCliRunner = (
+  command: string,
+  args: string[],
+  options: FeishuCliRunOptions,
+) => Promise<FeishuCliRunResult>
+
+export type FeishuCliContext = {
+  cliPath?: string
+  env?: Record<string, string | undefined>
+  timeoutMs?: number
+  runner?: FeishuCliRunner
+}
+
+export type FeishuAuthState = 'authenticated' | 'need_config' | 'need_login' | 'unknown'
+
+export type FeishuAuthStatus = {
+  state: FeishuAuthState
+  identity?: string
+  tokenStatus?: string
+  userName?: string
+  expiresAt?: string
+  refreshExpiresAt?: string
+  raw?: Record<string, unknown>
+  result: FeishuCliRunResult
+}
+
+export type FeishuCliJsonResult = FeishuCliRunResult & {
+  json?: unknown
+}
+
+export function resolveFeishuCliPath(
+  cliPathSetting: string | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  if (cliPathSetting?.trim()) {
+    const value = cliPathSetting.trim()
+    if (hasPathSeparator(value) || isAbsolute(value)) return existsSync(value) ? value : undefined
+    return value
+  }
+
+  const pathValue = env.PATH ?? env.Path ?? env.path ?? process.env.PATH
+  if (!pathValue) return undefined
+  const names = process.platform === 'win32'
+    ? ['lark-cli.cmd', 'lark-cli.exe', 'lark-cli']
+    : ['lark-cli']
+  for (const directory of pathValue.split(delimiter)) {
+    if (!directory) continue
+    for (const name of names) {
+      const candidate = join(directory, name)
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+
+export async function getFeishuCliVersion(ctx: FeishuCliContext): Promise<FeishuCliJsonResult & { version?: string }> {
+  const result = await runFeishuCli(ctx.cliPath ?? 'lark-cli', ['--version'], {
+    env: effectiveEnv(ctx.env),
+    timeoutMs: ctx.timeoutMs ?? 2_000,
+    runner: ctx.runner,
+  })
+  return {
+    ...result,
+    version: parseVersion(result.stdout || result.stderr),
+  }
+}
+
+export async function getFeishuAuthStatus(ctx: FeishuCliContext): Promise<FeishuAuthStatus> {
+  const result = await runFeishuCli(ctx.cliPath ?? 'lark-cli', ['auth', 'status'], {
+    env: effectiveEnv(ctx.env),
+    timeoutMs: ctx.timeoutMs ?? 3_000,
+    runner: ctx.runner,
+  })
+  const parsed = parseCliJson(result.stdout, result.stderr)
+  const raw = asRecord(parsed)
+  return {
+    state: authStateFrom(raw, result),
+    identity: stringValue(raw?.identity),
+    tokenStatus: stringValue(raw?.tokenStatus),
+    userName: stringValue(raw?.userName),
+    expiresAt: stringValue(raw?.expiresAt),
+    refreshExpiresAt: stringValue(raw?.refreshExpiresAt),
+    raw,
+    result,
+  }
+}
+
+export async function runFeishuCliJsonWithFile(input: {
+  cliPath: string
+  args: string[]
+  fileFlag: '--params' | '--data'
+  fileName: string
+  payload: unknown
+  env?: Record<string, string | undefined>
+  timeoutMs: number
+  runner?: FeishuCliRunner
+}): Promise<FeishuCliJsonResult> {
+  const cwd = await mkdtemp(join(tmpdir(), 'nine1bot-feishu-'))
+  try {
+    await writeFile(join(cwd, input.fileName), JSON.stringify(input.payload), 'utf8')
+    const result = await runFeishuCli(input.cliPath, [
+      ...input.args,
+      input.fileFlag,
+      `@${input.fileName}`,
+      '--as',
+      'user',
+      '--format',
+      'json',
+    ], {
+      env: effectiveEnv(input.env),
+      timeoutMs: input.timeoutMs,
+      cwd,
+      runner: input.runner,
+    })
+    return {
+      ...result,
+      json: parseCliJson(result.stdout, result.stderr),
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true }).catch(() => undefined)
+  }
+}
+
+export function parseCliJson(stdout: string, stderr = ''): unknown | undefined {
+  const candidates = [stdout, stderr, `${stdout}\n${stderr}`]
+  for (const candidate of candidates) {
+    const parsed = parseFirstJson(candidate)
+    if (parsed !== undefined) return parsed
+  }
+  return undefined
+}
+
+export function sanitizeCliError(input: unknown): Record<string, unknown> | undefined {
+  const record = asRecord(input)
+  if (!record) return undefined
+  const error = asRecord(record.error)
+  if (!error) return pick(record, ['code', 'msg', 'message'])
+  return dropUndefined({
+    type: stringValue(error.type),
+    code: numberOrString(error.code),
+    message: stringValue(error.message),
+  })
+}
+
+export function runFeishuCli(
+  command: string,
+  args: string[],
+  options: FeishuCliRunOptions & { runner?: FeishuCliRunner },
+): Promise<FeishuCliRunResult> {
+  if (options.runner) return options.runner(command, args, options)
+  return new Promise((resolve) => {
+    execFile(command, args, {
+      cwd: options.cwd,
+      env: effectiveEnv(options.env),
+      timeout: options.timeoutMs,
+      windowsHide: true,
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(command),
+    }, (error, stdout, stderr) => {
+      const errorRecord = error && typeof error === 'object' ? error as Record<string, unknown> : undefined
+      const code = errorRecord?.code
+      const exitCode = typeof code === 'number' ? code : error ? 1 : 0
+      resolve({
+        exitCode,
+        stdout: String(stdout ?? ''),
+        stderr: String(stderr ?? ''),
+        timedOut: Boolean(errorRecord?.killed) || code === 'ETIMEDOUT',
+      })
+    })
+  })
+}
+
+export function authStateFrom(
+  parsed: Record<string, unknown> | undefined,
+  result: Pick<FeishuCliRunResult, 'exitCode' | 'stdout' | 'stderr' | 'timedOut'>,
+): FeishuAuthState {
+  const tokenStatus = stringValue(parsed?.tokenStatus)?.toLowerCase()
+  const identity = stringValue(parsed?.identity)
+  if (result.exitCode === 0 && identity && (tokenStatus === 'valid' || tokenStatus === 'needs_refresh')) {
+    return 'authenticated'
+  }
+  if (
+    tokenStatus === 'expired'
+    || tokenStatus === 'invalid'
+    || tokenStatus === 'revoked'
+    || tokenStatus === 'unauthorized'
+    || tokenStatus === 'login_required'
+  ) return 'need_login'
+
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase()
+  if (output.includes('config') || output.includes('app id') || output.includes('app secret')) return 'need_config'
+  if (output.includes('login') || output.includes('unauthorized') || output.includes('auth')) return 'need_login'
+  return 'unknown'
+}
+
+export function parseVersion(stdout: string): string | undefined {
+  const firstLine = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+  if (!firstLine) return undefined
+  const match = firstLine.match(/(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)/)
+  return match?.[1] ?? firstLine
+}
+
+function parseFirstJson(input: string): unknown | undefined {
+  const trimmed = input.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed)
+  } catch {}
+
+  const objectStart = trimmed.indexOf('{')
+  const arrayStart = trimmed.indexOf('[')
+  const starts = [objectStart, arrayStart].filter((value) => value >= 0)
+  if (starts.length === 0) return undefined
+  const start = Math.min(...starts)
+  const end = trimmed.lastIndexOf(trimmed[start] === '[' ? ']' : '}')
+  if (end <= start) return undefined
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1))
+  } catch {
+    return undefined
+  }
+}
+
+function effectiveEnv(env?: Record<string, string | undefined>) {
+  return {
+    ...process.env,
+    ...env,
+  }
+}
+
+function hasPathSeparator(input: string) {
+  return input.includes('/') || input.includes('\\')
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined
+}
+
+function numberOrString(input: unknown): string | number | undefined {
+  return typeof input === 'number' || typeof input === 'string' ? input : undefined
+}
+
+function asRecord(input: unknown): Record<string, unknown> | undefined {
+  return input && typeof input === 'object' && !Array.isArray(input) ? input as Record<string, unknown> : undefined
+}
+
+function pick(input: Record<string, unknown>, keys: string[]) {
+  const output: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (input[key] !== undefined) output[key] = input[key]
+  }
+  if (output.code === 0 || output.code === '0') return undefined
+  return Object.keys(output).length ? output : undefined
+}
+
+function dropUndefined(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) output[key] = value
+  }
+  return output
+}

--- a/packages/platform-feishu/src/cli.ts
+++ b/packages/platform-feishu/src/cli.ts
@@ -54,14 +54,19 @@ export function resolveFeishuCliPath(
   if (cliPathSetting?.trim()) {
     const value = cliPathSetting.trim()
     if (hasPathSeparator(value) || isAbsolute(value)) return existsSync(value) ? value : undefined
-    return value
+    return findCommandOnPath(value, env)
   }
 
+  return findCommandOnPath('lark-cli', env)
+}
+
+function findCommandOnPath(
+  commandName: string,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
   const pathValue = env.PATH ?? env.Path ?? env.path ?? process.env.PATH
   if (!pathValue) return undefined
-  const names = process.platform === 'win32'
-    ? ['lark-cli.cmd', 'lark-cli.exe', 'lark-cli']
-    : ['lark-cli']
+  const names = commandNames(commandName, env)
   for (const directory of pathValue.split(delimiter)) {
     if (!directory) continue
     for (const name of names) {
@@ -70,6 +75,15 @@ export function resolveFeishuCliPath(
     }
   }
   return undefined
+}
+
+function commandNames(commandName: string, env: Record<string, string | undefined>) {
+  if (!isWindowsEnv(env) || /\.[^\\/]+$/.test(commandName)) return [commandName]
+  return [`${commandName}.cmd`, `${commandName}.exe`, `${commandName}.bat`, commandName]
+}
+
+function isWindowsEnv(env: Record<string, string | undefined>) {
+  return process.platform === 'win32' || env.OS === 'Windows_NT'
 }
 
 export async function getFeishuCliVersion(ctx: FeishuCliContext): Promise<FeishuCliJsonResult & { version?: string }> {

--- a/packages/platform-feishu/src/cli.ts
+++ b/packages/platform-feishu/src/cli.ts
@@ -78,8 +78,17 @@ function findCommandOnPath(
 }
 
 function commandNames(commandName: string, env: Record<string, string | undefined>) {
-  if (!isWindowsEnv(env) || /\.[^\\/]+$/.test(commandName)) return [commandName]
+  if (!isWindowsEnv(env) || hasFileExtension(commandName)) return [commandName]
   return [`${commandName}.cmd`, `${commandName}.exe`, `${commandName}.bat`, commandName]
+}
+
+function hasFileExtension(commandName: string) {
+  for (let index = commandName.length - 1; index >= 0; index--) {
+    const char = commandName[index]
+    if (char === '/' || char === '\\') return false
+    if (char === '.') return index < commandName.length - 1
+  }
+  return false
 }
 
 function isWindowsEnv(env: Record<string, string | undefined>) {

--- a/packages/platform-feishu/src/cli.ts
+++ b/packages/platform-feishu/src/cli.ts
@@ -212,10 +212,67 @@ export function authStateFrom(
 }
 
 export function parseVersion(stdout: string): string | undefined {
-  const firstLine = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+  const firstLine = firstNonEmptyLine(stdout)
   if (!firstLine) return undefined
-  const match = firstLine.match(/(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)/)
-  return match?.[1] ?? firstLine
+  return findVersionToken(firstLine) ?? firstLine
+}
+
+function firstNonEmptyLine(input: string): string | undefined {
+  let start = 0
+  for (let index = 0; index <= input.length; index++) {
+    const isEnd = index === input.length
+    const char = isEnd ? '' : input[index]
+    if (!isEnd && char !== '\n' && char !== '\r') continue
+    const line = input.slice(start, index).trim()
+    if (line) return line
+    if (char === '\r' && input[index + 1] === '\n') index++
+    start = index + 1
+  }
+  return undefined
+}
+
+function findVersionToken(input: string): string | undefined {
+  for (let index = 0; index < input.length; index++) {
+    if (!isDigit(input[index])) continue
+    const end = consumeSemverToken(input, index)
+    if (end > index) return input.slice(index, end)
+  }
+  return undefined
+}
+
+function consumeSemverToken(input: string, start: number): number {
+  let index = consumeDigits(input, start)
+  if (input[index] !== '.') return -1
+  index = consumeDigits(input, index + 1)
+  if (input[index] !== '.') return -1
+  index = consumeDigits(input, index + 1)
+  if (index <= start) return -1
+  if (input[index] !== '-' && input[index] !== '+') return index
+  const suffixStart = index
+  index++
+  while (index < input.length && isVersionSuffixChar(input[index])) index++
+  return index > suffixStart + 1 ? index : suffixStart
+}
+
+function consumeDigits(input: string, start: number): number {
+  let index = start
+  while (index < input.length && isDigit(input[index])) index++
+  return index > start ? index : -1
+}
+
+function isDigit(char: string | undefined) {
+  return char !== undefined && char >= '0' && char <= '9'
+}
+
+function isVersionSuffixChar(char: string | undefined) {
+  if (!char) return false
+  return isDigit(char)
+    || (char >= 'a' && char <= 'z')
+    || (char >= 'A' && char <= 'Z')
+    || char === '_'
+    || char === '.'
+    || char === '-'
+    || char === '+'
 }
 
 function parseFirstJson(input: string): unknown | undefined {

--- a/packages/platform-feishu/src/cli.ts
+++ b/packages/platform-feishu/src/cli.ts
@@ -240,10 +240,39 @@ function parseFirstJson(input: string): unknown | undefined {
 }
 
 function effectiveEnv(env?: Record<string, string | undefined>) {
-  return {
-    ...process.env,
-    ...env,
+  const output: Record<string, string> = {}
+  for (const source of [process.env, env ?? {}]) {
+    for (const [key, value] of Object.entries(source)) {
+      if (value === undefined || !isAllowedEnvKey(key)) continue
+      output[key] = value
+    }
   }
+  return output
+}
+
+function isAllowedEnvKey(key: string) {
+  const upper = key.toUpperCase()
+  return upper === 'PATH'
+    || upper === 'PATHEXT'
+    || upper === 'SYSTEMROOT'
+    || upper === 'WINDIR'
+    || upper === 'COMSPEC'
+    || upper === 'TEMP'
+    || upper === 'TMP'
+    || upper === 'TMPDIR'
+    || upper === 'USERPROFILE'
+    || upper === 'HOME'
+    || upper === 'HOMEDRIVE'
+    || upper === 'HOMEPATH'
+    || upper === 'APPDATA'
+    || upper === 'LOCALAPPDATA'
+    || upper === 'LANG'
+    || upper === 'SHELL'
+    || upper === 'HTTP_PROXY'
+    || upper === 'HTTPS_PROXY'
+    || upper === 'NO_PROXY'
+    || upper === 'ALL_PROXY'
+    || upper.startsWith('LC_')
 }
 
 function hasPathSeparator(input: string) {

--- a/packages/platform-feishu/src/enrichment.ts
+++ b/packages/platform-feishu/src/enrichment.ts
@@ -1,0 +1,568 @@
+import {
+  asRecord,
+  normalizeFeishuPagePayload,
+} from './shared'
+import {
+  getFeishuAuthStatus,
+  resolveFeishuCliPath,
+  runFeishuCliJsonWithFile,
+  sanitizeCliError,
+  type FeishuCliRunner,
+} from './cli'
+import type { PageContextPayload, PlatformContextBlock } from './types'
+
+export type FeishuContextEnrichmentStatus =
+  | 'not_applicable'
+  | 'visible_only'
+  | 'loaded'
+  | 'missing_cli'
+  | 'need_config'
+  | 'need_login'
+  | 'permission_denied'
+  | 'timeout'
+  | 'error'
+
+export type FeishuContextEnrichmentSummary = {
+  platform: 'feishu'
+  status: FeishuContextEnrichmentStatus
+  message: string
+  tone?: 'neutral' | 'success' | 'warning' | 'danger'
+}
+
+export type FeishuContextEnrichmentMode = 'auto' | 'visible-only' | 'disabled'
+
+export type FeishuMetadata = {
+  api: 'wiki.spaces.get_node' | 'drive.metas.batch_query'
+  title?: string
+  url?: string
+  objType?: string
+  objToken?: string
+  objectKey?: string
+  wikiToken?: string
+  spaceId?: string
+  owner?: string
+  creator?: string
+  createdAt?: string
+  updatedAt?: string
+  latestModifyTime?: string
+  raw?: Record<string, unknown>
+}
+
+export type FeishuPageContextEnrichmentResult = {
+  page: PageContextPayload
+  blocks: PlatformContextBlock[]
+  summary?: FeishuContextEnrichmentSummary
+  metadata?: FeishuMetadata
+}
+
+export type FeishuPageContextEnrichmentInput = {
+  page?: PageContextPayload
+  settings?: unknown
+  env?: Record<string, string | undefined>
+  observedAt?: number
+  runner?: FeishuCliRunner
+}
+
+type FeishuSettings = {
+  cliPath?: string
+  contextEnrichment: FeishuContextEnrichmentMode
+  metadataTimeoutMs: number
+}
+
+const DEFAULT_METADATA_TIMEOUT_MS = 2_000
+
+export async function enrichFeishuPageContext(
+  input: FeishuPageContextEnrichmentInput,
+): Promise<FeishuPageContextEnrichmentResult> {
+  const page = input.page ? normalizeFeishuPagePayload(input.page) : undefined
+  if (!page) {
+    return {
+      page: input.page ?? { platform: 'generic-browser' },
+      blocks: [],
+      summary: summary('not_applicable'),
+    }
+  }
+
+  const settings = readSettings(input.settings)
+  if (settings.contextEnrichment === 'disabled') {
+    return {
+      page,
+      blocks: [],
+      summary: summary('not_applicable'),
+    }
+  }
+
+  if (settings.contextEnrichment === 'visible-only') {
+    return {
+      page: withEnrichmentStatus(page, 'visible_only'),
+      blocks: [],
+      summary: summary('visible_only'),
+    }
+  }
+
+  const cliPath = resolveFeishuCliPath(settings.cliPath, input.env)
+  if (!cliPath) {
+    return failed(page, 'missing_cli', input.observedAt)
+  }
+
+  const auth = await getFeishuAuthStatus({
+    cliPath,
+    env: input.env,
+    timeoutMs: settings.metadataTimeoutMs,
+    runner: input.runner,
+  })
+  if (auth.result.timedOut) return failed(page, 'timeout', input.observedAt)
+  if (auth.state === 'need_config') return failed(page, 'need_config', input.observedAt)
+  if (auth.state === 'need_login') return failed(page, 'need_login', input.observedAt)
+  if (auth.state !== 'authenticated') return failed(page, 'need_login', input.observedAt)
+
+  const feishu = asRecord(page.raw?.feishu)
+  const token = stringValue(feishu?.token)
+  if (!token) return failed(page, 'error', input.observedAt, 'No Feishu token was found in the page URL.')
+
+  const timeoutMs = settings.metadataTimeoutMs
+  const result = await fetchMetadata({
+    cliPath,
+    token,
+    page,
+    env: input.env,
+    timeoutMs,
+    runner: input.runner,
+  })
+
+  if (result.status !== 'loaded') {
+    return failed(page, result.status, input.observedAt, result.message)
+  }
+
+  const metadata = result.metadata
+  const enrichedPage = withLoadedMetadata(page, metadata)
+  return {
+    page: enrichedPage,
+    blocks: [metadataBlock(enrichedPage, metadata, input.observedAt ?? Date.now())],
+    summary: summary('loaded', metadata.title),
+    metadata,
+  }
+}
+
+export function readFeishuContextEnrichmentSettings(settings: unknown): FeishuSettings {
+  return readSettings(settings)
+}
+
+async function fetchMetadata(input: {
+  cliPath: string
+  token: string
+  page: PageContextPayload
+  env?: Record<string, string | undefined>
+  timeoutMs: number
+  runner?: FeishuCliRunner
+}): Promise<
+  | { status: 'loaded'; metadata: FeishuMetadata }
+  | { status: Exclude<FeishuContextEnrichmentStatus, 'loaded' | 'not_applicable' | 'visible_only' | 'missing_cli' | 'need_config'>; message?: string }
+> {
+  const feishu = asRecord(input.page.raw?.feishu)
+  if (input.page.pageType === 'feishu-wiki') {
+    const result = await runFeishuCliJsonWithFile({
+      cliPath: input.cliPath,
+      args: ['wiki', 'spaces', 'get_node'],
+      fileFlag: '--params',
+      fileName: 'params.json',
+      payload: { token: input.token },
+      env: input.env,
+      timeoutMs: input.timeoutMs,
+      runner: input.runner,
+    })
+    if (result.timedOut) return { status: 'timeout' }
+    const errorStatus = classifyApiFailure(result)
+    if (errorStatus) return errorStatus
+    const node = wikiNodeFrom(result.json)
+    if (!node) return { status: 'error', message: 'Could not parse wiki node metadata.' }
+    return {
+      status: 'loaded',
+      metadata: metadataFromWikiNode(node, input.token),
+    }
+  }
+
+  const docType = driveDocTypeForPage(input.page.pageType, stringValue(feishu?.objType))
+  if (!docType) return { status: 'error', message: 'This Feishu page type is not supported for metadata enrichment yet.' }
+
+  const result = await runFeishuCliJsonWithFile({
+    cliPath: input.cliPath,
+    args: ['drive', 'metas', 'batch_query'],
+    fileFlag: '--data',
+    fileName: 'data.json',
+    payload: {
+      request_docs: [
+        {
+          doc_token: input.token,
+          doc_type: docType,
+        },
+      ],
+      with_url: true,
+    },
+    env: input.env,
+    timeoutMs: input.timeoutMs,
+    runner: input.runner,
+  })
+  if (result.timedOut) return { status: 'timeout' }
+  const errorStatus = classifyApiFailure(result)
+  if (errorStatus) return errorStatus
+  const meta = driveMetaFrom(result.json)
+  if (!meta) return { status: 'error', message: 'Could not parse drive metadata.' }
+  return {
+    status: 'loaded',
+    metadata: metadataFromDriveMeta(meta, input.token, docType),
+  }
+}
+
+function failed(
+  page: PageContextPayload,
+  status: Exclude<FeishuContextEnrichmentStatus, 'loaded' | 'not_applicable' | 'visible_only'>,
+  observedAt = Date.now(),
+  reason?: string,
+): FeishuPageContextEnrichmentResult {
+  const enrichedPage = withEnrichmentStatus(page, status)
+  return {
+    page: enrichedPage,
+    blocks: [statusBlock(enrichedPage, status, observedAt, reason)],
+    summary: summary(status, undefined, reason),
+  }
+}
+
+function withLoadedMetadata(page: PageContextPayload, metadata: FeishuMetadata): PageContextPayload {
+  return withFeishuRaw(page, {
+    metadata: metadataRaw(metadata),
+    enrichment: {
+      status: 'loaded',
+      source: 'lark-cli',
+      api: metadata.api,
+      resolvedObjType: metadata.objType,
+      resolvedObjToken: metadata.objToken,
+      resolvedObjectKey: metadata.objectKey,
+      spaceId: metadata.spaceId,
+      checkedAt: new Date().toISOString(),
+    },
+  })
+}
+
+function withEnrichmentStatus(page: PageContextPayload, status: FeishuContextEnrichmentStatus): PageContextPayload {
+  return withFeishuRaw(page, {
+    enrichment: {
+      status,
+      source: 'lark-cli',
+      checkedAt: new Date().toISOString(),
+    },
+  })
+}
+
+function withFeishuRaw(page: PageContextPayload, patch: Record<string, unknown>): PageContextPayload {
+  return {
+    ...page,
+    raw: {
+      ...(page.raw ?? {}),
+      feishu: {
+        ...(asRecord(page.raw?.feishu) ?? {}),
+        ...patch,
+      },
+    },
+  }
+}
+
+function metadataBlock(page: PageContextPayload, metadata: FeishuMetadata, observedAt: number): PlatformContextBlock {
+  return {
+    id: 'page:feishu-metadata',
+    layer: 'page',
+    source: `page-context.feishu.metadata.${metadata.api}`,
+    content: renderMetadata(metadata),
+    lifecycle: 'turn',
+    visibility: 'developer-toggle',
+    enabled: true,
+    priority: 72,
+    mergeKey: page.objectKey,
+    observedAt,
+  }
+}
+
+function statusBlock(
+  page: PageContextPayload,
+  status: FeishuContextEnrichmentStatus,
+  observedAt: number,
+  reason?: string,
+): PlatformContextBlock {
+  return {
+    id: 'page:feishu-metadata',
+    layer: 'page',
+    source: 'page-context.feishu.metadata.status',
+    content: [
+      `Feishu metadata: ${status}`,
+      'Using visible browser page context only.',
+      reason ? `Reason: ${reason}` : summary(status).message,
+    ].join('\n'),
+    lifecycle: 'turn',
+    visibility: 'developer-toggle',
+    enabled: true,
+    priority: 56,
+    mergeKey: page.objectKey,
+    observedAt,
+  }
+}
+
+function renderMetadata(metadata: FeishuMetadata) {
+  return [
+    'Feishu metadata: loaded',
+    `Metadata API: ${metadata.api}`,
+    metadata.title ? `Title: ${metadata.title}` : undefined,
+    metadata.url ? `URL: ${metadata.url}` : undefined,
+    metadata.objType ? `Object type: ${metadata.objType}` : undefined,
+    metadata.objectKey ? `Object key: ${metadata.objectKey}` : undefined,
+    metadata.spaceId ? `Wiki space: ${metadata.spaceId}` : undefined,
+    metadata.owner ? `Owner: ${metadata.owner}` : undefined,
+    metadata.creator ? `Creator: ${metadata.creator}` : undefined,
+    metadata.createdAt ? `Created at: ${metadata.createdAt}` : undefined,
+    metadata.updatedAt ? `Updated at: ${metadata.updatedAt}` : undefined,
+    metadata.latestModifyTime ? `Latest modify time: ${metadata.latestModifyTime}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function summary(
+  status: FeishuContextEnrichmentStatus,
+  title?: string,
+  reason?: string,
+): FeishuContextEnrichmentSummary {
+  if (status === 'loaded') {
+    return {
+      platform: 'feishu',
+      status,
+      message: title ? `Feishu metadata loaded: ${title}` : 'Feishu metadata loaded.',
+      tone: 'success',
+    }
+  }
+  const messages: Record<FeishuContextEnrichmentStatus, string> = {
+    not_applicable: 'No Feishu page metadata was needed.',
+    visible_only: 'Using visible Feishu page context only.',
+    loaded: 'Feishu metadata loaded.',
+    missing_cli: 'lark-cli was not found; using visible Feishu page context only.',
+    need_config: 'lark-cli needs configuration before Feishu metadata can be loaded.',
+    need_login: 'lark-cli needs Feishu login before metadata can be loaded.',
+    permission_denied: 'Feishu metadata permission was denied; using visible page context only.',
+    timeout: 'Feishu metadata lookup timed out; using visible page context only.',
+    error: 'Feishu metadata lookup failed; using visible page context only.',
+  }
+  return {
+    platform: 'feishu',
+    status,
+    message: reason ?? messages[status],
+    tone: status === 'visible_only' || status === 'not_applicable' ? 'neutral' : 'warning',
+  }
+}
+
+function classifyApiFailure(result: { exitCode: number | null; stdout: string; stderr: string; json?: unknown }) {
+  const record = asRecord(result.json)
+  const error = sanitizeCliError(record) ?? sanitizeCliError(parseMaybeJson(result.stderr))
+  const code = stringValue(error?.code)
+  const message = stringValue(error?.message) ?? stringValue(error?.msg)
+  const output = `${result.stdout}\n${result.stderr}\n${message ?? ''}`.toLowerCase()
+  if (result.exitCode !== 0 || error || isFailedEnvelope(record)) {
+    if (isPermissionDenied(code, output)) {
+      return { status: 'permission_denied' as const, message: message ?? 'Permission denied.' }
+    }
+    if (output.includes('login') || output.includes('unauthorized')) {
+      return { status: 'need_login' as const, message: message ?? 'lark-cli login is required.' }
+    }
+    return { status: 'error' as const, message: message ?? 'lark-cli metadata request failed.' }
+  }
+  const failedItem = firstFailedItem(record)
+  if (failedItem) {
+    const failedCode = stringValue(failedItem.code)
+    const failedMessage = stringValue(failedItem.msg) ?? stringValue(failedItem.message)
+    if (isPermissionDenied(failedCode, failedMessage?.toLowerCase() ?? '')) {
+      return { status: 'permission_denied' as const, message: failedMessage ?? 'Permission denied.' }
+    }
+    return { status: 'error' as const, message: failedMessage ?? 'lark-cli metadata request failed.' }
+  }
+  return undefined
+}
+
+function wikiNodeFrom(input: unknown): Record<string, unknown> | undefined {
+  const root = asRecord(input)
+  const data = asRecord(root?.data) ?? root
+  return asRecord(data?.node) ?? asRecord(data?.item) ?? data
+}
+
+function driveMetaFrom(input: unknown): Record<string, unknown> | undefined {
+  const root = asRecord(input)
+  const data = asRecord(root?.data) ?? root
+  const metas = Array.isArray(data?.metas)
+    ? data.metas
+    : Array.isArray(data?.docs)
+      ? data.docs
+      : Array.isArray(data?.items)
+        ? data.items
+        : undefined
+  return asRecord(metas?.[0])
+}
+
+function metadataFromWikiNode(node: Record<string, unknown>, wikiToken: string): FeishuMetadata {
+  const objType = stringValue(node.obj_type) ?? stringValue(node.objType)
+  const objToken = stringValue(node.obj_token) ?? stringValue(node.objToken)
+  return {
+    api: 'wiki.spaces.get_node',
+    title: stringValue(node.title),
+    objType,
+    objToken,
+    objectKey: objType && objToken ? `feishu:${objType}:${objToken}` : undefined,
+    wikiToken,
+    spaceId: stringValue(node.space_id) ?? stringValue(node.spaceId),
+    owner: personValue(node.owner) ?? personValue(node.node_creator) ?? personValue(node.creator),
+    creator: personValue(node.node_creator) ?? personValue(node.creator),
+    createdAt: timeValue(node.obj_create_time) ?? timeValue(node.create_time),
+    updatedAt: timeValue(node.obj_edit_time) ?? timeValue(node.edit_time),
+    raw: compactRecord({
+      nodeToken: stringValue(node.node_token) ?? stringValue(node.nodeToken),
+      objType,
+      objToken,
+      spaceId: stringValue(node.space_id) ?? stringValue(node.spaceId),
+    }),
+  }
+}
+
+function metadataFromDriveMeta(meta: Record<string, unknown>, token: string, docType: string): FeishuMetadata {
+  const objType = stringValue(meta.doc_type) ?? stringValue(meta.docType) ?? docType
+  const objToken = stringValue(meta.doc_token) ?? stringValue(meta.docToken) ?? token
+  return {
+    api: 'drive.metas.batch_query',
+    title: stringValue(meta.title) ?? stringValue(meta.name),
+    url: stringValue(meta.url),
+    objType,
+    objToken,
+    objectKey: objType && objToken ? `feishu:${objType}:${objToken}` : undefined,
+    owner: personValue(meta.owner) ?? stringValue(meta.owner_id) ?? stringValue(meta.ownerId),
+    latestModifyTime: timeValue(meta.latest_modify_time) ?? timeValue(meta.latestModifyTime),
+    raw: compactRecord({
+      docType: objType,
+      docToken: objToken,
+    }),
+  }
+}
+
+function metadataRaw(metadata: FeishuMetadata): Record<string, unknown> {
+  return compactRecord({
+    api: metadata.api,
+    title: metadata.title,
+    url: metadata.url,
+    objType: metadata.objType,
+    objToken: metadata.objToken,
+    objectKey: metadata.objectKey,
+    wikiToken: metadata.wikiToken,
+    spaceId: metadata.spaceId,
+    owner: metadata.owner,
+    creator: metadata.creator,
+    createdAt: metadata.createdAt,
+    updatedAt: metadata.updatedAt,
+    latestModifyTime: metadata.latestModifyTime,
+  })
+}
+
+function driveDocTypeForPage(pageType?: string, objType?: string): string | undefined {
+  if (pageType === 'feishu-docx' || objType === 'docx') return 'docx'
+  if (pageType === 'feishu-sheet' || objType === 'sheet') return 'sheet'
+  if (pageType === 'feishu-bitable' || objType === 'bitable') return 'bitable'
+  if (pageType === 'feishu-slides' || objType === 'slides') return 'slides'
+  if (pageType === 'feishu-folder' || objType === 'folder') return 'folder'
+  return undefined
+}
+
+function readSettings(settings: unknown): FeishuSettings {
+  const record = asRecord(settings)
+  const contextEnrichment = record?.contextEnrichment === 'disabled'
+    ? 'disabled'
+    : record?.contextEnrichment === 'visible-only'
+      ? 'visible-only'
+      : 'auto'
+  return {
+    cliPath: stringValue(record?.cliPath),
+    contextEnrichment,
+    metadataTimeoutMs: clampNumber(numberValue(record?.metadataTimeoutMs) ?? DEFAULT_METADATA_TIMEOUT_MS, 500, 15_000),
+  }
+}
+
+function firstFailedItem(record?: Record<string, unknown>) {
+  const data = asRecord(record?.data)
+  const failed = Array.isArray(data?.failed_list)
+    ? data.failed_list
+    : Array.isArray(data?.failedList)
+      ? data.failedList
+      : undefined
+  return asRecord(failed?.[0])
+}
+
+function isFailedEnvelope(record?: Record<string, unknown>) {
+  const code = record?.code
+  if (typeof code === 'number') return code !== 0
+  if (typeof code === 'string' && code !== '0') return true
+  return record?.ok === false || record?.success === false
+}
+
+function isPermissionDenied(code: string | undefined, output: string) {
+  return code === '99991663'
+    || code === '99991664'
+    || code === '970003'
+    || output.includes('permission')
+    || output.includes('forbidden')
+    || output.includes('scope')
+    || output.includes('no permission')
+}
+
+function parseMaybeJson(input: string) {
+  const trimmed = input.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return undefined
+  }
+}
+
+function personValue(input: unknown): string | undefined {
+  const record = asRecord(input)
+  return stringValue(record?.name)
+    ?? stringValue(record?.en_name)
+    ?? stringValue(record?.user_id)
+    ?? stringValue(record?.open_id)
+    ?? stringValue(input)
+}
+
+function timeValue(input: unknown): string | undefined {
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    const ms = input > 10_000_000_000 ? input : input * 1000
+    return new Date(ms).toISOString()
+  }
+  if (typeof input === 'string' && input.trim()) {
+    if (/^\d+$/.test(input.trim())) return timeValue(Number(input))
+    return input.trim()
+  }
+  return undefined
+}
+
+function compactRecord(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) output[key] = value
+  }
+  return output
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined
+}
+
+function numberValue(input: unknown): number | undefined {
+  if (typeof input === 'number' && Number.isFinite(input)) return input
+  if (typeof input === 'string' && input.trim() && Number.isFinite(Number(input))) return Number(input)
+  return undefined
+}
+
+function clampNumber(input: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, input))
+}

--- a/packages/platform-feishu/src/index.ts
+++ b/packages/platform-feishu/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  buildFeishuPageContextPayload,
+  buildFeishuPageContextPayload as buildPageContextPayload,
+  feishuTemplateIdsForPage,
+  isFeishuPagePayload,
+  parseFeishuUrl,
+} from './browser'
+export {
+  createFeishuPlatformAdapter,
+  feishuPlatformContribution,
+  feishuPlatformDescriptor,
+  normalizeFeishuPagePayload,
+} from './runtime'
+export type { FeishuPlatformAdapter } from './runtime'
+export type * from './types'

--- a/packages/platform-feishu/src/node.ts
+++ b/packages/platform-feishu/src/node.ts
@@ -1,0 +1,32 @@
+export {
+  enrichFeishuPageContext,
+  readFeishuContextEnrichmentSettings,
+} from './enrichment'
+export type {
+  FeishuContextEnrichmentMode,
+  FeishuContextEnrichmentStatus,
+  FeishuContextEnrichmentSummary,
+  FeishuMetadata,
+  FeishuPageContextEnrichmentInput,
+  FeishuPageContextEnrichmentResult,
+} from './enrichment'
+export {
+  authStateFrom,
+  getFeishuAuthStatus,
+  getFeishuCliVersion,
+  parseCliJson,
+  parseVersion,
+  resolveFeishuCliPath,
+  runFeishuCli,
+  runFeishuCliJsonWithFile,
+  sanitizeCliError,
+} from './cli'
+export type {
+  FeishuAuthState,
+  FeishuAuthStatus,
+  FeishuCliContext,
+  FeishuCliJsonResult,
+  FeishuCliRunOptions,
+  FeishuCliRunResult,
+  FeishuCliRunner,
+} from './cli'

--- a/packages/platform-feishu/src/runtime.ts
+++ b/packages/platform-feishu/src/runtime.ts
@@ -11,7 +11,16 @@ import {
   resolveFeishuCliPath,
 } from './cli'
 import { readFeishuContextEnrichmentSettings } from './enrichment'
+import {
+  FEISHU_CURRENT_PAGE_SKILL,
+  directoryFromActionInput,
+  feishuRuntimeSources,
+  inspectFeishuSkillSources,
+  inspectSkillDirectory,
+  resolveOfficialSkillsDirectory,
+} from './skills'
 import type {
+  PlatformActionResult,
   PlatformAdapterContext,
   PlatformAdapterContribution,
   PlatformDescriptor,
@@ -80,6 +89,12 @@ export const feishuPlatformDescriptor = {
             label: 'Metadata timeout',
             description: 'Timeout in milliseconds for read-only metadata lookups. Default: 2000.',
           },
+          {
+            key: 'officialSkillsDirectory',
+            type: 'string',
+            label: 'Official skills directory',
+            description: 'External directory containing official lark-* skills. Defaults to ~/.agents/skills. Switching directories takes effect on the next resolve; file changes inside the same directory may take up to 30 seconds to rescan.',
+          },
         ],
       },
     ],
@@ -88,17 +103,46 @@ export const feishuPlatformDescriptor = {
     sections: [
       { id: 'status', type: 'status-cards', title: 'Status' },
       { id: 'settings', type: 'settings-form', title: 'Settings' },
+      { id: 'actions', type: 'action-list', title: 'Actions' },
       { id: 'recent-events', type: 'event-list', title: 'Recent events' },
     ],
   },
+  actions: [
+    {
+      id: 'skills.refreshOfficialDirectory',
+      label: 'Refresh official skills directory',
+      description: 'Checks the configured lark-* skills directory. Newly added or removed files inside the same directory may take up to 30 seconds to appear in agent skill resolution.',
+      kind: 'button',
+    },
+    {
+      id: 'skills.configureDirectory',
+      label: 'Configure official skills directory',
+      description: 'Changes the external lark-* skills directory and re-registers platform runtime sources immediately.',
+      kind: 'form',
+      inputSchema: {
+        sections: [{
+          id: 'directory',
+          title: 'Directory',
+          fields: [{
+            key: 'directory',
+            type: 'string',
+            label: 'Official skills directory',
+            description: 'Directory containing official lark-* skills. Empty value clears the override. Directory changes apply immediately; same-directory file changes may take up to 30 seconds to rescan.',
+          }],
+        }],
+      },
+    },
+  ],
 } satisfies PlatformDescriptor
 
 export const feishuPlatformContribution = {
   descriptor: feishuPlatformDescriptor,
   runtime: {
     createAdapter: createFeishuPlatformAdapter,
+    sources: feishuRuntimeSources,
   },
   getStatus: getFeishuStatus,
+  handleAction: handleFeishuAction,
 } satisfies PlatformAdapterContribution
 
 export function createFeishuPlatformAdapter(): FeishuPlatformAdapter {
@@ -119,7 +163,7 @@ export function createFeishuPlatformAdapter(): FeishuPlatformAdapter {
       if (!input.templateIds.some((templateId) => templateId === 'browser-feishu' || templateId.startsWith('feishu-'))) {
         return undefined
       }
-      return emptyResources(['feishu-context'])
+      return emptyResources(['feishu-context'], [FEISHU_CURRENT_PAGE_SKILL])
     },
   }
 }
@@ -131,6 +175,7 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
   const cliPathSetting = stringValue(settings?.cliPath)
   const cliPath = resolveFeishuCliPath(cliPathSetting, ctx.env)
   const enrichmentSettings = readFeishuContextEnrichmentSettings(ctx.settings)
+  const skillStatus = inspectFeishuSkillSources(ctx.settings)
   const checkedAt = new Date().toISOString()
 
   if (!cliPath) {
@@ -141,6 +186,9 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
         { id: 'cli', label: 'CLI', value: 'missing', tone: 'danger' },
         { id: 'auth', label: 'Auth', value: 'unknown', tone: 'neutral' },
         { id: 'context', label: 'Context', value: enrichmentSettings.contextEnrichment, tone: 'neutral' },
+        companionSkillCard(skillStatus.companion),
+        officialSkillsCard(skillStatus.official),
+        skillCacheCard(),
       ],
       recentEvents: [{
         id: `feishu-cli-missing-${Date.now()}`,
@@ -170,31 +218,114 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
     : authState === 'unknown'
       ? 'degraded'
       : 'auth-required'
+  const skillsReady = skillStatus.companion.skillCount > 0 && skillStatus.official.skillCount > 0
+  const finalStatus = status === 'available' && !skillsReady ? 'degraded' : status
 
   return {
-    status,
-    message: status === 'available'
-      ? 'lark-cli is available and authenticated.'
-      : status === 'auth-required'
+    status: finalStatus,
+    message: finalStatus === 'available'
+      ? 'lark-cli is available, authenticated, and Feishu skills are detected.'
+      : finalStatus === 'auth-required'
         ? 'lark-cli is available but authentication is required.'
-        : 'lark-cli is available, but auth status could not be parsed.',
+        : status === 'available'
+          ? 'lark-cli is available, but Feishu skills need attention.'
+          : 'lark-cli is available, but auth status could not be parsed.',
     cards: [
       { id: 'cli', label: 'CLI', value: `found · ${versionText}`, tone: version.exitCode === 0 ? 'success' : 'warning' },
       { id: 'auth', label: 'Auth', value: authCardValue(auth, authState), tone: authTone(authState) },
       { id: 'context', label: 'Context', value: enrichmentSettings.contextEnrichment, tone: contextTone(enrichmentSettings.contextEnrichment) },
+      companionSkillCard(skillStatus.companion),
+      officialSkillsCard(skillStatus.official),
+      skillCacheCard(),
     ],
     recentEvents: [{
       id: `feishu-status-${Date.now()}`,
       at: checkedAt,
-      level: status === 'available' ? 'info' : 'warn',
+      level: finalStatus === 'available' ? 'info' : 'warn',
       stage: 'status',
-      message: status === 'available' ? 'lark-cli status checked' : 'lark-cli requires authentication or status review',
+      message: finalStatus === 'available' ? 'lark-cli and Feishu skills status checked' : 'lark-cli or Feishu skills require status review',
       data: {
         cliPath,
         version: versionText,
         authExitCode: auth.result.exitCode,
+        companionSkillsDirectory: skillStatus.companion.directory,
+        officialSkillsDirectory: skillStatus.official.directory,
+        officialSkillCount: skillStatus.official.skillCount,
       },
     }],
+  }
+}
+
+async function handleFeishuAction(
+  actionId: string,
+  input: unknown,
+  ctx: PlatformAdapterContext,
+): Promise<PlatformActionResult> {
+  if (actionId === 'skills.refreshOfficialDirectory') {
+    const status = await getFeishuStatus(ctx)
+    const skills = inspectFeishuSkillSources(ctx.settings)
+    return {
+      status: 'ok',
+      message: skills.official.skillCount > 0
+        ? `Found ${skills.official.skillCount} official lark-* skills. Directory changes apply immediately; same-directory file changes may take up to 30 seconds to appear in agent skill resolution.`
+        : 'Official lark-* skills were not found in the configured directory. If files were just added to the same directory, they may take up to 30 seconds to appear in agent skill resolution.',
+      data: {
+        companion: skills.companion,
+        official: skills.official,
+      },
+      updatedStatus: status,
+    }
+  }
+
+  if (actionId === 'skills.configureDirectory') {
+    const directory = directoryFromActionInput(input)
+    if (directory === undefined) {
+      return {
+        status: 'failed',
+        message: 'Directory must be a string, null, or empty value.',
+      }
+    }
+    if (directory) {
+      const inspection = inspectSkillDirectory(directory, { prefix: 'lark-' })
+      if (!inspection.exists || !inspection.readable) {
+        return {
+          status: 'failed',
+          message: inspection.error ?? 'Official skills directory is not readable.',
+          data: {
+            official: inspection,
+          },
+        }
+      }
+    }
+
+    const currentSettings = asRecord(ctx.settings) ?? {}
+    const nextSettings = {
+      ...currentSettings,
+      officialSkillsDirectory: directory ?? undefined,
+    }
+    const updatedStatus = await getFeishuStatus({
+      ...ctx,
+      settings: nextSettings,
+    })
+    const official = inspectSkillDirectory(resolveOfficialSkillsDirectory(nextSettings), { prefix: 'lark-' })
+    return {
+      status: 'ok',
+      message: directory
+        ? `Configured official skills directory: ${directory}`
+        : 'Cleared official skills directory override.',
+      data: {
+        official,
+      },
+      updatedSettings: {
+        officialSkillsDirectory: directory ?? null,
+      },
+      updatedStatus,
+    }
+  }
+
+  return {
+    status: 'failed',
+    message: `Action is not implemented: ${actionId}`,
   }
 }
 
@@ -320,7 +451,7 @@ function renderPage(page: PageContextPayload, feishu?: Record<string, unknown>) 
     .join('\n')
 }
 
-function emptyResources(enabledGroups: string[]): PlatformResourceContribution {
+function emptyResources(enabledGroups: string[], skills: string[] = []): PlatformResourceContribution {
   return {
     builtinTools: {
       enabledGroups,
@@ -331,7 +462,7 @@ function emptyResources(enabledGroups: string[]): PlatformResourceContribution {
       mergeMode: 'additive-only',
     },
     skills: {
-      skills: [],
+      skills,
       lifecycle: 'session',
       mergeMode: 'additive-only',
     },
@@ -357,6 +488,33 @@ function contextTone(mode: string) {
   if (mode === 'auto') return 'success' as const
   if (mode === 'visible-only') return 'warning' as const
   return 'neutral' as const
+}
+
+function companionSkillCard(status: { skillCount: number; directory: string; readable: boolean; error?: string }) {
+  return {
+    id: 'companion',
+    label: 'Companion',
+    value: status.skillCount > 0 ? FEISHU_CURRENT_PAGE_SKILL : 'missing',
+    tone: status.skillCount > 0 ? 'success' as const : status.readable ? 'warning' as const : 'danger' as const,
+  }
+}
+
+function officialSkillsCard(status: { skillCount: number; directory: string; readable: boolean; error?: string }) {
+  return {
+    id: 'skills',
+    label: 'Skills',
+    value: status.skillCount > 0 ? `${status.skillCount} lark-* skills` : 'missing',
+    tone: status.skillCount > 0 ? 'success' as const : status.readable ? 'warning' as const : 'danger' as const,
+  }
+}
+
+function skillCacheCard() {
+  return {
+    id: 'skills-cache',
+    label: 'Skill cache',
+    value: 'rescan <= 30s',
+    tone: 'neutral' as const,
+  }
 }
 
 function pageKeyFor(page: PageContextPayload) {

--- a/packages/platform-feishu/src/runtime.ts
+++ b/packages/platform-feishu/src/runtime.ts
@@ -389,7 +389,10 @@ function buildFeishuTemplateContextBlocks(templateIds: string[], page?: PageCont
         id: 'template:browser-feishu',
         layer: 'platform',
         source: 'template.browser-feishu',
-        content: 'This session can use Feishu/Lark browser context. Treat the current Feishu/Lark page as active work context and use the official lark-cli when the user asks to access Feishu/Lark data.',
+        content: [
+          'This session can use Feishu/Lark browser context. Treat the current Feishu/Lark page as active work context and use the official lark-cli when the user asks to access Feishu/Lark data.',
+          feishuWriteSafetyContext(),
+        ].join('\n'),
         lifecycle: 'session',
         visibility: 'developer-toggle',
         enabled: true,
@@ -419,9 +422,14 @@ function renderFeishuTemplateContext(templateId: string, page?: PageContextPaylo
     page?.title ? `Initial page title: ${page.title}` : undefined,
     page?.url ? `Initial page URL: ${page.url}` : undefined,
     page?.objectKey ? `Initial object key: ${page.objectKey}` : undefined,
+    feishuWriteSafetyContext(),
   ]
     .filter(Boolean)
     .join('\n')
+}
+
+function feishuWriteSafetyContext() {
+  return 'Feishu/Lark write operations should prefer the official lark-cli, respect CLI-native prompts and existing Nine1Bot permissions, and use dry-run first when the chosen command supports it. Nine1Bot does not wrap or intercept arbitrary lark-cli write commands.'
 }
 
 function renderPlatform(page: PageContextPayload, feishu?: Record<string, unknown>) {

--- a/packages/platform-feishu/src/runtime.ts
+++ b/packages/platform-feishu/src/runtime.ts
@@ -1,6 +1,3 @@
-import { execFile } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { delimiter, isAbsolute, join } from 'node:path'
 import {
   asRecord,
   feishuTemplateIdsForPage,
@@ -8,6 +5,12 @@ import {
   normalizeFeishuPagePayload,
   parseFeishuUrl,
 } from './shared'
+import {
+  getFeishuAuthStatus,
+  getFeishuCliVersion,
+  resolveFeishuCliPath,
+} from './cli'
+import { readFeishuContextEnrichmentSettings } from './enrichment'
 import type {
   PlatformAdapterContext,
   PlatformAdapterContribution,
@@ -64,6 +67,19 @@ export const feishuPlatformDescriptor = {
             label: 'lark-cli path',
             description: 'Optional explicit path to lark-cli. Leave empty to search PATH.',
           },
+          {
+            key: 'contextEnrichment',
+            type: 'select',
+            label: 'Context enrichment',
+            description: 'Controls read-only Feishu metadata enrichment for browser side panel messages.',
+            options: ['auto', 'visible-only', 'disabled'],
+          },
+          {
+            key: 'metadataTimeoutMs',
+            type: 'number',
+            label: 'Metadata timeout',
+            description: 'Timeout in milliseconds for read-only metadata lookups. Default: 2000.',
+          },
         ],
       },
     ],
@@ -113,7 +129,8 @@ export { feishuTemplateIdsForPage, normalizeFeishuPagePayload, parseFeishuUrl }
 async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRuntimeStatus> {
   const settings = asRecord(ctx.settings)
   const cliPathSetting = stringValue(settings?.cliPath)
-  const cliPath = findCliPath(cliPathSetting, ctx.env)
+  const cliPath = resolveFeishuCliPath(cliPathSetting, ctx.env)
+  const enrichmentSettings = readFeishuContextEnrichmentSettings(ctx.settings)
   const checkedAt = new Date().toISOString()
 
   if (!cliPath) {
@@ -123,6 +140,7 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
       cards: [
         { id: 'cli', label: 'CLI', value: 'missing', tone: 'danger' },
         { id: 'auth', label: 'Auth', value: 'unknown', tone: 'neutral' },
+        { id: 'context', label: 'Context', value: enrichmentSettings.contextEnrichment, tone: 'neutral' },
       ],
       recentEvents: [{
         id: `feishu-cli-missing-${Date.now()}`,
@@ -134,11 +152,18 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
     }
   }
 
-  const version = await runCli(cliPath, ['version'], ctx.env, 2_000)
-  const versionText = parseVersion(version.stdout) ?? 'unknown'
-  const auth = await runCli(cliPath, ['auth', 'status'], ctx.env, 3_000)
-  const parsedAuth = parseAuthStatus(auth.stdout || auth.stderr)
-  const authState = authStateFrom(parsedAuth, auth)
+  const version = await getFeishuCliVersion({
+    cliPath,
+    env: ctx.env,
+    timeoutMs: 2_000,
+  })
+  const versionText = version.version ?? 'unknown'
+  const auth = await getFeishuAuthStatus({
+    cliPath,
+    env: ctx.env,
+    timeoutMs: 3_000,
+  })
+  const authState = auth.state
 
   const status = authState === 'authenticated'
     ? 'available'
@@ -155,7 +180,8 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
         : 'lark-cli is available, but auth status could not be parsed.',
     cards: [
       { id: 'cli', label: 'CLI', value: `found · ${versionText}`, tone: version.exitCode === 0 ? 'success' : 'warning' },
-      { id: 'auth', label: 'Auth', value: authCardValue(parsedAuth, authState), tone: authTone(authState) },
+      { id: 'auth', label: 'Auth', value: authCardValue(auth, authState), tone: authTone(authState) },
+      { id: 'context', label: 'Context', value: enrichmentSettings.contextEnrichment, tone: contextTone(enrichmentSettings.contextEnrichment) },
     ],
     recentEvents: [{
       id: `feishu-status-${Date.now()}`,
@@ -166,7 +192,7 @@ async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRun
       data: {
         cliPath,
         version: versionText,
-        authExitCode: auth.exitCode,
+        authExitCode: auth.result.exitCode,
       },
     }],
   }
@@ -312,107 +338,29 @@ function emptyResources(enabledGroups: string[]): PlatformResourceContribution {
   }
 }
 
-function findCliPath(cliPathSetting: string | undefined, env: Record<string, string | undefined>): string | undefined {
-  if (cliPathSetting) {
-    if (hasPathSeparator(cliPathSetting) || isAbsolute(cliPathSetting)) return existsSync(cliPathSetting) ? cliPathSetting : undefined
-    return cliPathSetting
-  }
-
-  const pathValue = env.PATH ?? env.Path ?? env.path ?? process.env.PATH
-  if (!pathValue) return undefined
-  const names = process.platform === 'win32'
-    ? ['lark-cli.cmd', 'lark-cli.exe', 'lark-cli']
-    : ['lark-cli']
-  for (const directory of pathValue.split(delimiter)) {
-    if (!directory) continue
-    for (const name of names) {
-      const candidate = join(directory, name)
-      if (existsSync(candidate)) return candidate
-    }
-  }
-  return undefined
-}
-
-function runCli(command: string, args: string[], env: Record<string, string | undefined>, timeoutMs: number): Promise<{
-  exitCode: number | null
-  stdout: string
-  stderr: string
-}> {
-  return new Promise((resolve) => {
-    execFile(command, args, {
-      env: {
-        ...process.env,
-        ...env,
-      },
-      timeout: timeoutMs,
-      windowsHide: true,
-      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(command),
-    }, (error, stdout, stderr) => {
-      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
-      const exitCode = typeof code === 'number' ? code : error ? 1 : 0
-      resolve({
-        exitCode,
-        stdout: String(stdout ?? ''),
-        stderr: String(stderr ?? ''),
-      })
-    })
-  })
-}
-
-function parseVersion(stdout: string): string | undefined {
-  const firstLine = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
-  if (!firstLine) return undefined
-  const match = firstLine.match(/(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)/)
-  return match?.[1] ?? firstLine
-}
-
-function parseAuthStatus(output: string): Record<string, unknown> | undefined {
-  const trimmed = output.trim()
-  if (!trimmed) return undefined
-  try {
-    return JSON.parse(trimmed) as Record<string, unknown>
-  } catch {
-    const start = trimmed.indexOf('{')
-    const end = trimmed.lastIndexOf('}')
-    if (start >= 0 && end > start) {
-      try {
-        return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>
-      } catch {}
-    }
-    return undefined
-  }
-}
-
-function authStateFrom(parsed: Record<string, unknown> | undefined, result: { exitCode: number | null; stdout: string; stderr: string }) {
-  const tokenStatus = stringValue(parsed?.tokenStatus)?.toLowerCase()
-  const identity = stringValue(parsed?.identity)
-  if (result.exitCode === 0 && tokenStatus === 'valid' && identity) return 'authenticated'
-  if (tokenStatus === 'expired' || tokenStatus === 'invalid') return 'auth-required'
-  const output = `${result.stdout}\n${result.stderr}`.toLowerCase()
-  if (output.includes('login') || output.includes('auth') || output.includes('config') || output.includes('unauthorized')) return 'auth-required'
-  return 'unknown'
-}
-
-function authCardValue(parsed: Record<string, unknown> | undefined, authState: string) {
+function authCardValue(auth: { identity?: string; tokenStatus?: string }, authState: string) {
   if (authState === 'authenticated') {
-    return [stringValue(parsed?.identity), stringValue(parsed?.tokenStatus)].filter(Boolean).join(' · ') || 'authenticated'
+    return [auth.identity, auth.tokenStatus].filter(Boolean).join(' · ') || 'authenticated'
   }
-  if (authState === 'auth-required') return 'required'
+  if (authState === 'need_config') return 'configuration required'
+  if (authState === 'need_login') return 'login required'
   return 'unknown'
 }
 
 function authTone(authState: string) {
   if (authState === 'authenticated') return 'success' as const
-  if (authState === 'auth-required') return 'warning' as const
+  if (authState === 'need_config' || authState === 'need_login') return 'warning' as const
+  return 'neutral' as const
+}
+
+function contextTone(mode: string) {
+  if (mode === 'auto') return 'success' as const
+  if (mode === 'visible-only') return 'warning' as const
   return 'neutral' as const
 }
 
 function pageKeyFor(page: PageContextPayload) {
   return [page.platform, page.pageType || 'page', page.objectKey || page.url || page.title || 'unknown'].join(':')
-}
-
-function hasPathSeparator(input: string) {
-  return input.includes('/') || input.includes('\\')
 }
 
 function stringValue(input: unknown): string | undefined {

--- a/packages/platform-feishu/src/runtime.ts
+++ b/packages/platform-feishu/src/runtime.ts
@@ -1,0 +1,429 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { delimiter, isAbsolute, join } from 'node:path'
+import {
+  asRecord,
+  feishuTemplateIdsForPage,
+  isFeishuPagePayload,
+  normalizeFeishuPagePayload,
+  parseFeishuUrl,
+} from './shared'
+import type {
+  PlatformAdapterContext,
+  PlatformAdapterContribution,
+  PlatformDescriptor,
+  PlatformRuntimeAdapter,
+  PlatformRuntimeStatus,
+} from '@nine1bot/platform-protocol'
+import type { PageContextPayload, PlatformContextBlock, PlatformResourceContribution } from './types'
+
+export type FeishuPlatformAdapter = PlatformRuntimeAdapter & {
+  id: 'feishu'
+  matchPage: (page: PageContextPayload) => boolean
+  normalizePage: (page: PageContextPayload) => PageContextPayload | undefined
+  blocksFromPage: (page: PageContextPayload, observedAt: number) => PlatformContextBlock[] | undefined
+  inferTemplateIds: (input: { entry?: { platform?: string }; page?: PageContextPayload }) => string[]
+  templateContextBlocks: (input: { templateIds: string[]; page?: PageContextPayload }) => PlatformContextBlock[]
+  resourceContributions: (input: { templateIds: string[] }) => PlatformResourceContribution | undefined
+}
+
+export const feishuPlatformDescriptor = {
+  id: 'feishu',
+  name: 'Feishu/Lark',
+  packageName: '@nine1bot/platform-feishu',
+  version: '0.1.0',
+  defaultEnabled: true,
+  capabilities: {
+    pageContext: true,
+    templates: [
+      'browser-feishu',
+      'feishu-docx',
+      'feishu-wiki',
+      'feishu-sheet',
+      'feishu-bitable',
+      'feishu-folder',
+      'feishu-slides',
+      'feishu-unknown',
+    ],
+    resources: true,
+    browserExtension: true,
+    auth: 'external',
+    settingsPage: true,
+    statusPage: true,
+  },
+  config: {
+    sections: [
+      {
+        id: 'cli',
+        title: 'CLI',
+        description: 'Use the external official lark-cli for Feishu/Lark access.',
+        fields: [
+          {
+            key: 'cliPath',
+            type: 'string',
+            label: 'lark-cli path',
+            description: 'Optional explicit path to lark-cli. Leave empty to search PATH.',
+          },
+        ],
+      },
+    ],
+  },
+  detailPage: {
+    sections: [
+      { id: 'status', type: 'status-cards', title: 'Status' },
+      { id: 'settings', type: 'settings-form', title: 'Settings' },
+      { id: 'recent-events', type: 'event-list', title: 'Recent events' },
+    ],
+  },
+} satisfies PlatformDescriptor
+
+export const feishuPlatformContribution = {
+  descriptor: feishuPlatformDescriptor,
+  runtime: {
+    createAdapter: createFeishuPlatformAdapter,
+  },
+  getStatus: getFeishuStatus,
+} satisfies PlatformAdapterContribution
+
+export function createFeishuPlatformAdapter(): FeishuPlatformAdapter {
+  return {
+    id: 'feishu',
+    matchPage: isFeishuPagePayload,
+    normalizePage: normalizeFeishuPagePayload,
+    blocksFromPage: buildFeishuContextBlocks,
+    inferTemplateIds(input) {
+      if (input.entry?.platform !== 'feishu' && !input.page) return []
+      const ids = feishuTemplateIdsForPage(input.page)
+      return ids.length > 0 || input.entry?.platform !== 'feishu' ? ids : ['browser-feishu', 'feishu-unknown']
+    },
+    templateContextBlocks(input) {
+      return buildFeishuTemplateContextBlocks(input.templateIds, input.page)
+    },
+    resourceContributions(input) {
+      if (!input.templateIds.some((templateId) => templateId === 'browser-feishu' || templateId.startsWith('feishu-'))) {
+        return undefined
+      }
+      return emptyResources(['feishu-context'])
+    },
+  }
+}
+
+export { feishuTemplateIdsForPage, normalizeFeishuPagePayload, parseFeishuUrl }
+
+async function getFeishuStatus(ctx: PlatformAdapterContext): Promise<PlatformRuntimeStatus> {
+  const settings = asRecord(ctx.settings)
+  const cliPathSetting = stringValue(settings?.cliPath)
+  const cliPath = findCliPath(cliPathSetting, ctx.env)
+  const checkedAt = new Date().toISOString()
+
+  if (!cliPath) {
+    return {
+      status: 'missing',
+      message: 'lark-cli was not found. Install the official CLI or configure its path.',
+      cards: [
+        { id: 'cli', label: 'CLI', value: 'missing', tone: 'danger' },
+        { id: 'auth', label: 'Auth', value: 'unknown', tone: 'neutral' },
+      ],
+      recentEvents: [{
+        id: `feishu-cli-missing-${Date.now()}`,
+        at: checkedAt,
+        level: 'warn',
+        stage: 'status',
+        message: 'lark-cli was not found',
+      }],
+    }
+  }
+
+  const version = await runCli(cliPath, ['version'], ctx.env, 2_000)
+  const versionText = parseVersion(version.stdout) ?? 'unknown'
+  const auth = await runCli(cliPath, ['auth', 'status'], ctx.env, 3_000)
+  const parsedAuth = parseAuthStatus(auth.stdout || auth.stderr)
+  const authState = authStateFrom(parsedAuth, auth)
+
+  const status = authState === 'authenticated'
+    ? 'available'
+    : authState === 'unknown'
+      ? 'degraded'
+      : 'auth-required'
+
+  return {
+    status,
+    message: status === 'available'
+      ? 'lark-cli is available and authenticated.'
+      : status === 'auth-required'
+        ? 'lark-cli is available but authentication is required.'
+        : 'lark-cli is available, but auth status could not be parsed.',
+    cards: [
+      { id: 'cli', label: 'CLI', value: `found · ${versionText}`, tone: version.exitCode === 0 ? 'success' : 'warning' },
+      { id: 'auth', label: 'Auth', value: authCardValue(parsedAuth, authState), tone: authTone(authState) },
+    ],
+    recentEvents: [{
+      id: `feishu-status-${Date.now()}`,
+      at: checkedAt,
+      level: status === 'available' ? 'info' : 'warn',
+      stage: 'status',
+      message: status === 'available' ? 'lark-cli status checked' : 'lark-cli requires authentication or status review',
+      data: {
+        cliPath,
+        version: versionText,
+        authExitCode: auth.exitCode,
+      },
+    }],
+  }
+}
+
+function buildFeishuContextBlocks(page: PageContextPayload, observedAt: number): PlatformContextBlock[] | undefined {
+  const adapted = normalizeFeishuPagePayload(page)
+  if (!adapted) return undefined
+  const feishu = asRecord(adapted.raw?.feishu)
+  const pageType = adapted.pageType ?? 'feishu-unknown'
+  const mergeKey = pageKeyFor(adapted)
+  const blocks: PlatformContextBlock[] = [
+    {
+      id: 'platform:feishu',
+      layer: 'platform',
+      source: 'page-context.feishu',
+      content: renderPlatform(adapted, feishu),
+      lifecycle: 'turn',
+      visibility: 'developer-toggle',
+      enabled: true,
+      priority: 65,
+      mergeKey,
+      observedAt,
+    },
+    {
+      id: `page:${pageType}`,
+      layer: 'page',
+      source: 'page-context.feishu',
+      content: renderPage(adapted, feishu),
+      lifecycle: 'turn',
+      visibility: 'developer-toggle',
+      enabled: true,
+      priority: 62,
+      mergeKey,
+      observedAt,
+    },
+  ]
+
+  if (adapted.selection?.trim()) {
+    blocks.push({
+      id: `page:browser-selection:${textDigest(adapted.selection).slice(0, 12)}`,
+      layer: 'page',
+      source: 'page-context.feishu.selection',
+      content: `Current page selection:\n${adapted.selection.trim()}`,
+      lifecycle: 'turn',
+      visibility: 'developer-toggle',
+      enabled: true,
+      priority: 55,
+      mergeKey: `${mergeKey}:selection`,
+      observedAt,
+    })
+  }
+
+  return blocks
+}
+
+function buildFeishuTemplateContextBlocks(templateIds: string[], page?: PageContextPayload): PlatformContextBlock[] {
+  const normalizedPage = page ? normalizeFeishuPagePayload(page) : undefined
+  const blocks: PlatformContextBlock[] = []
+  for (const templateId of templateIds) {
+    if (templateId === 'browser-feishu') {
+      blocks.push({
+        id: 'template:browser-feishu',
+        layer: 'platform',
+        source: 'template.browser-feishu',
+        content: 'This session can use Feishu/Lark browser context. Treat the current Feishu/Lark page as active work context and use the official lark-cli when the user asks to access Feishu/Lark data.',
+        lifecycle: 'session',
+        visibility: 'developer-toggle',
+        enabled: true,
+        priority: 45,
+      })
+    }
+    if (templateId.startsWith('feishu-')) {
+      blocks.push({
+        id: `template:${templateId}`,
+        layer: 'platform',
+        source: `template.${templateId}`,
+        content: renderFeishuTemplateContext(templateId, normalizedPage),
+        lifecycle: 'session',
+        visibility: 'developer-toggle',
+        enabled: true,
+        priority: 42,
+        mergeKey: normalizedPage?.objectKey,
+      })
+    }
+  }
+  return blocks
+}
+
+function renderFeishuTemplateContext(templateId: string, page?: PageContextPayload) {
+  return [
+    `Feishu/Lark template: ${templateId}`,
+    page?.title ? `Initial page title: ${page.title}` : undefined,
+    page?.url ? `Initial page URL: ${page.url}` : undefined,
+    page?.objectKey ? `Initial object key: ${page.objectKey}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function renderPlatform(page: PageContextPayload, feishu?: Record<string, unknown>) {
+  return [
+    'Platform: Feishu/Lark',
+    page.title ? `Title: ${page.title}` : undefined,
+    page.url ? `URL: ${page.url}` : undefined,
+    stringValue(feishu?.host) ? `Host: ${feishu?.host}` : undefined,
+    stringValue(feishu?.tenant) ? `Tenant: ${feishu?.tenant}` : undefined,
+    page.visibleSummary ? `Visible summary:\n${page.visibleSummary}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function renderPage(page: PageContextPayload, feishu?: Record<string, unknown>) {
+  return [
+    `Page type: ${page.pageType ?? 'feishu-unknown'}`,
+    page.objectKey ? `Object key: ${page.objectKey}` : undefined,
+    stringValue(feishu?.route) ? `Feishu route: ${feishu?.route}` : undefined,
+    stringValue(feishu?.objType) ? `Object type: ${feishu?.objType}` : undefined,
+    stringValue(feishu?.token) ? `Token: ${feishu?.token}` : undefined,
+    stringValue(feishu?.tableId) ? `Base table: ${feishu?.tableId}` : undefined,
+    stringValue(feishu?.viewId) ? `Base view: ${feishu?.viewId}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+function emptyResources(enabledGroups: string[]): PlatformResourceContribution {
+  return {
+    builtinTools: {
+      enabledGroups,
+    },
+    mcp: {
+      servers: [],
+      lifecycle: 'session',
+      mergeMode: 'additive-only',
+    },
+    skills: {
+      skills: [],
+      lifecycle: 'session',
+      mergeMode: 'additive-only',
+    },
+  }
+}
+
+function findCliPath(cliPathSetting: string | undefined, env: Record<string, string | undefined>): string | undefined {
+  if (cliPathSetting) {
+    if (hasPathSeparator(cliPathSetting) || isAbsolute(cliPathSetting)) return existsSync(cliPathSetting) ? cliPathSetting : undefined
+    return cliPathSetting
+  }
+
+  const pathValue = env.PATH ?? env.Path ?? env.path ?? process.env.PATH
+  if (!pathValue) return undefined
+  const names = process.platform === 'win32'
+    ? ['lark-cli.cmd', 'lark-cli.exe', 'lark-cli']
+    : ['lark-cli']
+  for (const directory of pathValue.split(delimiter)) {
+    if (!directory) continue
+    for (const name of names) {
+      const candidate = join(directory, name)
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+
+function runCli(command: string, args: string[], env: Record<string, string | undefined>, timeoutMs: number): Promise<{
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}> {
+  return new Promise((resolve) => {
+    execFile(command, args, {
+      env: {
+        ...process.env,
+        ...env,
+      },
+      timeout: timeoutMs,
+      windowsHide: true,
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(command),
+    }, (error, stdout, stderr) => {
+      const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
+      const exitCode = typeof code === 'number' ? code : error ? 1 : 0
+      resolve({
+        exitCode,
+        stdout: String(stdout ?? ''),
+        stderr: String(stderr ?? ''),
+      })
+    })
+  })
+}
+
+function parseVersion(stdout: string): string | undefined {
+  const firstLine = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
+  if (!firstLine) return undefined
+  const match = firstLine.match(/(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)/)
+  return match?.[1] ?? firstLine
+}
+
+function parseAuthStatus(output: string): Record<string, unknown> | undefined {
+  const trimmed = output.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>
+  } catch {
+    const start = trimmed.indexOf('{')
+    const end = trimmed.lastIndexOf('}')
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>
+      } catch {}
+    }
+    return undefined
+  }
+}
+
+function authStateFrom(parsed: Record<string, unknown> | undefined, result: { exitCode: number | null; stdout: string; stderr: string }) {
+  const tokenStatus = stringValue(parsed?.tokenStatus)?.toLowerCase()
+  const identity = stringValue(parsed?.identity)
+  if (result.exitCode === 0 && tokenStatus === 'valid' && identity) return 'authenticated'
+  if (tokenStatus === 'expired' || tokenStatus === 'invalid') return 'auth-required'
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase()
+  if (output.includes('login') || output.includes('auth') || output.includes('config') || output.includes('unauthorized')) return 'auth-required'
+  return 'unknown'
+}
+
+function authCardValue(parsed: Record<string, unknown> | undefined, authState: string) {
+  if (authState === 'authenticated') {
+    return [stringValue(parsed?.identity), stringValue(parsed?.tokenStatus)].filter(Boolean).join(' · ') || 'authenticated'
+  }
+  if (authState === 'auth-required') return 'required'
+  return 'unknown'
+}
+
+function authTone(authState: string) {
+  if (authState === 'authenticated') return 'success' as const
+  if (authState === 'auth-required') return 'warning' as const
+  return 'neutral' as const
+}
+
+function pageKeyFor(page: PageContextPayload) {
+  return [page.platform, page.pageType || 'page', page.objectKey || page.url || page.title || 'unknown'].join(':')
+}
+
+function hasPathSeparator(input: string) {
+  return input.includes('/') || input.includes('\\')
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined
+}
+
+function textDigest(input: string) {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}

--- a/packages/platform-feishu/src/shared.ts
+++ b/packages/platform-feishu/src/shared.ts
@@ -1,0 +1,286 @@
+import type { FeishuBrand, FeishuObjType, FeishuRoute, FeishuUrlInfo, KnownFeishuPageType, PageContextPayload } from './types'
+
+export function parseFeishuUrl(input?: string): FeishuUrlInfo | undefined {
+  if (!input) return undefined
+
+  let url: URL
+  try {
+    url = new URL(input)
+  } catch {
+    return undefined
+  }
+
+  if (!isLikelyFeishuHost(url.hostname)) return undefined
+
+  const parts = url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
+  const host = url.hostname
+  const brand = brandForHost(host)
+  const tenant = tenantForHost(host)
+
+  if (parts[0] === 'docx' && parts[1]) {
+    return routeInfo({ host, brand, tenant, route: 'docx', token: parts[1], objType: 'docx', pageType: 'feishu-docx' })
+  }
+
+  if (parts[0] === 'wiki' && parts[1]) {
+    return routeInfo({ host, brand, tenant, route: 'wiki', token: parts[1], objType: 'wiki', pageType: 'feishu-wiki' })
+  }
+
+  if (parts[0] === 'sheets' && parts[1]) {
+    return routeInfo({ host, brand, tenant, route: 'sheets', token: parts[1], objType: 'sheet', pageType: 'feishu-sheet' })
+  }
+
+  if (parts[0] === 'base' && parts[1]) {
+    const tableId = stringValue(url.searchParams.get('table'))
+    const viewId = stringValue(url.searchParams.get('view'))
+    const query = whitelistQuery({ table: tableId, view: viewId })
+    return routeInfo({
+      host,
+      brand,
+      tenant,
+      route: 'base',
+      token: parts[1],
+      objType: 'bitable',
+      pageType: 'feishu-bitable',
+      tableId,
+      viewId,
+      query,
+    })
+  }
+
+  if (parts[0] === 'drive' && parts[1] === 'folder' && parts[2]) {
+    return routeInfo({ host, brand, tenant, route: 'drive/folder', token: parts[2], objType: 'folder', pageType: 'feishu-folder' })
+  }
+
+  if (parts[0] === 'slides' && parts[1]) {
+    return routeInfo({ host, brand, tenant, route: 'slides', token: parts[1], objType: 'slides', pageType: 'feishu-slides' })
+  }
+
+  const pathKey = parts.length ? parts.join('/') : 'root'
+  return {
+    host,
+    brand,
+    tenant,
+    pageType: 'feishu-unknown',
+    objectKey: `feishu:unknown:${host}:${pathKey}`,
+    route: 'unknown',
+    objType: 'unknown',
+  }
+}
+
+export function buildFeishuPageContextPayload(input: {
+  url: string
+  title: string
+  selection?: string
+  visibleSummary?: string
+  raw?: Record<string, unknown>
+}): PageContextPayload {
+  const feishu = parseFeishuUrl(input.url)
+  if (!feishu) {
+    return {
+      platform: 'generic-browser',
+      url: input.url,
+      title: input.title,
+      selection: trimText(input.selection, 4000),
+      visibleSummary: trimText(input.visibleSummary, 2000),
+      raw: input.raw,
+    }
+  }
+
+  return {
+    platform: 'feishu',
+    url: input.url,
+    title: input.title,
+    pageType: feishu.pageType,
+    objectKey: feishu.objectKey,
+    selection: trimText(input.selection, 4000),
+    visibleSummary: trimText(input.visibleSummary, 2000),
+    raw: {
+      ...(input.raw ?? {}),
+      feishu: {
+        ...(asRecord(input.raw?.feishu) ?? {}),
+        ...rawFeishu(feishu),
+      },
+    },
+  }
+}
+
+export function normalizeFeishuPagePayload(page: PageContextPayload): PageContextPayload | undefined {
+  const parsed = parseFeishuUrl(page.url)
+  if (!parsed && page.platform !== 'feishu') return undefined
+  const feishu = parsed ?? feishuInfoFromRaw(page)
+  if (!feishu) return undefined
+
+  return {
+    ...page,
+    platform: 'feishu',
+    pageType: feishu.pageType,
+    objectKey: feishu.objectKey,
+    raw: {
+      ...(page.raw ?? {}),
+      feishu: {
+        ...(asRecord(page.raw?.feishu) ?? {}),
+        ...rawFeishu(feishu),
+      },
+    },
+  }
+}
+
+export function feishuTemplateIdsForPage(page?: Pick<PageContextPayload, 'platform' | 'pageType' | 'url' | 'raw'>): string[] {
+  const normalized = page ? normalizeFeishuPagePayload(page as PageContextPayload) : undefined
+  if (!normalized) return []
+  const ids = ['browser-feishu']
+  if (normalized.pageType?.startsWith('feishu-') && normalized.pageType !== 'browser-feishu') ids.push(normalized.pageType)
+  return ids
+}
+
+export function isFeishuPagePayload(page?: Pick<PageContextPayload, 'platform' | 'url'>): boolean {
+  return Boolean(page && (page.platform === 'feishu' || parseFeishuUrl(page.url)))
+}
+
+export function trimText(input: string | undefined, maxLength: number): string | undefined {
+  const normalized = input?.replace(/\s+/g, ' ').trim()
+  if (!normalized) return undefined
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength).trim()}...` : normalized
+}
+
+export function asRecord(input: unknown): Record<string, unknown> | undefined {
+  return input && typeof input === 'object' && !Array.isArray(input) ? (input as Record<string, unknown>) : undefined
+}
+
+function routeInfo(input: {
+  host: string
+  brand: FeishuBrand
+  tenant?: string
+  route: FeishuRoute
+  token: string
+  objType: FeishuObjType
+  pageType: KnownFeishuPageType
+  tableId?: string
+  viewId?: string
+  query?: Record<string, string>
+}): FeishuUrlInfo {
+  return {
+    ...input,
+    objectKey: `feishu:${input.objType}:${input.token}`,
+  }
+}
+
+function rawFeishu(info: FeishuUrlInfo): Record<string, unknown> {
+  return dropUndefined({
+    host: info.host,
+    brand: info.brand,
+    tenant: info.tenant,
+    route: info.route,
+    token: info.token,
+    objType: info.objType,
+    tableId: info.tableId,
+    viewId: info.viewId,
+    query: info.query,
+  })
+}
+
+function feishuInfoFromRaw(page: PageContextPayload): FeishuUrlInfo | undefined {
+  const raw = asRecord(page.raw?.feishu)
+  const host = stringValue(raw?.host)
+  const brand = brandValue(raw?.brand) ?? (host ? brandForHost(host) : undefined)
+  const route = routeValue(raw?.route)
+  const objType = objTypeValue(raw?.objType)
+  if (!host || !brand || !route || !objType) return undefined
+
+  const token = stringValue(raw?.token)
+  const pageType = pageTypeFor(route, objType, page.pageType)
+  const objectKey = page.objectKey || (token ? `feishu:${objType}:${token}` : `feishu:unknown:${host}:${route}`)
+  const tableId = stringValue(raw?.tableId)
+  const viewId = stringValue(raw?.viewId)
+  const query = whitelistQuery({ table: tableId, view: viewId })
+
+  return {
+    host,
+    brand,
+    tenant: stringValue(raw?.tenant),
+    pageType,
+    objectKey,
+    route,
+    token,
+    objType,
+    tableId,
+    viewId,
+    query,
+  }
+}
+
+function pageTypeFor(route: FeishuRoute, objType: FeishuObjType, existing?: string): KnownFeishuPageType {
+  if (existing?.startsWith('feishu-')) return existing as KnownFeishuPageType
+  if (route === 'docx' || objType === 'docx') return 'feishu-docx'
+  if (route === 'wiki' || objType === 'wiki') return 'feishu-wiki'
+  if (route === 'sheets' || objType === 'sheet') return 'feishu-sheet'
+  if (route === 'base' || objType === 'bitable') return 'feishu-bitable'
+  if (route === 'drive/folder' || objType === 'folder') return 'feishu-folder'
+  if (route === 'slides' || objType === 'slides') return 'feishu-slides'
+  return 'feishu-unknown'
+}
+
+function isLikelyFeishuHost(hostname: string) {
+  const normalized = hostname.toLowerCase()
+  return normalized === 'feishu.cn'
+    || normalized.endsWith('.feishu.cn')
+    || normalized === 'larksuite.com'
+    || normalized.endsWith('.larksuite.com')
+}
+
+function brandForHost(hostname: string): FeishuBrand {
+  return hostname.toLowerCase().includes('larksuite') ? 'lark' : 'feishu'
+}
+
+function tenantForHost(hostname: string): string | undefined {
+  const normalized = hostname.toLowerCase()
+  const parts = normalized.split('.')
+  if (parts.length <= 2) return undefined
+  const first = parts[0]
+  return first && first !== 'www' ? first : undefined
+}
+
+function whitelistQuery(input: Record<string, string | undefined>): Record<string, string> | undefined {
+  const query = dropUndefined(input) as Record<string, string>
+  return Object.keys(query).length ? query : undefined
+}
+
+function dropUndefined(input: Record<string, unknown>): Record<string, unknown> {
+  const output: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) output[key] = value
+  }
+  return output
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined
+}
+
+function brandValue(input: unknown): FeishuBrand | undefined {
+  return input === 'feishu' || input === 'lark' ? input : undefined
+}
+
+function routeValue(input: unknown): FeishuRoute | undefined {
+  return input === 'docx'
+    || input === 'wiki'
+    || input === 'sheets'
+    || input === 'base'
+    || input === 'drive/folder'
+    || input === 'slides'
+    || input === 'unknown'
+    ? input
+    : undefined
+}
+
+function objTypeValue(input: unknown): FeishuObjType | undefined {
+  return input === 'docx'
+    || input === 'wiki'
+    || input === 'sheet'
+    || input === 'bitable'
+    || input === 'folder'
+    || input === 'slides'
+    || input === 'unknown'
+    ? input
+    : undefined
+}

--- a/packages/platform-feishu/src/skills.ts
+++ b/packages/platform-feishu/src/skills.ts
@@ -36,6 +36,7 @@ export function feishuRuntimeSources(ctx: PlatformAdapterContext): PlatformRunti
       {
         id: 'feishu-official-skills',
         directory: sources.officialDirectory,
+        includeNamePrefix: 'lark-',
         visibility: 'default',
         lifecycle: 'platform-enabled',
       },

--- a/packages/platform-feishu/src/skills.ts
+++ b/packages/platform-feishu/src/skills.ts
@@ -1,0 +1,152 @@
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join, normalize, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { asRecord } from './shared'
+import type { PlatformAdapterContext, PlatformRuntimeSourcesDescriptor } from '@nine1bot/platform-protocol'
+
+export const FEISHU_CURRENT_PAGE_SKILL = 'feishu-current-page'
+
+const companionSkillsDirectory = fileURLToPath(new URL('../skills', import.meta.url))
+
+export type FeishuSkillDirectoryInspection = {
+  directory: string
+  exists: boolean
+  readable: boolean
+  skillCount: number
+  skills: string[]
+  error?: string
+}
+
+export type FeishuSkillSources = {
+  companionDirectory: string
+  officialDirectory: string
+}
+
+export function feishuRuntimeSources(ctx: PlatformAdapterContext): PlatformRuntimeSourcesDescriptor {
+  const sources = feishuSkillSources(ctx.settings)
+  return {
+    skills: [
+      {
+        id: 'feishu-companion-skills',
+        directory: sources.companionDirectory,
+        visibility: 'declared-only',
+        lifecycle: 'platform-enabled',
+      },
+      {
+        id: 'feishu-official-skills',
+        directory: sources.officialDirectory,
+        visibility: 'default',
+        lifecycle: 'platform-enabled',
+      },
+    ],
+  }
+}
+
+export function feishuSkillSources(settings: unknown): FeishuSkillSources {
+  return {
+    companionDirectory: companionSkillsDirectory,
+    officialDirectory: resolveOfficialSkillsDirectory(settings),
+  }
+}
+
+export function inspectFeishuSkillSources(settings: unknown) {
+  const sources = feishuSkillSources(settings)
+  return {
+    companion: inspectSkillDirectory(sources.companionDirectory, {
+      names: [FEISHU_CURRENT_PAGE_SKILL],
+    }),
+    official: inspectSkillDirectory(sources.officialDirectory, {
+      prefix: 'lark-',
+    }),
+  }
+}
+
+export function resolveOfficialSkillsDirectory(settings: unknown): string {
+  const record = asRecord(settings)
+  return normalizeDirectory(stringValue(record?.officialSkillsDirectory) ?? defaultOfficialSkillsDirectory())
+}
+
+export function defaultOfficialSkillsDirectory(): string {
+  return join(homedir(), '.agents', 'skills')
+}
+
+export function normalizeDirectory(input: string): string {
+  const trimmed = input.trim()
+  if (trimmed === '~') return homedir()
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return normalize(join(homedir(), trimmed.slice(2)))
+  }
+  return normalize(resolve(trimmed))
+}
+
+export function inspectSkillDirectory(
+  directory: string,
+  filter: { prefix?: string; names?: string[] } = {},
+): FeishuSkillDirectoryInspection {
+  const normalized = normalizeDirectory(directory)
+  if (!existsSync(normalized)) {
+    return {
+      directory: normalized,
+      exists: false,
+      readable: false,
+      skillCount: 0,
+      skills: [],
+      error: 'Directory does not exist',
+    }
+  }
+
+  try {
+    if (!statSync(normalized).isDirectory()) {
+      return {
+        directory: normalized,
+        exists: true,
+        readable: false,
+        skillCount: 0,
+        skills: [],
+        error: 'Path is not a directory',
+      }
+    }
+
+    const allowedNames = new Set(filter.names ?? [])
+    const skills = readdirSync(normalized, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) => {
+        if (filter.prefix && !name.startsWith(filter.prefix)) return false
+        if (allowedNames.size > 0 && !allowedNames.has(name)) return false
+        return existsSync(join(normalized, name, 'SKILL.md'))
+      })
+      .sort((left, right) => left.localeCompare(right))
+
+    return {
+      directory: normalized,
+      exists: true,
+      readable: true,
+      skillCount: skills.length,
+      skills,
+    }
+  } catch (error) {
+    return {
+      directory: normalized,
+      exists: true,
+      readable: false,
+      skillCount: 0,
+      skills: [],
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export function directoryFromActionInput(input: unknown): string | null | undefined {
+  const record = asRecord(input)
+  const value = record ? record.directory : input
+  if (value === null) return null
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? normalizeDirectory(trimmed) : null
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined
+}

--- a/packages/platform-feishu/src/types.ts
+++ b/packages/platform-feishu/src/types.ts
@@ -1,0 +1,54 @@
+import type {
+  PlatformContextBlock as ProtocolPlatformContextBlock,
+  PlatformPagePayload,
+  PlatformResourceContribution as ProtocolPlatformResourceContribution,
+} from '@nine1bot/platform-protocol'
+
+export type KnownFeishuPageType =
+  | 'feishu-docx'
+  | 'feishu-wiki'
+  | 'feishu-sheet'
+  | 'feishu-bitable'
+  | 'feishu-folder'
+  | 'feishu-slides'
+  | 'feishu-unknown'
+
+export type FeishuBrand = 'feishu' | 'lark'
+
+export type FeishuRoute =
+  | 'docx'
+  | 'wiki'
+  | 'sheets'
+  | 'base'
+  | 'drive/folder'
+  | 'slides'
+  | 'unknown'
+
+export type FeishuObjType =
+  | 'docx'
+  | 'wiki'
+  | 'sheet'
+  | 'bitable'
+  | 'folder'
+  | 'slides'
+  | 'unknown'
+
+export type PageContextPayload = PlatformPagePayload
+
+export interface FeishuUrlInfo {
+  host: string
+  brand: FeishuBrand
+  tenant?: string
+  pageType: KnownFeishuPageType
+  objectKey: string
+  route: FeishuRoute
+  token?: string
+  objType: FeishuObjType
+  tableId?: string
+  viewId?: string
+  query?: Record<string, string>
+}
+
+export type PlatformContextBlock = ProtocolPlatformContextBlock
+
+export type PlatformResourceContribution = ProtocolPlatformResourceContribution

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -6,7 +6,15 @@ import {
   feishuTemplateIdsForPage,
   parseFeishuUrl,
 } from '../src'
+import {
+  enrichFeishuPageContext,
+  getFeishuAuthStatus,
+  getFeishuCliVersion,
+  runFeishuCliJsonWithFile,
+  type FeishuCliRunner,
+} from '../src/node'
 import type { PlatformAdapterContext } from '@nine1bot/platform-protocol'
+import { join } from 'node:path'
 
 describe('Feishu platform adapter package', () => {
   test('parses Phase 1 Feishu URL routes', () => {
@@ -164,12 +172,262 @@ describe('Feishu platform adapter package', () => {
       },
     }
 
-    await expect(feishuPlatformContribution.getStatus?.(ctx)).resolves.toMatchObject({
-      status: 'missing',
-      cards: [
-        { id: 'cli', value: 'missing' },
-        { id: 'auth', value: 'unknown' },
-      ],
+    const status = await feishuPlatformContribution.getStatus?.(ctx)
+    expect(status).toMatchObject({ status: 'missing' })
+    expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'cli', value: 'missing' }))
+    expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'auth', value: 'unknown' }))
+    expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'context', value: 'auto' }))
+  })
+
+  test('uses verified lark-cli commands and parses auth states', async () => {
+    const runner: FeishuCliRunner = async (_command, args) => {
+      if (args[0] === '--version') {
+        return { exitCode: 0, stdout: 'lark-cli version 1.0.23\n', stderr: '' }
+      }
+      if (args.join(' ') === 'auth status') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            identity: 'user:ou_123',
+            tokenStatus: 'needs_refresh',
+            userName: 'Demo User',
+          }),
+          stderr: '',
+        }
+      }
+      return { exitCode: 1, stdout: '', stderr: 'unexpected command' }
+    }
+
+    await expect(getFeishuCliVersion({ cliPath: 'lark-cli', runner })).resolves.toMatchObject({
+      version: '1.0.23',
+    })
+    await expect(getFeishuAuthStatus({ cliPath: 'lark-cli', runner })).resolves.toMatchObject({
+      state: 'authenticated',
+      tokenStatus: 'needs_refresh',
+    })
+  })
+
+  test('passes JSON params through relative @file arguments', async () => {
+    const seen: Array<{ args: string[]; payload: unknown }> = []
+    const runner: FeishuCliRunner = async (_command, args, options) => {
+      const fileArg = args.find((arg) => arg.startsWith('@'))
+      const payload = fileArg && options.cwd
+        ? await Bun.file(join(options.cwd, fileArg.slice(1))).json()
+        : undefined
+      seen.push({ args, payload })
+      return { exitCode: 0, stdout: JSON.stringify({ code: 0, data: { node: { title: 'Wiki' } } }), stderr: '' }
+    }
+
+    await runFeishuCliJsonWithFile({
+      cliPath: 'lark-cli',
+      args: ['wiki', 'spaces', 'get_node'],
+      fileFlag: '--params',
+      fileName: 'params.json',
+      payload: { token: 'wikcn_token' },
+      timeoutMs: 2_000,
+      runner,
+    })
+
+    expect(seen[0]?.args).toEqual([
+      'wiki',
+      'spaces',
+      'get_node',
+      '--params',
+      '@params.json',
+      '--as',
+      'user',
+      '--format',
+      'json',
+    ])
+    expect(seen[0]?.payload).toEqual({ token: 'wikcn_token' })
+  })
+
+  test('enriches wiki pages with get_node metadata', async () => {
+    const calls: string[][] = []
+    const runner: FeishuCliRunner = async (_command, args) => {
+      calls.push(args)
+      if (args.join(' ') === 'auth status') {
+        return authOk()
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          code: 0,
+          data: {
+            node: {
+              title: 'Wiki Doc',
+              space_id: 'spc_123',
+              obj_type: 'docx',
+              obj_token: 'docx_token',
+              owner: { name: 'Owner' },
+              obj_create_time: 1710000000,
+              obj_edit_time: 1710000100,
+            },
+          },
+        }),
+        stderr: '',
+      }
+    }
+
+    const page = buildFeishuPageContextPayload({
+      url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+      title: 'Visible Wiki Title',
+    })
+    const result = await enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli' },
+      observedAt: 1000,
+      runner,
+    })
+
+    expect(calls[1]).toContain('--params')
+    expect(result.summary).toMatchObject({ status: 'loaded' })
+    expect(result.metadata).toMatchObject({
+      api: 'wiki.spaces.get_node',
+      title: 'Wiki Doc',
+      objType: 'docx',
+      objToken: 'docx_token',
+      objectKey: 'feishu:docx:docx_token',
+      spaceId: 'spc_123',
+    })
+    expect(result.page.raw?.feishu).toMatchObject({
+      enrichment: {
+        status: 'loaded',
+        resolvedObjType: 'docx',
+        resolvedObjToken: 'docx_token',
+      },
+    })
+    expect(result.blocks[0]?.id).toBe('page:feishu-metadata')
+    expect(result.blocks[0]?.content).toEqual(expect.stringContaining('Metadata API: wiki.spaces.get_node'))
+  })
+
+  test('maps direct Feishu pages to drive metas batch_query doc types', async () => {
+    const cases = [
+      ['https://gdut-topview.feishu.cn/docx/GeVqd0rdho2WbPxLCyWcXI8nnpg', 'docx'],
+      ['https://www.feishu.cn/sheets/shtcnI8QzfNsZk8B1RKJhtOEyHh', 'sheet'],
+      ['https://gdut-topview.feishu.cn/base/GOerbRw0LaPdCpsnfT1cMg39ntb?table=tbl&view=vew', 'bitable'],
+      ['https://gdut-topview.feishu.cn/slides/PKkosoB9RlwVFcdKj42cBRk2n3e', 'slides'],
+      ['https://gdut-topview.feishu.cn/drive/folder/WpF7fSL5PlZYUkdfxBqcQ6KJnSC', 'folder'],
+    ] as const
+
+    for (const [url, docType] of cases) {
+      let payload: any
+      const runner: FeishuCliRunner = async (_command, args, options) => {
+        if (args.join(' ') === 'auth status') return authOk()
+        const fileArg = args.find((arg) => arg.startsWith('@'))
+        payload = fileArg && options.cwd
+          ? await Bun.file(join(options.cwd, fileArg.slice(1))).json()
+          : undefined
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            code: 0,
+            data: {
+              metas: [{
+                title: `${docType} title`,
+                doc_type: docType,
+                doc_token: 'token_123',
+                url: 'https://example.feishu.cn/meta',
+                owner_id: 'ou_owner',
+                latest_modify_time: 1710000100,
+              }],
+            },
+          }),
+          stderr: '',
+        }
+      }
+      const result = await enrichFeishuPageContext({
+        page: buildFeishuPageContextPayload({ url, title: 'Visible' }),
+        settings: { cliPath: 'lark-cli' },
+        runner,
+      })
+
+      expect(payload.request_docs[0].doc_type).toBe(docType)
+      expect(result.summary).toMatchObject({ status: 'loaded' })
+      expect(result.metadata).toMatchObject({
+        api: 'drive.metas.batch_query',
+        objType: docType,
+        title: `${docType} title`,
+      })
+    }
+  })
+
+  test('degrades Feishu enrichment without secrets for missing CLI, login, permission, timeout, and visible-only', async () => {
+    const page = buildFeishuPageContextPayload({
+      url: 'https://gdut-topview.feishu.cn/docx/GeVqd0rdho2WbPxLCyWcXI8nnpg',
+      title: 'Docx',
+    })
+
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: {},
+      env: { PATH: '' },
+    })).resolves.toMatchObject({
+      summary: { status: 'missing_cli' },
+      blocks: [{ id: 'page:feishu-metadata' }],
+    })
+
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli' },
+      runner: async () => ({ exitCode: 0, stdout: JSON.stringify({ tokenStatus: 'expired' }), stderr: '' }),
+    })).resolves.toMatchObject({
+      summary: { status: 'need_login' },
+    })
+
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli' },
+      runner: async (_command, args) => {
+        if (args.join(' ') === 'auth status') return authOk()
+        return { exitCode: 1, stdout: '', stderr: JSON.stringify({ error: { code: 99991663, message: 'Permission denied' } }) }
+      },
+    })).resolves.toMatchObject({
+      summary: { status: 'permission_denied' },
+    })
+
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli' },
+      runner: async (_command, args) => {
+        if (args.join(' ') === 'auth status') return authOk()
+        return { exitCode: null, stdout: '', stderr: '', timedOut: true }
+      },
+    })).resolves.toMatchObject({
+      summary: { status: 'timeout' },
+    })
+
+    const visibleOnlyRunner: FeishuCliRunner = async () => {
+      throw new Error('CLI should not run')
+    }
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli', contextEnrichment: 'visible-only' },
+      runner: visibleOnlyRunner,
+    })).resolves.toMatchObject({
+      summary: { status: 'visible_only' },
+      blocks: [],
+    })
+
+    await expect(enrichFeishuPageContext({
+      page,
+      settings: { cliPath: 'lark-cli', contextEnrichment: 'disabled' },
+      runner: visibleOnlyRunner,
+    })).resolves.toMatchObject({
+      summary: { status: 'not_applicable' },
+      blocks: [],
+      page,
     })
   })
 })
+
+function authOk() {
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify({
+      identity: 'user:ou_123',
+      tokenStatus: 'valid',
+    }),
+    stderr: '',
+  }
+}

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -11,6 +11,7 @@ import {
   getFeishuAuthStatus,
   getFeishuCliVersion,
   parseVersion,
+  resolveFeishuCliPath,
   runFeishuCliJsonWithFile,
   type FeishuCliRunner,
 } from '../src/node'
@@ -343,6 +344,18 @@ describe('Feishu platform adapter package', () => {
     await expect(getFeishuAuthStatus({ cliPath: 'lark-cli', runner })).resolves.toMatchObject({
       state: 'authenticated',
       tokenStatus: 'needs_refresh',
+    })
+  })
+
+  test('resolves explicit bare lark-cli command names through PATH on Windows', async () => {
+    await withTempDir(async (directory) => {
+      const command = join(directory, 'lark-cli.cmd')
+      await writeFile(command, '@echo off\n', 'utf8')
+
+      expect(resolveFeishuCliPath('lark-cli', {
+        OS: 'Windows_NT',
+        PATH: directory,
+      })).toBe(command)
     })
   })
 

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildFeishuPageContextPayload,
+  createFeishuPlatformAdapter,
+  feishuPlatformContribution,
+  feishuTemplateIdsForPage,
+  parseFeishuUrl,
+} from '../src'
+import type { PlatformAdapterContext } from '@nine1bot/platform-protocol'
+
+describe('Feishu platform adapter package', () => {
+  test('parses Phase 1 Feishu URL routes', () => {
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/docx/GeVqd0rdho2WbPxLCyWcXI8nnpg')).toMatchObject({
+      host: 'gdut-topview.feishu.cn',
+      tenant: 'gdut-topview',
+      brand: 'feishu',
+      pageType: 'feishu-docx',
+      objectKey: 'feishu:docx:GeVqd0rdho2WbPxLCyWcXI8nnpg',
+      route: 'docx',
+      objType: 'docx',
+    })
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg')).toMatchObject({
+      pageType: 'feishu-wiki',
+      objectKey: 'feishu:wiki:GKw9w6TOliwkBXkqO8UcphiDnUg',
+      route: 'wiki',
+      objType: 'wiki',
+    })
+    expect(parseFeishuUrl('https://www.feishu.cn/sheets/shtcnI8QzfNsZk8B1RKJhtOEyHh')).toMatchObject({
+      host: 'www.feishu.cn',
+      pageType: 'feishu-sheet',
+      objectKey: 'feishu:sheet:shtcnI8QzfNsZk8B1RKJhtOEyHh',
+      route: 'sheets',
+      objType: 'sheet',
+    })
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/base/GOerbRw0LaPdCpsnfT1cMg39ntb?table=tblikn3kcM2UbD4L&view=vewXxBNTOK')).toMatchObject({
+      pageType: 'feishu-bitable',
+      objectKey: 'feishu:bitable:GOerbRw0LaPdCpsnfT1cMg39ntb',
+      route: 'base',
+      objType: 'bitable',
+      tableId: 'tblikn3kcM2UbD4L',
+      viewId: 'vewXxBNTOK',
+      query: {
+        table: 'tblikn3kcM2UbD4L',
+        view: 'vewXxBNTOK',
+      },
+    })
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/drive/folder/WpF7fSL5PlZYUkdfxBqcQ6KJnSC')).toMatchObject({
+      pageType: 'feishu-folder',
+      objectKey: 'feishu:folder:WpF7fSL5PlZYUkdfxBqcQ6KJnSC',
+      route: 'drive/folder',
+      objType: 'folder',
+    })
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/slides/PKkosoB9RlwVFcdKj42cBRk2n3e')).toMatchObject({
+      pageType: 'feishu-slides',
+      objectKey: 'feishu:slides:PKkosoB9RlwVFcdKj42cBRk2n3e',
+      route: 'slides',
+      objType: 'slides',
+    })
+    expect(parseFeishuUrl('https://gdut-topview.feishu.cn/space/home')).toMatchObject({
+      pageType: 'feishu-unknown',
+      objectKey: 'feishu:unknown:gdut-topview.feishu.cn:space/home',
+      route: 'unknown',
+      objType: 'unknown',
+    })
+    expect(parseFeishuUrl('https://example.com/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg')).toBeUndefined()
+  })
+
+  test('builds browser page payloads with stable Feishu identity', () => {
+    const payload = buildFeishuPageContextPayload({
+      url: 'https://gdut-topview.feishu.cn/base/GOerbRw0LaPdCpsnfT1cMg39ntb?table=tblikn3kcM2UbD4L&view=vewXxBNTOK',
+      title: 'Project Base',
+      selection: ' selected text ',
+      visibleSummary: 'Base overview',
+    })
+
+    expect(payload).toMatchObject({
+      platform: 'feishu',
+      pageType: 'feishu-bitable',
+      objectKey: 'feishu:bitable:GOerbRw0LaPdCpsnfT1cMg39ntb',
+      selection: 'selected text',
+      visibleSummary: 'Base overview',
+      raw: {
+        feishu: {
+          host: 'gdut-topview.feishu.cn',
+          tenant: 'gdut-topview',
+          route: 'base',
+          token: 'GOerbRw0LaPdCpsnfT1cMg39ntb',
+          objType: 'bitable',
+          tableId: 'tblikn3kcM2UbD4L',
+          viewId: 'vewXxBNTOK',
+        },
+      },
+    })
+
+    expect(buildFeishuPageContextPayload({
+      url: 'https://example.com/page',
+      title: 'Example',
+    })).toMatchObject({
+      platform: 'generic-browser',
+      url: 'https://example.com/page',
+    })
+  })
+
+  test('contributes template ids, context blocks, and builtin resources', () => {
+    const page = {
+      platform: 'feishu',
+      url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+      title: 'Wiki Doc',
+    }
+    const adapter = createFeishuPlatformAdapter()
+    const templateIds = feishuTemplateIdsForPage(page)
+
+    expect(templateIds).toEqual(['browser-feishu', 'feishu-wiki'])
+    expect(adapter.inferTemplateIds({ entry: { platform: 'feishu' }, page })).toEqual(templateIds)
+    expect(adapter.templateContextBlocks({ templateIds, page }).map((block) => block.source)).toEqual([
+      'template.browser-feishu',
+      'template.feishu-wiki',
+    ])
+    expect(adapter.resourceContributions({ templateIds })?.builtinTools.enabledGroups).toContain('feishu-context')
+  })
+
+  test('builds stable runtime page context blocks and truncates selection', () => {
+    const adapter = createFeishuPlatformAdapter()
+    const page = buildFeishuPageContextPayload({
+      url: 'https://gdut-topview.feishu.cn/docx/GeVqd0rdho2WbPxLCyWcXI8nnpg',
+      title: 'Docx',
+      selection: ` ${'a'.repeat(5000)} `,
+      visibleSummary: 'Doc overview',
+    })
+
+    expect(page.selection?.length).toBe(4003)
+    expect(page.selection?.endsWith('...')).toBe(true)
+    const normalized = adapter.normalizePage(page)
+    expect(normalized).toMatchObject({
+      platform: 'feishu',
+      pageType: 'feishu-docx',
+      objectKey: 'feishu:docx:GeVqd0rdho2WbPxLCyWcXI8nnpg',
+    })
+
+    const blocks = adapter.blocksFromPage(page, 1_000) ?? []
+    expect(blocks.map((block) => block.id)).toEqual([
+      'platform:feishu',
+      'page:feishu-docx',
+      expect.stringMatching(/^page:browser-selection:/),
+    ])
+    expect(blocks[1]?.content).toEqual(expect.stringContaining('Object key: feishu:docx:GeVqd0rdho2WbPxLCyWcXI8nnpg'))
+  })
+
+  test('reports missing CLI without reading CLI private token storage', async () => {
+    const ctx: PlatformAdapterContext = {
+      platformId: 'feishu',
+      enabled: true,
+      settings: {},
+      features: {},
+      env: { PATH: '' },
+      secrets: {
+        async get() { return undefined },
+        async set() {},
+        async delete() {},
+        async has() { return false },
+      },
+      audit: {
+        write() {},
+      },
+    }
+
+    await expect(feishuPlatformContribution.getStatus?.(ctx)).resolves.toMatchObject({
+      status: 'missing',
+      cards: [
+        { id: 'cli', value: 'missing' },
+        { id: 'auth', value: 'unknown' },
+      ],
+    })
+  })
+})

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -345,6 +345,45 @@ describe('Feishu platform adapter package', () => {
     })
   })
 
+  test('passes only whitelisted environment variables to lark-cli', async () => {
+    const originalSecret = process.env.NINE1BOT_SECRET
+    const originalApiKey = process.env.OPENAI_API_KEY
+    process.env.NINE1BOT_SECRET = 'process-secret'
+    process.env.OPENAI_API_KEY = 'process-api-key'
+
+    try {
+      let seenEnv: Record<string, string | undefined> | undefined
+      const runner: FeishuCliRunner = async (_command, _args, options) => {
+        seenEnv = options.env
+        return { exitCode: 0, stdout: 'lark-cli version 1.0.23\n', stderr: '' }
+      }
+
+      await getFeishuCliVersion({
+        cliPath: 'lark-cli',
+        env: {
+          PATH: 'C:\\bin',
+          TEMP: 'C:\\tmp',
+          HTTP_PROXY: 'http://proxy.local',
+          NINE1BOT_SECRET: 'override-secret',
+          LARK_ACCESS_TOKEN: 'uat-token',
+        },
+        runner,
+      })
+
+      expect(seenEnv).toMatchObject({
+        PATH: 'C:\\bin',
+        TEMP: 'C:\\tmp',
+        HTTP_PROXY: 'http://proxy.local',
+      })
+      expect(seenEnv).not.toHaveProperty('NINE1BOT_SECRET')
+      expect(seenEnv).not.toHaveProperty('OPENAI_API_KEY')
+      expect(seenEnv).not.toHaveProperty('LARK_ACCESS_TOKEN')
+    } finally {
+      restoreEnv('NINE1BOT_SECRET', originalSecret)
+      restoreEnv('OPENAI_API_KEY', originalApiKey)
+    }
+  })
+
   test('passes JSON params through relative @file arguments', async () => {
     const seen: Array<{ args: string[]; payload: unknown }> = []
     const runner: FeishuCliRunner = async (_command, args, options) => {
@@ -591,4 +630,12 @@ async function writeSkill(root: string, name: string) {
     `# ${name}`,
     '',
   ].join('\n'), 'utf8')
+}
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
 }

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -10,6 +10,7 @@ import {
   enrichFeishuPageContext,
   getFeishuAuthStatus,
   getFeishuCliVersion,
+  parseVersion,
   runFeishuCliJsonWithFile,
   type FeishuCliRunner,
 } from '../src/node'
@@ -343,6 +344,12 @@ describe('Feishu platform adapter package', () => {
       state: 'authenticated',
       tokenStatus: 'needs_refresh',
     })
+  })
+
+  test('parses lark-cli versions without regex backtracking', () => {
+    expect(parseVersion('lark-cli version 1.0.23\n')).toBe('1.0.23')
+    expect(parseVersion('lark-cli 1.0.23-beta.1+build.5\n')).toBe('1.0.23-beta.1+build.5')
+    expect(parseVersion(`lark-cli version ${'9'.repeat(10_000)}\n`)).toBe(`lark-cli version ${'9'.repeat(10_000)}`)
   })
 
   test('passes only whitelisted environment variables to lark-cli', async () => {

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -15,6 +15,13 @@ import {
 } from '../src/node'
 import type { PlatformAdapterContext } from '@nine1bot/platform-protocol'
 import { join } from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import {
+  FEISHU_CURRENT_PAGE_SKILL,
+  inspectFeishuSkillSources,
+  resolveOfficialSkillsDirectory,
+} from '../src/skills'
 
 describe('Feishu platform adapter package', () => {
   test('parses Phase 1 Feishu URL routes', () => {
@@ -125,6 +132,31 @@ describe('Feishu platform adapter package', () => {
       'template.feishu-wiki',
     ])
     expect(adapter.resourceContributions({ templateIds })?.builtinTools.enabledGroups).toContain('feishu-context')
+    expect(adapter.resourceContributions({ templateIds })?.skills.skills).toContain(FEISHU_CURRENT_PAGE_SKILL)
+  })
+
+  test('discovers companion and official skill directories', async () => {
+    await withTempDir(async (officialDirectory) => {
+      await writeSkill(officialDirectory, 'lark-doc')
+      await writeSkill(officialDirectory, 'lark-drive')
+      await writeSkill(officialDirectory, 'custom-skill')
+
+      const status = inspectFeishuSkillSources({ officialSkillsDirectory: officialDirectory })
+
+      expect(status.companion).toMatchObject({
+        exists: true,
+        readable: true,
+        skillCount: 1,
+        skills: [FEISHU_CURRENT_PAGE_SKILL],
+      })
+      expect(status.official).toMatchObject({
+        exists: true,
+        readable: true,
+        skillCount: 2,
+        skills: ['lark-doc', 'lark-drive'],
+      })
+      expect(resolveOfficialSkillsDirectory({ officialSkillsDirectory: officialDirectory })).toBe(status.official.directory)
+    })
   })
 
   test('builds stable runtime page context blocks and truncates selection', () => {
@@ -177,6 +209,91 @@ describe('Feishu platform adapter package', () => {
     expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'cli', value: 'missing' }))
     expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'auth', value: 'unknown' }))
     expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'context', value: 'auto' }))
+    expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'companion', value: FEISHU_CURRENT_PAGE_SKILL }))
+    expect(status?.cards).toContainEqual(expect.objectContaining({ id: 'skills' }))
+  })
+
+  test('handles official skills directory actions without mutating CLI auth state', async () => {
+    await withTempDir(async (officialDirectory) => {
+      await writeSkill(officialDirectory, 'lark-doc')
+      const ctx: PlatformAdapterContext = {
+        platformId: 'feishu',
+        enabled: true,
+        settings: {},
+        features: {},
+        env: { PATH: '' },
+        secrets: {
+          async get() { return undefined },
+          async set() {},
+          async delete() {},
+          async has() { return false },
+        },
+        audit: {
+          write() {},
+        },
+      }
+
+      const configure = await feishuPlatformContribution.handleAction?.('skills.configureDirectory', {
+        directory: officialDirectory,
+      }, ctx)
+      expect(configure).toMatchObject({
+        status: 'ok',
+        updatedSettings: {
+          officialSkillsDirectory: officialDirectory,
+        },
+        updatedStatus: {
+          status: 'missing',
+        },
+        data: {
+          official: {
+            skillCount: 1,
+            skills: ['lark-doc'],
+          },
+        },
+      })
+
+      const refresh = await feishuPlatformContribution.handleAction?.('skills.refreshOfficialDirectory', undefined, {
+        ...ctx,
+        settings: { officialSkillsDirectory: officialDirectory },
+      })
+      expect(refresh).toMatchObject({
+        status: 'ok',
+        data: {
+          official: {
+            skillCount: 1,
+            skills: ['lark-doc'],
+          },
+        },
+      })
+      expect(refresh?.updatedSettings).toBeUndefined()
+
+      const clear = await feishuPlatformContribution.handleAction?.('skills.configureDirectory', {
+        directory: '',
+      }, {
+        ...ctx,
+        settings: { officialSkillsDirectory: officialDirectory },
+      })
+      expect(clear).toMatchObject({
+        status: 'ok',
+        updatedSettings: {
+          officialSkillsDirectory: null,
+        },
+      })
+
+      await withTempDir(async (missingParent) => {
+        const missing = await feishuPlatformContribution.handleAction?.('skills.configureDirectory', {
+          directory: join(missingParent, 'missing'),
+        }, ctx)
+        expect(missing).toMatchObject({
+          status: 'failed',
+          data: {
+            official: {
+              exists: false,
+            },
+          },
+        })
+      })
+    })
   })
 
   test('uses verified lark-cli commands and parses auth states', async () => {
@@ -430,4 +547,27 @@ function authOk() {
     }),
     stderr: '',
   }
+}
+
+async function withTempDir<T>(fn: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), 'nine1bot-feishu-skills-'))
+  try {
+    return await fn(directory)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+async function writeSkill(root: string, name: string) {
+  const directory = join(root, name)
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, 'SKILL.md'), [
+    '---',
+    `name: ${name}`,
+    `description: ${name}`,
+    '---',
+    '',
+    `# ${name}`,
+    '',
+  ].join('\n'), 'utf8')
 }

--- a/packages/platform-feishu/test/feishu-platform.test.ts
+++ b/packages/platform-feishu/test/feishu-platform.test.ts
@@ -127,12 +127,33 @@ describe('Feishu platform adapter package', () => {
 
     expect(templateIds).toEqual(['browser-feishu', 'feishu-wiki'])
     expect(adapter.inferTemplateIds({ entry: { platform: 'feishu' }, page })).toEqual(templateIds)
-    expect(adapter.templateContextBlocks({ templateIds, page }).map((block) => block.source)).toEqual([
+    const templateBlocks = adapter.templateContextBlocks({ templateIds, page })
+    expect(templateBlocks.map((block) => block.source)).toEqual([
       'template.browser-feishu',
       'template.feishu-wiki',
     ])
-    expect(adapter.resourceContributions({ templateIds })?.builtinTools.enabledGroups).toContain('feishu-context')
-    expect(adapter.resourceContributions({ templateIds })?.skills.skills).toContain(FEISHU_CURRENT_PAGE_SKILL)
+    expect(templateBlocks[0]?.content).toEqual(expect.stringContaining('official lark-cli'))
+    expect(templateBlocks[0]?.content).toEqual(expect.stringContaining('dry-run first'))
+    expect(templateBlocks[0]?.content).toEqual(expect.stringContaining('existing Nine1Bot permissions'))
+    expect(templateBlocks[1]?.content).toEqual(expect.stringContaining('official lark-cli'))
+
+    const resources = adapter.resourceContributions({ templateIds })
+    expect(resources?.builtinTools.enabledGroups).toEqual(['feishu-context'])
+    expect(resources?.skills.skills).toEqual([FEISHU_CURRENT_PAGE_SKILL])
+  })
+
+  test('documents write guidance without adding a CLI wrapper boundary', async () => {
+    const skillText = await Bun.file(join(import.meta.dir, '..', 'skills', FEISHU_CURRENT_PAGE_SKILL, 'SKILL.md')).text()
+
+    expect(skillText).toEqual(expect.stringContaining('## Write Operations'))
+    expect(skillText).toEqual(expect.stringContaining('Target object'))
+    expect(skillText).toEqual(expect.stringContaining('Impact scope'))
+    expect(skillText).toEqual(expect.stringContaining('--dry-run'))
+    expect(skillText).toEqual(expect.stringContaining('Do not invent dry-run behavior'))
+    expect(skillText).toEqual(expect.stringContaining('Do not build a Nine1Bot-specific wrapper'))
+    expect(skillText).toEqual(expect.stringContaining('never use a wiki node token directly as a docx/file token for writes'))
+    expect(skillText).toEqual(expect.stringContaining('do not require a separate Nine1Bot high-risk API confirmation layer'))
+    expect(skillText).toEqual(expect.stringContaining('Do not ask the user to copy access tokens'))
   })
 
   test('discovers companion and official skill directories', async () => {

--- a/packages/platform-feishu/tsconfig.json
+++ b/packages/platform-feishu/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/platform-protocol/src/index.ts
+++ b/packages/platform-protocol/src/index.ts
@@ -155,6 +155,7 @@ export type PlatformSkillSourceDescriptor = {
   id: string
   directory: string
   namespace?: string
+  includeNamePrefix?: string
   visibility: 'default' | 'declared-only'
   lifecycle: PlatformRuntimeSourceLifecycle
 }

--- a/packages/platform-protocol/src/index.ts
+++ b/packages/platform-protocol/src/index.ts
@@ -172,11 +172,15 @@ export type PlatformRuntimeSourcesDescriptor = {
   skills?: PlatformSkillSourceDescriptor[]
 }
 
+export type PlatformRuntimeSourcesProvider =
+  | PlatformRuntimeSourcesDescriptor
+  | ((ctx: PlatformAdapterContext) => PlatformRuntimeSourcesDescriptor | undefined)
+
 export type PlatformAdapterContribution = {
   descriptor: PlatformDescriptor
   runtime?: {
     createAdapter: (ctx: PlatformAdapterContext) => PlatformRuntimeAdapter
-    sources?: PlatformRuntimeSourcesDescriptor
+    sources?: PlatformRuntimeSourcesProvider
   }
   getStatus?: (ctx: PlatformAdapterContext) => Promise<PlatformRuntimeStatus>
   validateConfig?: (settings: unknown, ctx: PlatformAdapterContext) => Promise<PlatformValidationResult>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,7 +3,6 @@ import {
   normalizeRuntimeEventEnvelope,
   type RuntimeEventEnvelope,
 } from './runtime-events'
-import { gitLabTemplateIdsForPage } from '@nine1bot/platform-gitlab/browser'
 import type { RequestPagePayload } from './page-context'
 
 const BASE_URL = ''  // 使用相对路径，由 vite proxy 或同源处理
@@ -81,14 +80,10 @@ function controllerEntry(page?: RequestPagePayload) {
     }
   }
 
-  const templateIds = ['default-user-template', 'browser-generic']
-  templateIds.push(...gitLabTemplateIdsForPage(page))
-
   return {
     source: 'browser-extension',
     platform: page.platform,
     mode: 'browser-sidepanel',
-    templateIds,
   }
 }
 
@@ -158,6 +153,21 @@ export interface SessionRuntimeSummary {
     modelID: string
     source?: string
   }
+}
+
+export interface ContextEnrichmentSummary {
+  platform: string
+  status: string
+  message: string
+  tone?: 'neutral' | 'success' | 'warning' | 'danger'
+}
+
+export interface MessageSendResult {
+  accepted: boolean
+  sessionId: string
+  turnSnapshotId?: string
+  busy?: boolean
+  contextEnrichment?: ContextEnrichmentSummary
 }
 
 export interface MetricsOverview {
@@ -816,7 +826,7 @@ export const api = {
     content: string,
     files?: Array<{ type: 'file'; mime: string; filename: string; url: string }>,
     pageContext?: RequestPagePayload
-  ): Promise<{ accepted: boolean; sessionId: string; turnSnapshotId?: string; busy?: boolean }> {
+  ): Promise<MessageSendResult> {
     const parts: any[] = []
 
     if (content.trim()) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1852,6 +1852,7 @@ export interface PlatformRuntimeSourceSummary {
   id: string
   directory: string
   namespace?: string
+  includeNamePrefix?: string
   visibility: string
   status: 'registered' | 'disabled' | 'error'
   error?: string

--- a/web/src/components/PlatformManager.vue
+++ b/web/src/components/PlatformManager.vue
@@ -341,6 +341,10 @@ function actionFieldError(action: PlatformActionDescriptor, key: string) {
   return actionJsonErrors[action.id]?.[key]
 }
 
+function actionFieldId(action: PlatformActionDescriptor, field: PlatformConfigField) {
+  return `platform-action-${action.id.replace(/[^\w-]/g, '-')}-${field.key.replace(/[^\w-]/g, '-')}`
+}
+
 function buildActionInput(action: PlatformActionDescriptor) {
   const values = ensureActionValues(action)
   const errors: Record<string, string> = {}
@@ -546,12 +550,13 @@ function buildActionInput(action: PlatformActionDescriptor) {
                       <span v-if="section.description" class="text-muted text-sm">{{ section.description }}</span>
                     </div>
 
-                    <label v-for="field in section.fields" :key="field.key" class="platform-field">
-                      <span class="platform-field-label">{{ field.label }}</span>
+                    <div v-for="field in section.fields" :key="field.key" class="platform-field">
+                      <label class="platform-field-label" :for="actionFieldId(action, field)">{{ field.label }}</label>
                       <span v-if="field.description" class="platform-field-desc text-muted text-sm">{{ field.description }}</span>
 
                       <select
                         v-if="field.type === 'select'"
+                        :id="actionFieldId(action, field)"
                         :value="actionTextValue(action, field.key)"
                         class="input platform-input"
                         @change="setActionTextValue(action, field, $event)"
@@ -561,6 +566,7 @@ function buildActionInput(action: PlatformActionDescriptor) {
 
                       <label v-else-if="field.type === 'boolean'" class="platform-switch inline">
                         <input
+                          :id="actionFieldId(action, field)"
                           :checked="actionBooleanValue(action, field.key)"
                           type="checkbox"
                           @change="setActionBooleanValue(action, field, $event)"
@@ -570,6 +576,7 @@ function buildActionInput(action: PlatformActionDescriptor) {
 
                       <textarea
                         v-else-if="field.type === 'string-list' || field.type === 'json'"
+                        :id="actionFieldId(action, field)"
                         :value="actionTextValue(action, field.key)"
                         class="input platform-textarea"
                         :placeholder="field.type === 'string-list' ? '每行一个值' : '{}'"
@@ -578,6 +585,7 @@ function buildActionInput(action: PlatformActionDescriptor) {
 
                       <input
                         v-else
+                        :id="actionFieldId(action, field)"
                         :value="actionTextValue(action, field.key)"
                         class="input platform-input"
                         :type="fieldInputType(field)"
@@ -587,7 +595,7 @@ function buildActionInput(action: PlatformActionDescriptor) {
                       <span v-if="actionFieldError(action, field.key)" class="platform-field-error">
                         {{ actionFieldError(action, field.key) }}
                       </span>
-                    </label>
+                    </div>
                   </div>
                 </div>
               </form>

--- a/web/src/components/PlatformManager.vue
+++ b/web/src/components/PlatformManager.vue
@@ -31,6 +31,8 @@ const enabledDraft = ref(true)
 const formValues = reactive<Record<string, string | number | boolean>>({})
 const secretClears = reactive<Record<string, boolean>>({})
 const jsonErrors = reactive<Record<string, string>>({})
+const actionFormValues = reactive<Record<string, Record<string, string | number | boolean>>>({})
+const actionJsonErrors = reactive<Record<string, Record<string, string>>>({})
 
 const configFields = computed(() => {
   return props.selectedPlatform?.config?.sections.flatMap((section) => section.fields) ?? []
@@ -51,6 +53,8 @@ function resetForm(platform: PlatformDetail | null) {
   for (const key of Object.keys(formValues)) delete formValues[key]
   for (const key of Object.keys(secretClears)) delete secretClears[key]
   for (const key of Object.keys(jsonErrors)) delete jsonErrors[key]
+  for (const key of Object.keys(actionFormValues)) delete actionFormValues[key]
+  for (const key of Object.keys(actionJsonErrors)) delete actionJsonErrors[key]
   if (!platform) return
 
   for (const field of configFields.value) {
@@ -68,6 +72,25 @@ function resetForm(platform: PlatformDetail | null) {
       formValues[field.key] = typeof value === 'number' ? value : ''
     } else {
       formValues[field.key] = typeof value === 'string' ? value : ''
+    }
+  }
+
+  for (const action of platform.actions) {
+    if (action.kind !== 'form' || !action.inputSchema) continue
+    actionFormValues[action.id] = {}
+    for (const field of actionFields(action)) {
+      const value = platform.settings[field.key]
+      if (field.type === 'string-list') {
+        actionFormValues[action.id][field.key] = Array.isArray(value) ? value.join('\n') : ''
+      } else if (field.type === 'json') {
+        actionFormValues[action.id][field.key] = value === undefined ? '' : JSON.stringify(value, null, 2)
+      } else if (field.type === 'boolean') {
+        actionFormValues[action.id][field.key] = typeof value === 'boolean' ? value : false
+      } else if (field.type === 'number') {
+        actionFormValues[action.id][field.key] = typeof value === 'number' ? value : ''
+      } else {
+        actionFormValues[action.id][field.key] = typeof value === 'string' ? value : ''
+      }
     }
   }
 }
@@ -207,6 +230,43 @@ function parseField(field: PlatformConfigField): { include: boolean; value?: unk
   return { include: true, value }
 }
 
+function parsePlainField(
+  field: PlatformConfigField,
+  values: Record<string, string | number | boolean>,
+): { include: boolean; value?: unknown; error?: string } {
+  const value = values[field.key]
+  if (field.type === 'string-list') {
+    const values = typeof value === 'string'
+      ? value.split('\n').map((item) => item.trim()).filter(Boolean)
+      : []
+    return { include: true, value: values }
+  }
+
+  if (field.type === 'json') {
+    if (typeof value !== 'string' || !value.trim()) return { include: true, value: null }
+    try {
+      return { include: true, value: JSON.parse(value) }
+    } catch {
+      return { include: false, error: 'JSON 格式不正确' }
+    }
+  }
+
+  if (field.type === 'select') {
+    return { include: true, value: typeof value === 'string' && value.trim() ? value.trim() : null }
+  }
+
+  if (field.type === 'number') {
+    if (value === '') return { include: true, value: null }
+    const numberValue = Number(value)
+    if (!Number.isFinite(numberValue)) return { include: false, error: '请输入有效数字' }
+    return { include: true, value: numberValue }
+  }
+
+  if (field.type === 'boolean') return { include: true, value: Boolean(value) }
+  if (typeof value === 'string') return { include: true, value: value.trim() }
+  return { include: true, value }
+}
+
 function buildSettingsPatch() {
   const settings: Record<string, unknown> = {}
   for (const key of Object.keys(jsonErrors)) delete jsonErrors[key]
@@ -241,12 +301,65 @@ function refreshStatus() {
 function runAction(action: PlatformActionDescriptor) {
   const platform = props.selectedPlatform
   if (!platform) return
+  const input = action.kind === 'form' ? buildActionInput(action) : undefined
+  if (input === undefined && action.kind === 'form') return
   let confirmed = false
   if (action.danger) {
     confirmed = window.confirm(`确认执行「${action.label}」？`)
     if (!confirmed) return
   }
-  emit('action', platform.id, action.id, undefined, action.danger ? confirmed : undefined)
+  emit('action', platform.id, action.id, input, action.danger ? confirmed : undefined)
+}
+
+function actionFields(action: PlatformActionDescriptor): PlatformConfigField[] {
+  return action.inputSchema?.sections.flatMap((section) => section.fields) ?? []
+}
+
+function ensureActionValues(action: PlatformActionDescriptor) {
+  if (!actionFormValues[action.id]) actionFormValues[action.id] = {}
+  return actionFormValues[action.id]
+}
+
+function actionTextValue(action: PlatformActionDescriptor, key: string) {
+  const value = ensureActionValues(action)[key]
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : ''
+}
+
+function actionBooleanValue(action: PlatformActionDescriptor, key: string) {
+  return Boolean(ensureActionValues(action)[key])
+}
+
+function setActionTextValue(action: PlatformActionDescriptor, field: PlatformConfigField, event: Event) {
+  ensureActionValues(action)[field.key] = (event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
+}
+
+function setActionBooleanValue(action: PlatformActionDescriptor, field: PlatformConfigField, event: Event) {
+  ensureActionValues(action)[field.key] = (event.target as HTMLInputElement).checked
+}
+
+function actionFieldError(action: PlatformActionDescriptor, key: string) {
+  return actionJsonErrors[action.id]?.[key]
+}
+
+function buildActionInput(action: PlatformActionDescriptor) {
+  const values = ensureActionValues(action)
+  const errors: Record<string, string> = {}
+  const input: Record<string, unknown> = {}
+  for (const field of actionFields(action)) {
+    const parsed = parsePlainField(field, values)
+    if (parsed.error) {
+      errors[field.key] = parsed.error
+      continue
+    }
+    if (parsed.include) input[field.key] = parsed.value
+  }
+
+  if (Object.keys(errors).length > 0) {
+    actionJsonErrors[action.id] = errors
+    return undefined
+  }
+  delete actionJsonErrors[action.id]
+  return input
 }
 </script>
 
@@ -404,21 +517,80 @@ function runAction(action: PlatformActionDescriptor) {
           <div v-if="selectedPlatform.actions.length" class="platform-section">
             <h5 class="platform-section-title">操作</h5>
             <div class="platform-action-list">
-              <div v-for="action in selectedPlatform.actions" :key="action.id" class="platform-action-item">
-                <div>
-                  <div class="platform-action-title">{{ action.label }}</div>
-                  <div class="platform-action-desc text-muted text-sm">{{ action.description || action.id }}</div>
+              <form
+                v-for="action in selectedPlatform.actions"
+                :key="action.id"
+                class="platform-action-item"
+                @submit.prevent="runAction(action)"
+              >
+                <div class="platform-action-header">
+                  <div>
+                    <div class="platform-action-title">{{ action.label }}</div>
+                    <div class="platform-action-desc text-muted text-sm">{{ action.description || action.id }}</div>
+                  </div>
+                  <button
+                    class="btn btn-secondary btn-sm"
+                    :class="{ danger: action.danger }"
+                    :disabled="operationLocked"
+                    type="submit"
+                  >
+                    <Play :size="13" />
+                    <span>{{ actionRunning === action.id ? '执行中' : '执行' }}</span>
+                  </button>
                 </div>
-                <button
-                  class="btn btn-secondary btn-sm"
-                  :class="{ danger: action.danger }"
-                  :disabled="operationLocked"
-                  @click="runAction(action)"
-                >
-                  <Play :size="13" />
-                  <span>{{ actionRunning === action.id ? '执行中' : '执行' }}</span>
-                </button>
-              </div>
+
+                <div v-if="action.kind === 'form' && action.inputSchema" class="platform-action-form">
+                  <div v-for="section in action.inputSchema.sections" :key="section.id" class="platform-form-section compact">
+                    <div v-if="section.title || section.description" class="platform-form-section-header">
+                      <span v-if="section.title" class="platform-form-section-title">{{ section.title }}</span>
+                      <span v-if="section.description" class="text-muted text-sm">{{ section.description }}</span>
+                    </div>
+
+                    <label v-for="field in section.fields" :key="field.key" class="platform-field">
+                      <span class="platform-field-label">{{ field.label }}</span>
+                      <span v-if="field.description" class="platform-field-desc text-muted text-sm">{{ field.description }}</span>
+
+                      <select
+                        v-if="field.type === 'select'"
+                        :value="actionTextValue(action, field.key)"
+                        class="input platform-input"
+                        @change="setActionTextValue(action, field, $event)"
+                      >
+                        <option v-for="option in field.options || []" :key="option" :value="option">{{ option }}</option>
+                      </select>
+
+                      <label v-else-if="field.type === 'boolean'" class="platform-switch inline">
+                        <input
+                          :checked="actionBooleanValue(action, field.key)"
+                          type="checkbox"
+                          @change="setActionBooleanValue(action, field, $event)"
+                        />
+                        <span>{{ actionBooleanValue(action, field.key) ? '开启' : '关闭' }}</span>
+                      </label>
+
+                      <textarea
+                        v-else-if="field.type === 'string-list' || field.type === 'json'"
+                        :value="actionTextValue(action, field.key)"
+                        class="input platform-textarea"
+                        :placeholder="field.type === 'string-list' ? '每行一个值' : '{}'"
+                        @input="setActionTextValue(action, field, $event)"
+                      ></textarea>
+
+                      <input
+                        v-else
+                        :value="actionTextValue(action, field.key)"
+                        class="input platform-input"
+                        :type="fieldInputType(field)"
+                        @input="setActionTextValue(action, field, $event)"
+                      />
+
+                      <span v-if="actionFieldError(action, field.key)" class="platform-field-error">
+                        {{ actionFieldError(action, field.key) }}
+                      </span>
+                    </label>
+                  </div>
+                </div>
+              </form>
             </div>
             <div v-if="actionResult" class="platform-alert" :class="actionResult.status === 'ok' ? 'success' : 'warning'">
               {{ actionResult.message || actionResult.status }}
@@ -673,6 +845,23 @@ function runAction(action: PlatformActionDescriptor) {
   border: 0.5px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: var(--bg-primary);
+  align-items: stretch;
+  flex-direction: column;
+}
+
+.platform-action-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.platform-action-form {
+  margin-top: var(--space-sm);
+}
+
+.platform-form-section.compact {
+  padding: 10px;
 }
 
 .platform-event {

--- a/web/src/composables/useSession.ts
+++ b/web/src/composables/useSession.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue'
-import { api, type Session, type Message, type SSEEvent, type MessagePart, type QuestionRequest, type PermissionRequest, type TodoItem, questionApi, permissionApi, SessionBusyError, setApiDirectory } from '../api/client'
+import { api, type Session, type Message, type SSEEvent, type MessagePart, type QuestionRequest, type PermissionRequest, type TodoItem, type ContextEnrichmentSummary, questionApi, permissionApi, SessionBusyError, setApiDirectory } from '../api/client'
 import { collectActivePageContext } from '../api/page-context'
 import { useParallelSessions, MAX_PARALLEL_AGENTS } from './useParallelSessions'
 
@@ -66,6 +66,50 @@ export function useSession() {
 
   // 通知定时器追踪（用于清理）
   const notificationTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+
+  function pushSessionNotification(input: {
+    sessionId: string
+    message: string
+    type?: 'success' | 'info'
+    ttlMs?: number
+  }) {
+    const session = sessions.value.find(s => s.id === input.sessionId) ?? currentSession.value
+    const notificationId = `${input.sessionId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    sessionNotifications.value.push({
+      id: notificationId,
+      sessionId: input.sessionId,
+      sessionTitle: session?.title || '会话',
+      message: input.message,
+      type: input.type ?? 'info'
+    })
+    const timerId = setTimeout(() => {
+      sessionNotifications.value = sessionNotifications.value.filter(n => n.id !== notificationId)
+      notificationTimers.delete(notificationId)
+    }, input.ttlMs ?? 5000)
+    notificationTimers.set(notificationId, timerId)
+  }
+
+  function showContextEnrichmentNotice(sessionId: string, summary?: ContextEnrichmentSummary) {
+    if (!summary || summary.platform !== 'feishu') return
+    if (summary.status === 'not_applicable') return
+    pushSessionNotification({
+      sessionId,
+      message: contextEnrichmentMessage(summary),
+      type: summary.status === 'loaded' ? 'success' : 'info',
+      ttlMs: summary.status === 'loaded' ? 3500 : 6000
+    })
+  }
+
+  function contextEnrichmentMessage(summary: ContextEnrichmentSummary) {
+    if (summary.status === 'loaded') return 'Feishu metadata loaded'
+    if (summary.status === 'visible_only') return 'Feishu visible context only'
+    if (summary.status === 'need_login') return 'Feishu metadata needs lark-cli login'
+    if (summary.status === 'need_config') return 'Feishu metadata needs lark-cli config'
+    if (summary.status === 'permission_denied') return 'Feishu metadata permission denied'
+    if (summary.status === 'timeout') return 'Feishu metadata lookup timed out'
+    if (summary.status === 'missing_cli') return 'lark-cli not found; using visible context'
+    return summary.message || 'Feishu metadata unavailable'
+  }
 
   // 外部事件处理器
   const externalEventHandlers: ((event: SSEEvent) => void)[] = []
@@ -300,7 +344,8 @@ export function useSession() {
           console.warn('Failed to collect active page context:', error)
           return undefined
         }))
-      await api.sendMessage(sessionId, content, files, pageContext)
+      const sendResult = await api.sendMessage(sessionId, content, files, pageContext)
+      showContextEnrichmentNotice(sessionId, sendResult.contextEnrichment)
     } catch (error: any) {
       // Ignore abort errors
       const errorMessage = error.message?.toLowerCase() || ''

--- a/web/test/controller-message-page-context.test.ts
+++ b/web/test/controller-message-page-context.test.ts
@@ -74,7 +74,6 @@ describe('Controller message page context', () => {
         source: 'browser-extension',
         platform: 'gitlab',
         mode: 'browser-sidepanel',
-        templateIds: ['default-user-template', 'browser-generic', 'browser-gitlab', 'gitlab-mr'],
       },
       context: {
         page,
@@ -84,6 +83,7 @@ describe('Controller message page context', () => {
         selectionContext: true,
       },
     })
+    expect(calls[0]?.body.entry.templateIds).toBeUndefined()
   })
 
   it('keeps standalone Web messages free of page context', async () => {
@@ -126,12 +126,59 @@ describe('Controller message page context', () => {
         source: 'browser-extension',
         platform: 'gitlab',
         mode: 'browser-sidepanel',
-        templateIds: ['default-user-template', 'browser-generic', 'browser-gitlab', 'gitlab-issue'],
       },
       clientCapabilities: {
         pageContext: true,
         selectionContext: false,
       },
+    })
+    expect(calls[0]?.body.entry.templateIds).toBeUndefined()
+  })
+
+  it('returns Feishu context enrichment summaries from message send', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+      const body = typeof init?.body === 'string' ? JSON.parse(init.body) : undefined
+      calls.push({
+        url,
+        method: init?.method || 'GET',
+        body,
+      })
+      return jsonResponse({
+        accepted: true,
+        sessionId: 'ses_1',
+        turnSnapshotId: 'turn_1',
+        contextEnrichment: {
+          platform: 'feishu',
+          status: 'need_login',
+          message: 'lark-cli needs Feishu login before metadata can be loaded.',
+          tone: 'warning',
+        },
+      })
+    }) as typeof fetch
+    const page: RequestPagePayload = {
+      platform: 'feishu',
+      url: 'https://gdut-topview.feishu.cn/wiki/GKw9w6TOliwkBXkqO8UcphiDnUg',
+      title: 'Wiki Doc',
+      pageType: 'feishu-wiki',
+      objectKey: 'feishu:wiki:GKw9w6TOliwkBXkqO8UcphiDnUg',
+    }
+
+    const result = await api.sendMessage('ses_1', 'hello', undefined, page)
+
+    expect(result.contextEnrichment).toMatchObject({
+      platform: 'feishu',
+      status: 'need_login',
+    })
+    expect(calls[0]?.body.entry).toEqual({
+      source: 'browser-extension',
+      platform: 'feishu',
+      mode: 'browser-sidepanel',
     })
   })
 })


### PR DESCRIPTION
﻿# 描述 / Summary

实现 Feishu/Lark 深度适配的最小闭环与后续增强：页面识别、浏览器侧边栏上下文、只读 metadata enrichment、官方 lark-* skills 外部目录协同、当前页面 companion skill、写操作提示约束，以及配置保存不打断运行中对话。

## 类型 / Type of change

- [x] 新功能 (feature)
- [x] Bug 修复 (bugfix)
- [ ] 文档 (docs)
- [ ] 重构 (refactor)
- [ ] 其他 (describe):

## 关联的 issue（如果有）/ Related issues

/

## 变更点 / What changed

- 新增 `@nine1bot/platform-feishu`，支持 Feishu/Lark URL 解析、browser page context、runtime template/resource contribution。
- 增加通过外部 `lark-cli` 获取只读页面 metadata 的降级链路，不读取 CLI token/config 内部存储。
- 增加 `feishu-current-page` companion skill，并支持官方 `lark-*` skills 外部目录注册与名称过滤。
- 完善 Platform Manager action 表单输入、runtime source 动态重载、skills 状态提示与 30 秒扫描延迟提示。
- 修复 Web 配置保存触发 instance dispose 导致运行中对话被 abort 的问题。

## 如何测试 / How to test

1. `bun test packages/platform-feishu/test/feishu-platform.test.ts`
2. `cd packages/nine1bot && bun test src/platform/manager.test.ts`
3. `bun test opencode/packages/opencode/test/controller opencode/packages/opencode/test/session/platform-page-context.test.ts opencode/packages/opencode/test/skill/platform-skill-source.test.ts`
4. `bun test opencode/packages/opencode/test/config/config.test.ts -t "updates config"`
5. `bun test opencode/packages/opencode/test/server/config-routes.test.ts`
6. `bun test opencode/packages/opencode/test/server`
7. `bun test web/test/config-api.test.ts web/test/use-settings-platforms.test.ts`
8. `cd packages/platform-feishu && bun run typecheck`
9. `cd packages/browser-extension && bun run typecheck && bun run build`
10. `cd packages/nine1bot && bun run typecheck`
11. `cd opencode/packages/opencode && bun run typecheck`

## 截图（UI 变更时提供）/ Screenshots for UI changed

暂无。

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

- `lark-cli` 仍作为外部官方组件使用，Nine1Bot 不读取 CLI token/config 内部存储。
- 官方 Feishu skills 仅从外部目录注册，并通过 `lark-*` 名称过滤避免暴露非官方 skills。
- 当前工作区仍有未提交设计文档草稿，未纳入本 PR。
