### PR TITLE
fix: stabilize browser extension tab group recovery

### DIFF
--- a/opencode/packages/opencode/src/server/server.ts
+++ b/opencode/packages/opencode/src/server/server.ts
@@ -104,6 +104,36 @@ export namespace Server {
     return headers[name] ?? headers[name.toLowerCase()] ?? headers[name.toUpperCase()]
   }
 
+  export function formatListenError(opts: { port: number; hostname: string }, cause?: unknown) {
+    const reason =
+      cause instanceof Error
+        ? cause.message
+        : typeof cause === "string"
+          ? cause
+          : ""
+
+    const portTarget =
+      opts.port === 0
+        ? `an available port on ${opts.hostname} (preferred 4096)`
+        : `${opts.hostname}:${opts.port}`
+
+    const addressInUse =
+      /EADDRINUSE|address already in use|in use/i.test(reason) ||
+      /failed to bind|failed to listen/i.test(reason)
+
+    if (!reason) {
+      return addressInUse
+        ? `Failed to start server on ${portTarget}. The port appears to already be in use.`
+        : `Failed to start server on ${portTarget}.`
+    }
+
+    if (addressInUse) {
+      return `Failed to start server on ${portTarget}. The port appears to already be in use. Original error: ${reason}`
+    }
+
+    return `Failed to start server on ${portTarget}. Original error: ${reason}`
+  }
+
   function hasForwardedHeader(headers: Record<string, string | undefined>) {
     return getHeader(headers, "forwarded") !== undefined || getHeader(headers, "x-forwarded-for") !== undefined
   }
@@ -858,12 +888,14 @@ export namespace Server {
     const tryServe = (port: number) => {
       try {
         return Bun.serve({ ...args, port })
-      } catch {
+      } catch (error) {
+        lastServeError = error
         return undefined
       }
     }
+    let lastServeError: unknown
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
-    if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
+    if (!server) throw new Error(formatListenError(opts, lastServeError))
 
     _url = server.url
     Schedule.init()

--- a/opencode/packages/opencode/src/tool/browser.ts
+++ b/opencode/packages/opencode/src/tool/browser.ts
@@ -44,6 +44,9 @@ Call this first to discover which browsers are available and get tab IDs.`,
 
     if (status.user) {
       lines.push(`User Browser: ${status.user.connected ? "Connected" : "Not connected"}`)
+      if (status.user.tabListSource && status.user.connected) {
+        lines.push(`  Tab source: ${status.user.tabListSource}`)
+      }
       if (status.user.tabs.length > 0) {
         lines.push("  Tabs:")
         for (const tab of status.user.tabs) {

--- a/opencode/packages/opencode/test/server/listen-errors.test.ts
+++ b/opencode/packages/opencode/test/server/listen-errors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+
+describe("server listen error formatting", () => {
+  test("surfaces port-in-use hints with hostname and port", () => {
+    const message = Server.formatListenError(
+      { hostname: "127.0.0.1", port: 4096 },
+      new Error("EADDRINUSE: address already in use 127.0.0.1:4096"),
+    )
+
+    expect(message).toContain("127.0.0.1:4096")
+    expect(message).toContain("already be in use")
+  })
+
+  test("describes ephemeral port fallback requests clearly", () => {
+    const message = Server.formatListenError(
+      { hostname: "127.0.0.1", port: 0 },
+      new Error("bind failed"),
+    )
+
+    expect(message).toContain("available port")
+    expect(message).toContain("preferred 4096")
+  })
+})

--- a/packages/browser-extension/src/background/index.ts
+++ b/packages/browser-extension/src/background/index.ts
@@ -37,15 +37,16 @@ function createOpenNonce(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-async function markSidePanelOpened(): Promise<void> {
-  await chrome.storage.sync.set({ [SIDE_PANEL_OPEN_NONCE_STORAGE_KEY]: createOpenNonce() })
+async function markSidePanelOpened(openNonce: string): Promise<void> {
+  await chrome.storage.sync.set({ [SIDE_PANEL_OPEN_NONCE_STORAGE_KEY]: openNonce })
 }
 
 async function openSidePanel(windowId: number): Promise<void> {
-  await activateDedicatedNine1TabGroup(windowId).catch((error) => {
+  const openNonce = createOpenNonce()
+  await activateDedicatedNine1TabGroup(windowId, { openNonce }).catch((error) => {
     console.warn('[Nine1Bot Browser Control] Failed to activate dedicated tab group:', error)
   })
-  await markSidePanelOpened().catch((error) => {
+  await markSidePanelOpened(openNonce).catch((error) => {
     console.warn('[Nine1Bot Browser Control] Failed to persist side panel open nonce:', error)
   })
   await chrome.sidePanel.open({ windowId })
@@ -77,7 +78,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     return true
   }
   if (message?.type === 'nine1bot-sidepanel-ensure-tab-group') {
-    activateDedicatedNine1TabGroup()
+    activateDedicatedNine1TabGroup(undefined, {
+      onlyIfMissing: Boolean(message.onlyIfMissing),
+    })
       .then((result) => sendResponse({ ok: true, ...result }))
       .catch((error) => {
         sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) })

--- a/packages/browser-extension/src/background/relay-client.ts
+++ b/packages/browser-extension/src/background/relay-client.ts
@@ -20,8 +20,9 @@ import { isAbortError } from '../tools/execution-context'
 import { setupDiagnosticsListeners } from './diagnostics-buffer'
 import {
   addTabToNine1Group,
+  getTabGroupDiagnostics,
   getDefaultNine1Tab,
-  getTabsInActiveNine1Group,
+  getTabsInAllActiveNine1Groups,
   getTabsInGroupByTab,
   isTabInActiveNine1Group,
   setNine1GroupActive,
@@ -77,6 +78,31 @@ interface RunningCommand {
   taskLabel?: string
 }
 
+interface RelayResyncState {
+  reason: string
+  windowId: number | null
+  attachedTabIds: number[]
+  detachedTabIds: number[]
+  updatedTabIds: number[]
+  authoritativeTabIds: number[]
+  at: number
+}
+
+interface ExtensionRelayDiagnosticsPayload {
+  authoritativeTabs: Array<{
+    tabId: number
+    windowId: number
+    title: string
+    url: string
+  }>
+  activeSessions: Array<{
+    tabId: number
+    sessionId: string
+  }>
+  tabGroups: Awaited<ReturnType<typeof getTabGroupDiagnostics>>
+  lastResync: RelayResyncState | null
+}
+
 // WebSocket 连接状态
 let ws: WebSocket | null = null
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
@@ -90,19 +116,17 @@ let lastPongAt = 0
 // 当前活动的标签页 session
 const activeSessions = new Map<number, string>() // tabId -> sessionId
 const attachedTabs = new Set<number>()
+const targetMetadataByTabId = new Map<number, { title: string; url: string }>()
+const resyncTimers = new Map<number, ReturnType<typeof setTimeout>>()
+let lastResyncState: RelayResyncState | null = null
 
 // 命令状态
 const runningCommands = new Map<number, RunningCommand>()
 const tabActiveCommandCount = new Map<number, number>()
 const tabStopRequestedAt = new Map<number, number>()
 
-/**
- * 生成唯一的 session ID
- */
-function generateSessionId(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(16))
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
-  return `session_${Date.now()}_${hex}`
+export function getManagedSessionId(tabId: number): string {
+  return `tab_${tabId}`
 }
 
 /**
@@ -154,27 +178,26 @@ function detachManagedTarget(tabId: number, reason = 'target_detached'): void {
   })
   activeSessions.delete(tabId)
   attachedTabs.delete(tabId)
+  targetMetadataByTabId.delete(tabId)
   cancelRunningCommands({ tabId, reason })
   tabActiveCommandCount.delete(tabId)
   tabStopRequestedAt.delete(tabId)
 }
 
-function detachAllActiveSessions(): void {
-  for (const tabId of Array.from(activeSessions.keys())) {
-    detachManagedTarget(tabId, 'tab_group_changed')
-  }
-}
-
 async function attachManagedTarget(tab: chrome.tabs.Tab): Promise<string | null> {
   if (!tab.id) return null
   if (!isAutomatableTabUrl(tab.url)) return null
-  if (!await isTabInActiveNine1Group(tab.id)) return null
+  if (!await isTabInActiveNine1Group(tab.id, tab.windowId)) return null
 
   const existing = activeSessions.get(tab.id)
   if (existing) return existing
 
-  const sessionId = generateSessionId()
+  const sessionId = getManagedSessionId(tab.id)
   activeSessions.set(tab.id, sessionId)
+  targetMetadataByTabId.set(tab.id, {
+    title: tab.title || '',
+    url: tab.url || '',
+  })
 
   forwardCdpEvent('Target.attachedToTarget', {
     sessionId,
@@ -183,6 +206,126 @@ async function attachManagedTarget(tab: chrome.tabs.Tab): Promise<string | null>
   })
 
   return sessionId
+}
+
+async function getLiveTab(tabId: number): Promise<chrome.tabs.Tab | null> {
+  try {
+    return await chrome.tabs.get(tabId)
+  } catch {
+    return null
+  }
+}
+
+async function listAuthoritativeManagedTabs(windowId?: number): Promise<chrome.tabs.Tab[]> {
+  const tabs = windowId === undefined
+    ? await getTabsInAllActiveNine1Groups()
+    : await getTabsInAllActiveNine1Groups().then((allTabs) => allTabs.filter((tab) => tab.windowId === windowId))
+
+  return tabs.filter((tab) => typeof tab.id === 'number' && isAutomatableTabUrl(tab.url))
+}
+
+async function resyncManagedTargets(options: {
+  windowId?: number
+  reason: string
+  forceBroadcast?: boolean
+}): Promise<RelayResyncState> {
+  const desiredTabs = await listAuthoritativeManagedTabs(options.windowId)
+  const desiredByTabId = new Map(
+    desiredTabs
+      .filter((tab) => typeof tab.id === 'number')
+      .map((tab) => [tab.id as number, tab]),
+  )
+  const desiredTabIds = new Set(desiredByTabId.keys())
+  const attachedTabIds: number[] = []
+  const detachedTabIds: number[] = []
+  const updatedTabIds: number[] = []
+
+  for (const tabId of Array.from(activeSessions.keys())) {
+    if (desiredTabIds.has(tabId)) continue
+    const tab = await getLiveTab(tabId)
+    if (options.windowId !== undefined && tab?.windowId !== options.windowId && tab !== null) {
+      continue
+    }
+    detachManagedTarget(tabId, tab === null ? 'tab_missing' : 'tab_left_nine1_group')
+    detachedTabIds.push(tabId)
+  }
+
+  for (const [tabId, tab] of desiredByTabId) {
+    const sessionId = activeSessions.get(tabId)
+    if (!sessionId) {
+      const attachedSession = await attachManagedTarget(tab)
+      if (attachedSession) {
+        attachedTabIds.push(tabId)
+      }
+      continue
+    }
+
+    if (options.forceBroadcast) {
+      targetMetadataByTabId.set(tabId, {
+        title: tab.title || '',
+        url: tab.url || '',
+      })
+      forwardCdpEvent('Target.targetInfoChanged', {
+        targetInfo: targetInfoForTab(tab),
+      })
+      updatedTabIds.push(tabId)
+      continue
+    }
+
+    const previousTarget = targetMetadataByTabId.get(tabId)
+    if (!previousTarget || previousTarget.title !== (tab.title || '') || previousTarget.url !== (tab.url || '')) {
+      targetMetadataByTabId.set(tabId, {
+        title: tab.title || '',
+        url: tab.url || '',
+      })
+      forwardCdpEvent('Target.targetInfoChanged', {
+        targetInfo: targetInfoForTab(tab),
+      })
+      updatedTabIds.push(tabId)
+    }
+  }
+
+  lastResyncState = {
+    reason: options.reason,
+    windowId: options.windowId ?? null,
+    attachedTabIds,
+    detachedTabIds,
+    updatedTabIds,
+    authoritativeTabIds: Array.from(desiredTabIds),
+    at: Date.now(),
+  }
+
+  if (isRelayConnected()) {
+    void sendExtensionHealth()
+  }
+
+  return lastResyncState
+}
+
+function scheduleManagedTargetResync(options: {
+  windowId?: number
+  reason: string
+  delayMs?: number
+  forceBroadcast?: boolean
+}): void {
+  const key = options.windowId ?? -1
+  const existing = resyncTimers.get(key)
+  if (existing) {
+    clearTimeout(existing)
+  }
+
+  const timer = setTimeout(() => {
+    resyncTimers.delete(key)
+    resyncManagedTargets({
+      windowId: options.windowId,
+      reason: options.reason,
+      forceBroadcast: options.forceBroadcast,
+    }).catch((error) => {
+      console.warn('[Relay Client] Failed to resync managed targets:', error)
+    })
+  }, options.delayMs ?? 80)
+
+  resyncTimers.set(key, timer)
 }
 
 function sendExtensionHello(): void {
@@ -203,7 +346,28 @@ function sendExtensionHello(): void {
   })
 }
 
-function sendExtensionHealth(): void {
+async function collectRelayDiagnostics(): Promise<ExtensionRelayDiagnosticsPayload> {
+  const authoritativeTabs = (await getTabsInAllActiveNine1Groups())
+    .filter((tab) => typeof tab.id === 'number' && typeof tab.windowId === 'number' && isAutomatableTabUrl(tab.url))
+    .map((tab) => ({
+      tabId: tab.id as number,
+      windowId: tab.windowId as number,
+      title: tab.title || '',
+      url: tab.url || '',
+    }))
+
+  return {
+    authoritativeTabs,
+    activeSessions: Array.from(activeSessions.entries()).map(([tabId, sessionId]) => ({
+      tabId,
+      sessionId,
+    })),
+    tabGroups: await getTabGroupDiagnostics(),
+    lastResync: lastResyncState ? { ...lastResyncState } : null,
+  }
+}
+
+async function sendExtensionHealth(): Promise<void> {
   sendToRelay({
     method: 'extension.health',
     params: {
@@ -211,6 +375,21 @@ function sendExtensionHealth(): void {
       lastPongAt,
       activeCommands: runningCommands.size,
       reconnectAttempt,
+      diagnostics: await collectRelayDiagnostics().catch((error) => ({
+        authoritativeTabs: [],
+        activeSessions: Array.from(activeSessions.entries()).map(([tabId, sessionId]) => ({ tabId, sessionId })),
+        tabGroups: {
+          currentWindowId: null,
+          bindings: {},
+          lastResolutionByWindow: {},
+          lastError: {
+            code: 'diagnostics_collection_failed',
+            message: error instanceof Error ? error.message : String(error),
+            at: Date.now(),
+          },
+        },
+        lastResync: lastResyncState ? { ...lastResyncState } : null,
+      })),
     },
   })
 }
@@ -277,6 +456,13 @@ async function markCommandStart(command: RunningCommand): Promise<void> {
   bumpTabActiveCount(command.tabId, 1)
   await addTabToNine1Group(command.tabId, command.taskLabel)
   await setNine1GroupActive(command.tabId, command.taskLabel)
+  const commandTab = await getLiveTab(command.tabId)
+  if (typeof commandTab?.windowId === 'number') {
+    await resyncManagedTargets({
+      windowId: commandTab.windowId,
+      reason: 'command_start',
+    }).catch(() => undefined)
+  }
   await sendAgentStateToTabs(command.tabId, command.taskLabel)
 }
 
@@ -293,7 +479,7 @@ function startHealthReporting(): void {
   if (healthTimer) return
   healthTimer = setInterval(() => {
     if (ws && ws.readyState === WebSocket.OPEN) {
-      sendExtensionHealth()
+      void sendExtensionHealth()
     }
   }, HEALTH_REPORT_INTERVAL)
 }
@@ -696,47 +882,56 @@ async function ensureDebuggerAttached(tabId: number): Promise<void> {
 function setupTabListeners(): void {
   // 新标签页创建
   chrome.tabs.onCreated.addListener((tab) => {
-    if (!tab.id) return
-    setTimeout(() => {
-      chrome.tabs.get(tab.id!).then((freshTab) => attachManagedTarget(freshTab)).catch(() => {})
-    }, 150)
+    if (typeof tab.windowId !== 'number') return
+    scheduleManagedTargetResync({
+      windowId: tab.windowId,
+      reason: 'tab_created',
+      delayMs: 150,
+    })
   })
 
   // 标签页更新（URL/标题变化）
   chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+    if (typeof tab.windowId !== 'number') return
+
     if (changeInfo.groupId !== undefined) {
-      if (activeSessions.has(tabId) && !await isTabInActiveNine1Group(tabId)) {
-        detachManagedTarget(tabId, 'tab_left_nine1_group')
-        return
-      }
-      await attachManagedTarget(tab).catch(() => {})
+      scheduleManagedTargetResync({
+        windowId: tab.windowId,
+        reason: 'tab_group_changed',
+        delayMs: 60,
+      })
+      return
     }
 
     if (changeInfo.url || changeInfo.title) {
-      if (!await isTabInActiveNine1Group(tabId)) {
-        detachManagedTarget(tabId, 'tab_left_nine1_group')
-        return
-      }
-      const sessionId = activeSessions.get(tabId)
-      if (!sessionId) {
-        await attachManagedTarget(tab).catch(() => {})
-        return
-      }
-      forwardCdpEvent('Target.targetInfoChanged', {
-        targetInfo: targetInfoForTab(tab),
+      scheduleManagedTargetResync({
+        windowId: tab.windowId,
+        reason: 'tab_metadata_changed',
+        delayMs: 40,
       })
     }
   })
 
   // 标签页关闭
-  chrome.tabs.onRemoved.addListener((tabId) => {
+  chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
     detachManagedTarget(tabId, 'tab_removed')
+    if (typeof removeInfo.windowId === 'number') {
+      scheduleManagedTargetResync({
+        windowId: removeInfo.windowId,
+        reason: 'tab_removed',
+        delayMs: 40,
+      })
+    }
   })
 
   // 标签页激活
   chrome.tabs.onActivated.addListener(async (activeInfo) => {
-    const tab = await chrome.tabs.get(activeInfo.tabId)
-    await attachManagedTarget(tab)
+    scheduleManagedTargetResync({
+      windowId: activeInfo.windowId,
+      reason: 'tab_activated',
+      delayMs: 40,
+      forceBroadcast: true,
+    })
   })
 }
 
@@ -744,13 +939,16 @@ function setupTabListeners(): void {
  * 发送当前 Nine1Bot 标签组信息
  */
 async function sendInitialTargets(): Promise<void> {
-  const tabs = await getTabsInActiveNine1Group()
-  for (const tab of tabs) {
-    await attachManagedTarget(tab)
-  }
+  await resyncManagedTargets({
+    reason: 'relay_connected',
+    forceBroadcast: true,
+  })
 }
 
-export async function activateDedicatedNine1TabGroup(windowId?: number): Promise<{ groupId: number | null; tabId?: number }> {
+export async function activateDedicatedNine1TabGroup(
+  windowId?: number,
+  options: { onlyIfMissing?: boolean; openNonce?: string } = {},
+): Promise<{ groupId: number | null; tabId?: number }> {
   const [activeTab] = await chrome.tabs.query({
     active: true,
     currentWindow: windowId === undefined,
@@ -761,9 +959,17 @@ export async function activateDedicatedNine1TabGroup(windowId?: number): Promise
     return { groupId: null }
   }
 
-  const groupId = await addTabToNine1Group(activeTab.id)
-  detachAllActiveSessions()
-  await sendInitialTargets()
+  const groupId = await addTabToNine1Group(activeTab.id, undefined, {
+    onlyIfMissing: options.onlyIfMissing,
+    openNonce: options.openNonce,
+  })
+  if (typeof activeTab.windowId === 'number') {
+    await resyncManagedTargets({
+      windowId: activeTab.windowId,
+      reason: options.onlyIfMissing ? 'sidepanel_ensure' : 'sidepanel_activate',
+      forceBroadcast: true,
+    })
+  }
   return { groupId, tabId: activeTab.id }
 }
 
@@ -847,10 +1053,10 @@ export function connectToRelay(url?: string): void {
       }
 
       sendExtensionHello()
-      sendExtensionHealth()
+      void sendExtensionHealth()
       startHealthReporting()
       startAgentHeartbeat()
-      sendInitialTargets()
+      void sendInitialTargets()
     }
 
     ws.onmessage = (event) => {
@@ -887,7 +1093,13 @@ function cleanup(): void {
     ws = null
   }
 
+  for (const timer of resyncTimers.values()) {
+    clearTimeout(timer)
+  }
+  resyncTimers.clear()
+
   activeSessions.clear()
+  targetMetadataByTabId.clear()
 
   for (const [commandId, command] of runningCommands) {
     command.cancelReason = 'relay_disconnected'
@@ -895,6 +1107,7 @@ function cleanup(): void {
     runningCommands.delete(commandId)
   }
   tabActiveCommandCount.clear()
+  tabStopRequestedAt.clear()
 }
 
 /**
@@ -959,6 +1172,15 @@ export function initRelayClient(): void {
   chrome.debugger.onDetach.addListener((source) => {
     if (source.tabId) {
       attachedTabs.delete(source.tabId)
+      getLiveTab(source.tabId).then((tab) => {
+        if (typeof tab?.windowId === 'number') {
+          scheduleManagedTargetResync({
+            windowId: tab.windowId,
+            reason: 'debugger_detached',
+            delayMs: 40,
+          })
+        }
+      }).catch(() => undefined)
     }
   })
 

--- a/packages/browser-extension/src/background/relay-client.ts
+++ b/packages/browser-extension/src/background/relay-client.ts
@@ -22,6 +22,7 @@ import {
   addTabToNine1Group,
   getTabGroupDiagnostics,
   getDefaultNine1Tab,
+  getTabsInActiveNine1Group,
   getTabsInAllActiveNine1Groups,
   getTabsInGroupByTab,
   isTabInActiveNine1Group,
@@ -219,7 +220,7 @@ async function getLiveTab(tabId: number): Promise<chrome.tabs.Tab | null> {
 async function listAuthoritativeManagedTabs(windowId?: number): Promise<chrome.tabs.Tab[]> {
   const tabs = windowId === undefined
     ? await getTabsInAllActiveNine1Groups()
-    : await getTabsInAllActiveNine1Groups().then((allTabs) => allTabs.filter((tab) => tab.windowId === windowId))
+    : await getTabsInActiveNine1Group(windowId)
 
   return tabs.filter((tab) => typeof tab.id === 'number' && isAutomatableTabUrl(tab.url))
 }

--- a/packages/browser-extension/src/background/tab-group-manager.ts
+++ b/packages/browser-extension/src/background/tab-group-manager.ts
@@ -1,40 +1,118 @@
-import { ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY } from '../shared/tab-group'
+import {
+  ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY,
+  ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY,
+  NINE1_TAB_GROUP_TITLE_PREFIX,
+  type ActiveNine1TabGroupBinding,
+  type ActiveNine1TabGroupBindings,
+  type TabGroupDiagnostics,
+  type TabGroupRecoverySource,
+  type TabGroupResolution,
+} from '../shared/tab-group'
 
-const NINE1_TAB_GROUP_TITLE = 'Nine1Bot'
 const NINE1_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'blue'
 
 let cleanupInstalled = false
-let activeNine1GroupId: number | null = null
+let bindingsLoaded = false
+const activeNine1Groups = new Map<number, ActiveNine1TabGroupBinding>()
+const lastResolutionByWindow = new Map<number, TabGroupResolution>()
+let lastError: TabGroupDiagnostics['lastError'] = null
 
-function formatGroupTitle(taskLabel?: string): string {
-  if (!taskLabel) return NINE1_TAB_GROUP_TITLE
-  const trimmed = taskLabel.trim()
-  if (!trimmed) return NINE1_TAB_GROUP_TITLE
-  return `${NINE1_TAB_GROUP_TITLE}: ${trimmed.slice(0, 32)}`
+interface MatchingNine1Group {
+  groupId: number
+  windowId: number
+  title: string
 }
 
-async function getGroupIdForTab(tabId: number): Promise<number | null> {
-  try {
-    const tab = await chrome.tabs.get(tabId)
-    return typeof tab.groupId === 'number' && tab.groupId >= 0 ? tab.groupId : null
-  } catch {
-    return null
+interface ResolveGroupOptions {
+  windowId?: number
+  persistRecovered?: boolean
+}
+
+interface AddTabOptions {
+  onlyIfMissing?: boolean
+  openNonce?: string
+}
+
+function formatGroupTitle(taskLabel?: string): string {
+  if (!taskLabel) return NINE1_TAB_GROUP_TITLE_PREFIX
+  const trimmed = taskLabel.trim()
+  if (!trimmed) return NINE1_TAB_GROUP_TITLE_PREFIX
+  return `${NINE1_TAB_GROUP_TITLE_PREFIX}: ${trimmed.slice(0, 32)}`
+}
+
+function isNine1GroupTitle(title?: string): boolean {
+  return typeof title === 'string' && title.startsWith(NINE1_TAB_GROUP_TITLE_PREFIX)
+}
+
+function recordError(code: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error)
+  lastError = {
+    code,
+    message,
+    at: Date.now(),
+  }
+  console.warn(`[TabGroupManager] ${code}:`, message)
+}
+
+function bindingToStorageRecord(): ActiveNine1TabGroupBindings {
+  return Object.fromEntries(
+    Array.from(activeNine1Groups.entries()).map(([windowId, binding]) => [String(windowId), { ...binding }]),
+  )
+}
+
+function setLastResolution(resolution: TabGroupResolution): void {
+  if (typeof resolution.windowId === 'number') {
+    lastResolutionByWindow.set(resolution.windowId, resolution)
   }
 }
 
 async function getTab(tabId: number): Promise<chrome.tabs.Tab | null> {
   try {
     return await chrome.tabs.get(tabId)
-  } catch {
+  } catch (error) {
+    recordError('tab_lookup_failed', error)
     return null
   }
+}
+
+async function getWindowIdForTab(tabId: number): Promise<number | null> {
+  const tab = await getTab(tabId)
+  return typeof tab?.windowId === 'number' ? tab.windowId : null
+}
+
+async function getCurrentWindowId(): Promise<number | null> {
+  try {
+    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true })
+    if (typeof activeTab?.windowId === 'number') return activeTab.windowId
+  } catch (error) {
+    recordError('current_window_query_failed', error)
+  }
+
+  try {
+    const lastFocused = await chrome.windows.getLastFocused()
+    return typeof lastFocused?.id === 'number' ? lastFocused.id : null
+  } catch (error) {
+    recordError('last_focused_window_failed', error)
+    return null
+  }
+}
+
+async function resolveWindowId(windowId?: number): Promise<number | null> {
+  if (typeof windowId === 'number') return windowId
+  return await getCurrentWindowId()
+}
+
+async function getGroupIdForTab(tabId: number): Promise<number | null> {
+  const tab = await getTab(tabId)
+  return typeof tab?.groupId === 'number' && tab.groupId >= 0 ? tab.groupId : null
 }
 
 async function getGroupWindowId(groupId: number): Promise<number | null> {
   try {
     const group = await chrome.tabGroups.get(groupId)
     return typeof group.windowId === 'number' ? group.windowId : null
-  } catch {
+  } catch (error) {
+    recordError('group_window_lookup_failed', error)
     return null
   }
 }
@@ -48,10 +126,13 @@ async function groupExists(groupId: number): Promise<boolean> {
   }
 }
 
-async function updateGroup(groupId: number, options: {
-  collapsed?: boolean
-  taskLabel?: string
-}): Promise<void> {
+async function updateGroup(
+  groupId: number,
+  options: {
+    collapsed?: boolean
+    taskLabel?: string
+  },
+): Promise<void> {
   await chrome.tabGroups.update(groupId, {
     title: formatGroupTitle(options.taskLabel),
     color: NINE1_TAB_GROUP_COLOR,
@@ -59,112 +140,377 @@ async function updateGroup(groupId: number, options: {
   })
 }
 
-async function persistActiveGroup(groupId: number | null): Promise<void> {
-  activeNine1GroupId = groupId
+async function persistBindings(): Promise<void> {
   try {
-    if (groupId === null) {
-      await chrome.storage.local.remove(ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY)
-    } else {
-      await chrome.storage.local.set({ [ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]: groupId })
-    }
-  } catch {
-    // Storage is only a coordination convenience for side panel pages.
+    await chrome.storage.local.set({
+      [ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]: bindingToStorageRecord(),
+    })
+    await chrome.storage.local.remove(ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY)
+  } catch (error) {
+    recordError('persist_bindings_failed', error)
   }
 }
 
-export async function getActiveNine1GroupId(): Promise<number | null> {
-  if (activeNine1GroupId !== null && await groupExists(activeNine1GroupId)) {
-    return activeNine1GroupId
-  }
-
-  try {
-    const stored = await chrome.storage.local.get({ [ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]: -1 })
-    const groupId = stored[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]
-    if (typeof groupId === 'number' && groupId >= 0 && await groupExists(groupId)) {
-      activeNine1GroupId = groupId
-      return groupId
-    }
-  } catch {
-    // ignore storage failures
-  }
-
-  await persistActiveGroup(null)
-  return null
+function setBinding(binding: ActiveNine1TabGroupBinding | null): void {
+  if (!binding) return
+  activeNine1Groups.set(binding.windowId, binding)
 }
 
-export async function createDedicatedNine1Group(tabId: number, taskLabel?: string): Promise<number | null> {
+async function persistBinding(
+  windowId: number,
+  groupId: number | null,
+  options: { openNonce?: string } = {},
+): Promise<void> {
+  if (groupId === null) {
+    activeNine1Groups.delete(windowId)
+    await persistBindings()
+    return
+  }
+
+  setBinding({
+    groupId,
+    windowId,
+    openNonce: options.openNonce,
+    updatedAt: Date.now(),
+  })
+  await persistBindings()
+}
+
+function normalizeStoredBindings(value: unknown): ActiveNine1TabGroupBindings {
+  if (!value || typeof value !== 'object') return {}
+  const normalized: ActiveNine1TabGroupBindings = {}
+
+  for (const [windowKey, candidate] of Object.entries(value as Record<string, unknown>)) {
+    if (!candidate || typeof candidate !== 'object') continue
+    const record = candidate as Partial<ActiveNine1TabGroupBinding>
+    if (
+      typeof record.groupId !== 'number'
+      || record.groupId < 0
+      || typeof record.windowId !== 'number'
+      || record.windowId < 0
+    ) {
+      continue
+    }
+    normalized[windowKey] = {
+      groupId: record.groupId,
+      windowId: record.windowId,
+      openNonce: typeof record.openNonce === 'string' && record.openNonce.trim() ? record.openNonce : undefined,
+      updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : Date.now(),
+    }
+  }
+
+  return normalized
+}
+
+async function loadBindings(): Promise<void> {
+  if (bindingsLoaded) return
+  bindingsLoaded = true
+
+  try {
+    const stored = await chrome.storage.local.get({
+      [ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]: {},
+      [ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]: -1,
+    })
+
+    const nextBindings = normalizeStoredBindings(stored[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY])
+    for (const binding of Object.values(nextBindings)) {
+      activeNine1Groups.set(binding.windowId, binding)
+    }
+
+    if (activeNine1Groups.size > 0) return
+
+    const legacyGroupId = stored[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]
+    if (typeof legacyGroupId !== 'number' || legacyGroupId < 0) return
+    if (!(await groupExists(legacyGroupId))) return
+
+    const groupWindowId = await getGroupWindowId(legacyGroupId)
+    if (groupWindowId === null) return
+
+    setBinding({
+      groupId: legacyGroupId,
+      windowId: groupWindowId,
+      updatedAt: Date.now(),
+    })
+    await persistBindings()
+  } catch (error) {
+    recordError('load_bindings_failed', error)
+  }
+}
+
+async function findMatchingNine1Groups(windowId: number): Promise<MatchingNine1Group[]> {
+  try {
+    const tabs = await chrome.tabs.query({ windowId })
+    const groupIds = Array.from(
+      new Set(
+        tabs
+          .map((tab) => tab.groupId)
+          .filter((groupId): groupId is number => typeof groupId === 'number' && groupId >= 0),
+      ),
+    )
+
+    const groups = await Promise.all(
+      groupIds.map(async (groupId) => {
+        try {
+          const group = await chrome.tabGroups.get(groupId)
+          if (!isNine1GroupTitle(group.title)) return null
+          return {
+            groupId,
+            windowId: group.windowId,
+            title: group.title ?? '',
+          } satisfies MatchingNine1Group
+        } catch {
+          return null
+        }
+      }),
+    )
+
+    return groups.filter((group): group is MatchingNine1Group => group !== null)
+  } catch (error) {
+    recordError('matching_group_scan_failed', error)
+    return []
+  }
+}
+
+export function pickRecoverableNine1Group(options: {
+  activeTabGroupId: number | null
+  matchingGroupIds: number[]
+  hadStoredBinding: boolean
+}): {
+  groupId: number | null
+  recoverySource: TabGroupRecoverySource
+  issueCode?: string
+} {
+  const { activeTabGroupId, matchingGroupIds, hadStoredBinding } = options
+
+  if (
+    typeof activeTabGroupId === 'number'
+    && matchingGroupIds.includes(activeTabGroupId)
+  ) {
+    return {
+      groupId: activeTabGroupId,
+      recoverySource: 'active-tab-match',
+    }
+  }
+
+  if (matchingGroupIds.length === 1) {
+    return {
+      groupId: matchingGroupIds[0] ?? null,
+      recoverySource: 'single-title-match',
+    }
+  }
+
+  if (matchingGroupIds.length > 1) {
+    return {
+      groupId: null,
+      recoverySource: 'none',
+      issueCode: 'ambiguous_matching_groups',
+    }
+  }
+
+  return {
+    groupId: null,
+    recoverySource: 'none',
+    issueCode: hadStoredBinding ? 'group_binding_stale' : 'no_active_group',
+  }
+}
+
+async function resolveActiveGroup(options: ResolveGroupOptions = {}): Promise<TabGroupResolution> {
+  await loadBindings()
+
+  const effectiveWindowId = await resolveWindowId(options.windowId)
+  if (effectiveWindowId === null) {
+    const resolution: TabGroupResolution = {
+      windowId: null,
+      groupId: null,
+      binding: null,
+      recoverySource: 'none',
+      issueCode: 'window_unavailable',
+      matchedGroupIds: [],
+      resolvedAt: Date.now(),
+    }
+    return resolution
+  }
+
+  const storedBinding = activeNine1Groups.get(effectiveWindowId) ?? null
+  if (storedBinding && await groupExists(storedBinding.groupId)) {
+    const resolution: TabGroupResolution = {
+      windowId: effectiveWindowId,
+      groupId: storedBinding.groupId,
+      binding: { ...storedBinding },
+      recoverySource: 'stored',
+      matchedGroupIds: [storedBinding.groupId],
+      resolvedAt: Date.now(),
+    }
+    setLastResolution(resolution)
+    return resolution
+  }
+
+  if (storedBinding) {
+    activeNine1Groups.delete(effectiveWindowId)
+    await persistBindings()
+  }
+
+  const matchingGroups = await findMatchingNine1Groups(effectiveWindowId)
+  const [activeTab] = await chrome.tabs.query({ active: true, windowId: effectiveWindowId }).catch(() => [])
+  const selection = pickRecoverableNine1Group({
+    activeTabGroupId:
+      typeof activeTab?.groupId === 'number' && activeTab.groupId >= 0
+        ? activeTab.groupId
+        : null,
+    matchingGroupIds: matchingGroups.map((group) => group.groupId),
+    hadStoredBinding: Boolean(storedBinding),
+  })
+
+  if (selection.groupId !== null && options.persistRecovered !== false) {
+    await persistBinding(effectiveWindowId, selection.groupId)
+  }
+
+  const binding = selection.groupId === null
+    ? null
+    : activeNine1Groups.get(effectiveWindowId) ?? {
+      groupId: selection.groupId,
+      windowId: effectiveWindowId,
+      updatedAt: Date.now(),
+    }
+
+  const resolution: TabGroupResolution = {
+    windowId: effectiveWindowId,
+    groupId: selection.groupId,
+    binding,
+    recoverySource: selection.recoverySource,
+    issueCode: selection.issueCode,
+    matchedGroupIds: matchingGroups.map((group) => group.groupId),
+    resolvedAt: Date.now(),
+  }
+  setLastResolution(resolution)
+  return resolution
+}
+
+export async function getActiveNine1GroupId(windowId?: number): Promise<number | null> {
+  const resolution = await resolveActiveGroup({ windowId })
+  return resolution.groupId
+}
+
+export async function createDedicatedNine1Group(
+  tabId: number,
+  taskLabel?: string,
+  options: { openNonce?: string } = {},
+): Promise<number | null> {
+  const tab = await getTab(tabId)
+  if (!tab?.id || typeof tab.windowId !== 'number') return null
+
   try {
     const groupId = await chrome.tabs.group({ tabIds: [tabId] })
     await updateGroup(groupId, { collapsed: false, taskLabel })
-    await persistActiveGroup(groupId)
+    await persistBinding(tab.windowId, groupId, { openNonce: options.openNonce })
+    setLastResolution({
+      windowId: tab.windowId,
+      groupId,
+      binding: activeNine1Groups.get(tab.windowId) ?? null,
+      recoverySource: 'stored',
+      matchedGroupIds: [groupId],
+      resolvedAt: Date.now(),
+    })
     return groupId
-  } catch {
+  } catch (error) {
+    recordError('create_dedicated_group_failed', error)
     return null
   }
 }
 
-export async function addTabToNine1Group(tabId: number, taskLabel?: string): Promise<number | null> {
-  try {
-    const tab = await getTab(tabId)
-    if (!tab) return null
+export async function addTabToNine1Group(
+  tabId: number,
+  taskLabel?: string,
+  options: AddTabOptions = {},
+): Promise<number | null> {
+  const tab = await getTab(tabId)
+  if (!tab?.id || typeof tab.windowId !== 'number') return null
 
-    let groupId = await getActiveNine1GroupId()
-    if (groupId === null) {
-      return await createDedicatedNine1Group(tabId, taskLabel)
+  try {
+    const resolution = await resolveActiveGroup({ windowId: tab.windowId })
+    let groupId = resolution.groupId
+
+    if (options.onlyIfMissing && groupId !== null) {
+      await updateGroup(groupId, { collapsed: false, taskLabel })
+      return groupId
     }
 
-    const groupWindowId = await getGroupWindowId(groupId)
-    if (groupWindowId !== null && groupWindowId !== tab.windowId) {
-      return await createDedicatedNine1Group(tabId, taskLabel)
+    if (groupId === null) {
+      return await createDedicatedNine1Group(tabId, taskLabel, { openNonce: options.openNonce })
     }
 
     const existingGroupId = await getGroupIdForTab(tabId)
     if (existingGroupId !== groupId) {
       groupId = await chrome.tabs.group({ tabIds: [tabId], groupId })
-      await persistActiveGroup(groupId)
+      await persistBinding(tab.windowId, groupId, { openNonce: options.openNonce })
     }
 
     await updateGroup(groupId, { collapsed: false, taskLabel })
     return groupId
-  } catch {
+  } catch (error) {
+    recordError('add_tab_to_group_failed', error)
     return null
   }
 }
 
-export async function isTabInActiveNine1Group(tabId: number): Promise<boolean> {
-  const activeGroupId = await getActiveNine1GroupId()
+export async function isTabInActiveNine1Group(tabId: number, windowId?: number): Promise<boolean> {
+  const tab = await getTab(tabId)
+  if (!tab) return false
+  const activeGroupId = await getActiveNine1GroupId(windowId ?? tab.windowId)
   if (activeGroupId === null) return false
-  return await getGroupIdForTab(tabId) === activeGroupId
+  return tab.groupId === activeGroupId
 }
 
-export async function getTabsInActiveNine1Group(): Promise<chrome.tabs.Tab[]> {
-  const groupId = await getActiveNine1GroupId()
-  if (groupId === null) return []
+export async function getTabsInActiveNine1Group(windowId?: number): Promise<chrome.tabs.Tab[]> {
+  const resolution = await resolveActiveGroup({ windowId })
+  if (resolution.groupId === null) return []
   try {
-    return await chrome.tabs.query({ groupId })
-  } catch {
+    return await chrome.tabs.query({ groupId: resolution.groupId, windowId: resolution.windowId ?? undefined })
+  } catch (error) {
+    recordError('active_group_tabs_query_failed', error)
+    return []
+  }
+}
+
+export async function getTabsInAllActiveNine1Groups(): Promise<chrome.tabs.Tab[]> {
+  try {
+    const windows = await chrome.windows.getAll({ populate: false })
+    const tabs = await Promise.all(
+      windows
+        .map((window) => window.id)
+        .filter((windowId): windowId is number => typeof windowId === 'number')
+        .map((windowId) => getTabsInActiveNine1Group(windowId)),
+    )
+    return tabs.flat()
+  } catch (error) {
+    recordError('all_active_group_tabs_query_failed', error)
     return []
   }
 }
 
 export async function getTabsInGroupByTab(tabId: number): Promise<number[]> {
+  const tab = await getTab(tabId)
+  if (!tab?.id) return [tabId]
+
   try {
-    if (!await isTabInActiveNine1Group(tabId)) return [tabId]
-    const tabs = await getTabsInActiveNine1Group()
+    if (!await isTabInActiveNine1Group(tabId, tab.windowId)) return [tabId]
+    const tabs = await getTabsInActiveNine1Group(tab.windowId)
     const tabIds = tabs
-      .map((tab) => tab.id)
+      .map((candidate) => candidate.id)
       .filter((candidate): candidate is number => typeof candidate === 'number')
     return tabIds.length > 0 ? tabIds : [tabId]
-  } catch {
+  } catch (error) {
+    recordError('group_tabs_by_tab_failed', error)
     return [tabId]
   }
 }
 
 export async function getDefaultNine1Tab(windowId?: number): Promise<chrome.tabs.Tab | null> {
-  const tabs = await getTabsInActiveNine1Group()
+  const effectiveWindowId = await resolveWindowId(windowId)
+  const tabs = await getTabsInActiveNine1Group(effectiveWindowId ?? undefined)
   if (tabs.length === 0) return null
 
-  const activeInWindow = tabs.find((tab) => tab.active && (windowId === undefined || tab.windowId === windowId))
+  const activeInWindow = tabs.find((tab) => tab.active && (effectiveWindowId === null || tab.windowId === effectiveWindowId))
   if (activeInWindow) return activeInWindow
 
   const active = tabs.find((tab) => tab.active)
@@ -173,32 +519,59 @@ export async function getDefaultNine1Tab(windowId?: number): Promise<chrome.tabs
 
 export async function setNine1GroupActive(tabId: number, taskLabel?: string): Promise<void> {
   try {
-    if (!await isTabInActiveNine1Group(tabId)) return
-    const groupId = await getActiveNine1GroupId()
+    const tab = await getTab(tabId)
+    if (!tab?.id || typeof tab.windowId !== 'number') return
+    if (!await isTabInActiveNine1Group(tabId, tab.windowId)) return
+    const groupId = await getActiveNine1GroupId(tab.windowId)
     if (groupId === null) return
     await updateGroup(groupId, { collapsed: false, taskLabel })
-  } catch {
-    // ignore tab/group lifecycle races
+  } catch (error) {
+    recordError('set_group_active_failed', error)
   }
 }
 
 export async function setNine1GroupIdle(tabId: number): Promise<void> {
   try {
-    if (!await isTabInActiveNine1Group(tabId)) return
-    const groupId = await getActiveNine1GroupId()
+    const tab = await getTab(tabId)
+    if (!tab?.id || typeof tab.windowId !== 'number') return
+    if (!await isTabInActiveNine1Group(tabId, tab.windowId)) return
+    const groupId = await getActiveNine1GroupId(tab.windowId)
     if (groupId === null) return
     await updateGroup(groupId, { collapsed: true })
-  } catch {
-    // ignore tab/group lifecycle races
+  } catch (error) {
+    recordError('set_group_idle_failed', error)
   }
 }
 
-async function cleanupMissingActiveGroup(): Promise<void> {
-  const groupId = await getActiveNine1GroupId()
-  if (groupId === null) return
-  const tabs = await getTabsInActiveNine1Group()
-  if (tabs.length === 0) {
-    await persistActiveGroup(null)
+async function cleanupMissingActiveGroups(): Promise<void> {
+  await loadBindings()
+  const windowIds = Array.from(activeNine1Groups.keys())
+
+  for (const windowId of windowIds) {
+    const binding = activeNine1Groups.get(windowId)
+    if (!binding) continue
+    if (await groupExists(binding.groupId)) continue
+    await persistBinding(windowId, null)
+  }
+}
+
+export async function getTabGroupDiagnostics(windowId?: number): Promise<TabGroupDiagnostics> {
+  await loadBindings()
+  const currentWindowId = await resolveWindowId(windowId)
+  if (currentWindowId !== null && !lastResolutionByWindow.has(currentWindowId)) {
+    await resolveActiveGroup({ windowId: currentWindowId, persistRecovered: false })
+  }
+
+  return {
+    currentWindowId,
+    bindings: bindingToStorageRecord(),
+    lastResolutionByWindow: Object.fromEntries(
+      Array.from(lastResolutionByWindow.entries()).map(([resolvedWindowId, resolution]) => [
+        String(resolvedWindowId),
+        { ...resolution },
+      ]),
+    ),
+    lastError: lastError ? { ...lastError } : null,
   }
 }
 
@@ -207,8 +580,16 @@ export function setupTabGroupCleanup(): void {
   cleanupInstalled = true
 
   chrome.tabs.onRemoved.addListener(() => {
-    cleanupMissingActiveGroup().catch(() => {
-      // Tab groups self-heal as tabs close; this keeps setup idempotent.
+    cleanupMissingActiveGroups().catch((error) => {
+      recordError('cleanup_missing_active_group_failed', error)
     })
   })
+}
+
+export function __resetTabGroupManagerStateForTests(): void {
+  cleanupInstalled = false
+  bindingsLoaded = false
+  activeNine1Groups.clear()
+  lastResolutionByWindow.clear()
+  lastError = null
 }

--- a/packages/browser-extension/src/background/tab-group-manager.ts
+++ b/packages/browser-extension/src/background/tab-group-manager.ts
@@ -12,6 +12,7 @@ import {
 const NINE1_TAB_GROUP_COLOR: chrome.tabGroups.ColorEnum = 'blue'
 
 let cleanupInstalled = false
+let bindingsSyncInstalled = false
 let bindingsLoaded = false
 const activeNine1Groups = new Map<number, ActiveNine1TabGroupBinding>()
 const lastResolutionByWindow = new Map<number, TabGroupResolution>()
@@ -63,6 +64,13 @@ function bindingToStorageRecord(): ActiveNine1TabGroupBindings {
 function setLastResolution(resolution: TabGroupResolution): void {
   if (typeof resolution.windowId === 'number') {
     lastResolutionByWindow.set(resolution.windowId, resolution)
+  }
+}
+
+function replaceBindings(nextBindings: ActiveNine1TabGroupBindings): void {
+  activeNine1Groups.clear()
+  for (const binding of Object.values(nextBindings)) {
+    activeNine1Groups.set(binding.windowId, binding)
   }
 }
 
@@ -151,6 +159,38 @@ async function persistBindings(): Promise<void> {
   }
 }
 
+function installBindingsSyncListener(): void {
+  if (bindingsSyncInstalled) return
+  bindingsSyncInstalled = true
+
+  chrome.storage.onChanged?.addListener((changes, areaName) => {
+    if (areaName !== 'local') return
+
+    const bindingsChange = changes[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]
+    if (bindingsChange) {
+      replaceBindings(normalizeStoredBindings(bindingsChange.newValue))
+      return
+    }
+
+    const legacyChange = changes[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]
+    if (!legacyChange) return
+
+    const nextLegacyValue = legacyChange.newValue
+    if (typeof nextLegacyValue !== 'number' || nextLegacyValue < 0) return
+
+    getGroupWindowId(nextLegacyValue).then((windowId) => {
+      if (windowId === null) return
+      activeNine1Groups.set(windowId, {
+        groupId: nextLegacyValue,
+        windowId,
+        updatedAt: Date.now(),
+      })
+    }).catch((error) => {
+      recordError('legacy_binding_sync_failed', error)
+    })
+  })
+}
+
 function setBinding(binding: ActiveNine1TabGroupBinding | null): void {
   if (!binding) return
   activeNine1Groups.set(binding.windowId, binding)
@@ -205,6 +245,7 @@ function normalizeStoredBindings(value: unknown): ActiveNine1TabGroupBindings {
 async function loadBindings(): Promise<void> {
   if (bindingsLoaded) return
   bindingsLoaded = true
+  installBindingsSyncListener()
 
   try {
     const stored = await chrome.storage.local.get({
@@ -213,9 +254,7 @@ async function loadBindings(): Promise<void> {
     })
 
     const nextBindings = normalizeStoredBindings(stored[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY])
-    for (const binding of Object.values(nextBindings)) {
-      activeNine1Groups.set(binding.windowId, binding)
-    }
+    replaceBindings(nextBindings)
 
     if (activeNine1Groups.size > 0) return
 
@@ -234,6 +273,18 @@ async function loadBindings(): Promise<void> {
     await persistBindings()
   } catch (error) {
     recordError('load_bindings_failed', error)
+  }
+}
+
+export async function refreshBindingsFromStorage(): Promise<void> {
+  try {
+    installBindingsSyncListener()
+    const stored = await chrome.storage.local.get({
+      [ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]: {},
+    })
+    replaceBindings(normalizeStoredBindings(stored[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]))
+  } catch (error) {
+    recordError('refresh_bindings_from_storage_failed', error)
   }
 }
 
@@ -332,7 +383,10 @@ async function resolveActiveGroup(options: ResolveGroupOptions = {}): Promise<Ta
   }
 
   const storedBinding = activeNine1Groups.get(effectiveWindowId) ?? null
-  if (storedBinding && await groupExists(storedBinding.groupId)) {
+  const storedBindingWindowId = storedBinding
+    ? await getGroupWindowId(storedBinding.groupId)
+    : null
+  if (storedBinding && storedBindingWindowId === effectiveWindowId) {
     const resolution: TabGroupResolution = {
       windowId: effectiveWindowId,
       groupId: storedBinding.groupId,

--- a/packages/browser-extension/src/shared/tab-group.ts
+++ b/packages/browser-extension/src/shared/tab-group.ts
@@ -1,1 +1,39 @@
 export const ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY = 'activeNine1TabGroupId'
+export const ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY = 'activeNine1TabGroups'
+export const NINE1_TAB_GROUP_TITLE_PREFIX = 'Nine1Bot'
+
+export interface ActiveNine1TabGroupBinding {
+  groupId: number
+  windowId: number
+  openNonce?: string
+  updatedAt: number
+}
+
+export type ActiveNine1TabGroupBindings = Record<string, ActiveNine1TabGroupBinding>
+
+export type TabGroupRecoverySource =
+  | 'stored'
+  | 'active-tab-match'
+  | 'single-title-match'
+  | 'none'
+
+export interface TabGroupResolution {
+  windowId: number | null
+  groupId: number | null
+  binding: ActiveNine1TabGroupBinding | null
+  recoverySource: TabGroupRecoverySource
+  issueCode?: string
+  matchedGroupIds: number[]
+  resolvedAt: number
+}
+
+export interface TabGroupDiagnostics {
+  currentWindowId: number | null
+  bindings: ActiveNine1TabGroupBindings
+  lastResolutionByWindow: Record<string, TabGroupResolution>
+  lastError: {
+    code: string
+    message: string
+    at: number
+  } | null
+}

--- a/packages/browser-extension/src/sidepanel/index.ts
+++ b/packages/browser-extension/src/sidepanel/index.ts
@@ -9,7 +9,11 @@ import {
   readStoredServerOrigin,
   writeStoredServerOrigin,
 } from '../shared/server-config'
-import { ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY } from '../shared/tab-group'
+import {
+  ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY,
+  ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY,
+} from '../shared/tab-group'
+import { getDefaultNine1Tab } from '../background/tab-group-manager'
 
 let currentFrameOrigin = ''
 let currentServerOrigin = ''
@@ -347,25 +351,14 @@ async function collectActiveTabPageContext(): Promise<unknown | undefined> {
 }
 
 async function getActiveNine1GroupTab(): Promise<chrome.tabs.Tab | undefined> {
-  try {
-    const stored = await chrome.storage.local.get({ [ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]: -1 })
-    const groupId = stored[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]
-    if (typeof groupId !== 'number' || groupId < 0) return undefined
-
-    const tabs = await chrome.tabs.query({ groupId })
-    if (tabs.length === 0) return undefined
-
-    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true })
-    if (activeTab?.id && tabs.some((tab) => tab.id === activeTab.id)) return activeTab
-
-    return tabs.find((tab) => tab.active) ?? tabs[0]
-  } catch {
-    return undefined
-  }
+  return (await getDefaultNine1Tab()) ?? undefined
 }
 
 async function ensureDedicatedTabGroup(): Promise<void> {
-  await chrome.runtime.sendMessage({ type: 'nine1bot-sidepanel-ensure-tab-group' }).catch(() => undefined)
+  await chrome.runtime.sendMessage({
+    type: 'nine1bot-sidepanel-ensure-tab-group',
+    onlyIfMissing: true,
+  }).catch(() => undefined)
 }
 
 function notifyFramePageChanged(): void {
@@ -394,7 +387,13 @@ function setupActivePageListener(): void {
   })
 
   chrome.storage.onChanged.addListener((changes, areaName) => {
-    if (areaName === 'local' && changes[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]) {
+    if (
+      areaName === 'local'
+      && (
+        changes[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]
+        || changes[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]
+      )
+    ) {
       scheduleFramePageChanged()
     }
   })

--- a/packages/browser-extension/src/sidepanel/index.ts
+++ b/packages/browser-extension/src/sidepanel/index.ts
@@ -13,7 +13,7 @@ import {
   ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY,
   ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY,
 } from '../shared/tab-group'
-import { getDefaultNine1Tab } from '../background/tab-group-manager'
+import { getDefaultNine1Tab, refreshBindingsFromStorage } from '../background/tab-group-manager'
 
 let currentFrameOrigin = ''
 let currentServerOrigin = ''
@@ -351,6 +351,7 @@ async function collectActiveTabPageContext(): Promise<unknown | undefined> {
 }
 
 async function getActiveNine1GroupTab(): Promise<chrome.tabs.Tab | undefined> {
+  await refreshBindingsFromStorage()
   return (await getDefaultNine1Tab()) ?? undefined
 }
 

--- a/packages/browser-extension/src/tools/tabs.ts
+++ b/packages/browser-extension/src/tools/tabs.ts
@@ -1,5 +1,5 @@
 import type { ToolDefinition, ToolResult } from './index'
-import { addTabToNine1Group, getDefaultNine1Tab, getTabsInActiveNine1Group } from '../background/tab-group-manager'
+import { addTabToNine1Group, getDefaultNine1Tab, getTabGroupDiagnostics, getTabsInActiveNine1Group } from '../background/tab-group-manager'
 
 interface TabsContextArgs {
   createIfEmpty?: boolean
@@ -82,6 +82,15 @@ export const tabsContextTool = {
 
       const activeTab = await getDefaultNine1Tab()
       const automatableTabs = managedTabs.filter((tab) => isAutomatableTabUrl(tab.url))
+      const diagnostics = await getTabGroupDiagnostics(activeTab?.windowId)
+      const resolution = diagnostics.currentWindowId !== null
+        ? diagnostics.lastResolutionByWindow[String(diagnostics.currentWindowId)] ?? null
+        : null
+      const reasonCode = automatableTabs.length > 0
+        ? 'ok'
+        : managedTabs.length > 0
+          ? 'no_automatable_tabs'
+          : resolution?.issueCode ?? 'no_active_group'
 
       return {
         content: [
@@ -93,6 +102,15 @@ export const tabsContextTool = {
                 activeTab: activeTab ? serializeTab(activeTab) : null,
                 allTabs: includeAll ? automatableTabs.map(serializeTab) : undefined,
                 totalMcpTabs: managedTabs.length,
+                totalAutomatableTabs: automatableTabs.length,
+                tabScanStatus: {
+                  source: 'authoritative_group_scan',
+                  reasonCode,
+                  recoverySource: resolution?.recoverySource ?? 'none',
+                  windowId: diagnostics.currentWindowId,
+                  matchedGroupIds: resolution?.matchedGroupIds ?? [],
+                },
+                diagnostics,
               },
               null,
               2

--- a/packages/browser-extension/test/tab-group-manager.test.ts
+++ b/packages/browser-extension/test/tab-group-manager.test.ts
@@ -8,6 +8,7 @@ import {
   __resetTabGroupManagerStateForTests,
   getActiveNine1GroupId,
   getTabGroupDiagnostics,
+  refreshBindingsFromStorage,
 } from '../src/background/tab-group-manager'
 
 interface MockTab {
@@ -32,11 +33,13 @@ const state: {
   groups: Map<number, MockGroup>
   storage: Record<string, unknown>
   currentWindowId: number
+  storageListeners: Array<(changes: Record<string, { oldValue?: unknown; newValue?: unknown }>, areaName: string) => void>
 } = {
   tabs: new Map(),
   groups: new Map(),
   storage: {},
   currentWindowId: 1,
+  storageListeners: [],
 }
 
 function resetChromeState(): void {
@@ -44,6 +47,7 @@ function resetChromeState(): void {
   state.groups.clear()
   state.storage = {}
   state.currentWindowId = 1
+  state.storageListeners = []
   __resetTabGroupManagerStateForTests()
 }
 
@@ -68,13 +72,31 @@ beforeEach(() => {
           }
         },
         async set(values: Record<string, unknown>) {
+          const changes = Object.fromEntries(
+            Object.entries(values).map(([key, newValue]) => [
+              key,
+              { oldValue: state.storage[key], newValue },
+            ]),
+          )
           state.storage = {
             ...state.storage,
             ...values,
           }
+          for (const listener of state.storageListeners) {
+            listener(changes, 'local')
+          }
         },
         async remove(key: string) {
+          const oldValue = state.storage[key]
           delete state.storage[key]
+          for (const listener of state.storageListeners) {
+            listener({ [key]: { oldValue, newValue: undefined } }, 'local')
+          }
+        },
+      },
+      onChanged: {
+        addListener(listener: (changes: Record<string, { oldValue?: unknown; newValue?: unknown }>, areaName: string) => void) {
+          state.storageListeners.push(listener)
         },
       },
     },
@@ -175,6 +197,26 @@ describe('tab group manager recovery', () => {
     expect(diagnostics.lastResolutionByWindow['1']?.recoverySource).toBe('active-tab-match')
   })
 
+  test('rejects stored bindings when the group moved to another window', async () => {
+    setGroups([
+      { id: 12, windowId: 2, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: moved` },
+      { id: 13, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: local` },
+    ])
+    setTabs([
+      { id: 6, windowId: 1, groupId: 13, active: true },
+      { id: 7, windowId: 2, groupId: 12, active: false },
+    ])
+    state.storage[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY] = {
+      '1': { groupId: 12, windowId: 1, updatedAt: 1 },
+    }
+
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(13)
+
+    const diagnostics = await getTabGroupDiagnostics(1)
+    expect(diagnostics.lastResolutionByWindow['1']?.recoverySource).toBe('active-tab-match')
+    expect(diagnostics.bindings['1']?.groupId).toBe(13)
+  })
+
   test('prefers the active tab group when multiple matching groups exist', async () => {
     setGroups([
       { id: 21, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: first` },
@@ -203,5 +245,30 @@ describe('tab group manager recovery', () => {
     const diagnostics = await getTabGroupDiagnostics(5)
     expect(diagnostics.bindings['5']?.groupId).toBe(30)
     expect(state.storage[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]).toBeUndefined()
+  })
+
+  test('refreshes cached bindings when another extension context updates storage', async () => {
+    setGroups([
+      { id: 40, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: first` },
+      { id: 41, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: second` },
+    ])
+    setTabs([
+      { id: 8, windowId: 1, groupId: 40, active: true },
+      { id: 9, windowId: 1, groupId: 41, active: false },
+    ])
+    state.storage[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY] = {
+      '1': { groupId: 40, windowId: 1, updatedAt: 1 },
+    }
+
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(40)
+
+    await (globalThis.chrome as typeof chrome).storage.local.set({
+      [ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY]: {
+        '1': { groupId: 41, windowId: 1, updatedAt: 2 },
+      },
+    })
+
+    await refreshBindingsFromStorage()
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(41)
   })
 })

--- a/packages/browser-extension/test/tab-group-manager.test.ts
+++ b/packages/browser-extension/test/tab-group-manager.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import {
+  ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY,
+  ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY,
+  NINE1_TAB_GROUP_TITLE_PREFIX,
+} from '../src/shared/tab-group'
+import {
+  __resetTabGroupManagerStateForTests,
+  getActiveNine1GroupId,
+  getTabGroupDiagnostics,
+} from '../src/background/tab-group-manager'
+
+interface MockTab {
+  id: number
+  windowId: number
+  groupId: number
+  active?: boolean
+  url?: string
+  title?: string
+}
+
+interface MockGroup {
+  id: number
+  windowId: number
+  title?: string
+  color?: chrome.tabGroups.ColorEnum
+  collapsed?: boolean
+}
+
+const state: {
+  tabs: Map<number, MockTab>
+  groups: Map<number, MockGroup>
+  storage: Record<string, unknown>
+  currentWindowId: number
+} = {
+  tabs: new Map(),
+  groups: new Map(),
+  storage: {},
+  currentWindowId: 1,
+}
+
+function resetChromeState(): void {
+  state.tabs.clear()
+  state.groups.clear()
+  state.storage = {}
+  state.currentWindowId = 1
+  __resetTabGroupManagerStateForTests()
+}
+
+function setTabs(tabs: MockTab[]): void {
+  state.tabs = new Map(tabs.map((tab) => [tab.id, { ...tab }]))
+}
+
+function setGroups(groups: MockGroup[]): void {
+  state.groups = new Map(groups.map((group) => [group.id, { ...group }]))
+}
+
+beforeEach(() => {
+  resetChromeState()
+
+  ;(globalThis as { chrome?: unknown }).chrome = {
+    storage: {
+      local: {
+        async get(defaults: Record<string, unknown>) {
+          return {
+            ...defaults,
+            ...state.storage,
+          }
+        },
+        async set(values: Record<string, unknown>) {
+          state.storage = {
+            ...state.storage,
+            ...values,
+          }
+        },
+        async remove(key: string) {
+          delete state.storage[key]
+        },
+      },
+    },
+    tabs: {
+      async get(tabId: number) {
+        const tab = state.tabs.get(tabId)
+        if (!tab) throw new Error(`Missing tab ${tabId}`)
+        return { ...tab }
+      },
+      async query(queryInfo: {
+        active?: boolean
+        currentWindow?: boolean
+        windowId?: number
+        groupId?: number
+      }) {
+        return Array.from(state.tabs.values()).filter((tab) => {
+          if (typeof queryInfo.groupId === 'number' && tab.groupId !== queryInfo.groupId) return false
+          if (typeof queryInfo.windowId === 'number' && tab.windowId !== queryInfo.windowId) return false
+          if (queryInfo.currentWindow && tab.windowId !== state.currentWindowId) return false
+          if (queryInfo.active && !tab.active) return false
+          return true
+        }).map((tab) => ({ ...tab }))
+      },
+      async group(options: { tabIds: number[]; groupId?: number }) {
+        const nextGroupId = options.groupId ?? Math.max(0, ...state.groups.keys()) + 1
+        if (!state.groups.has(nextGroupId)) {
+          const firstTab = state.tabs.get(options.tabIds[0]!)
+          state.groups.set(nextGroupId, {
+            id: nextGroupId,
+            windowId: firstTab?.windowId ?? state.currentWindowId,
+            title: NINE1_TAB_GROUP_TITLE_PREFIX,
+          })
+        }
+        for (const tabId of options.tabIds) {
+          const tab = state.tabs.get(tabId)
+          if (!tab) continue
+          state.tabs.set(tabId, { ...tab, groupId: nextGroupId })
+        }
+        return nextGroupId
+      },
+      onRemoved: {
+        addListener() {
+          return undefined
+        },
+      },
+    },
+    tabGroups: {
+      async get(groupId: number) {
+        const group = state.groups.get(groupId)
+        if (!group) throw new Error(`Missing group ${groupId}`)
+        return { ...group }
+      },
+      async update(groupId: number, updateInfo: Partial<MockGroup>) {
+        const group = state.groups.get(groupId)
+        if (!group) throw new Error(`Missing group ${groupId}`)
+        const next = { ...group, ...updateInfo }
+        state.groups.set(groupId, next)
+        return { ...next }
+      },
+    },
+    windows: {
+      async getLastFocused() {
+        return { id: state.currentWindowId }
+      },
+      async getAll() {
+        return Array.from(
+          new Set(Array.from(state.tabs.values()).map((tab) => tab.windowId)),
+        ).map((id) => ({ id }))
+      },
+    },
+  }
+})
+
+describe('tab group manager recovery', () => {
+  test('reuses a valid stored binding without rebuilding the group', async () => {
+    setGroups([{ id: 10, windowId: 1, title: NINE1_TAB_GROUP_TITLE_PREFIX }])
+    setTabs([{ id: 1, windowId: 1, groupId: 10, active: true }])
+    state.storage[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY] = {
+      '1': { groupId: 10, windowId: 1, updatedAt: 1 },
+    }
+
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(10)
+
+    const diagnostics = await getTabGroupDiagnostics(1)
+    expect(diagnostics.lastResolutionByWindow['1']?.recoverySource).toBe('stored')
+  })
+
+  test('recovers from a stale binding using the active tab matching group', async () => {
+    setGroups([{ id: 11, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: task` }])
+    setTabs([{ id: 2, windowId: 1, groupId: 11, active: true }])
+    state.storage[ACTIVE_NINE1_TAB_GROUPS_STORAGE_KEY] = {
+      '1': { groupId: 999, windowId: 1, updatedAt: 1 },
+    }
+
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(11)
+
+    const diagnostics = await getTabGroupDiagnostics(1)
+    expect(diagnostics.lastResolutionByWindow['1']?.recoverySource).toBe('active-tab-match')
+  })
+
+  test('prefers the active tab group when multiple matching groups exist', async () => {
+    setGroups([
+      { id: 21, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: first` },
+      { id: 22, windowId: 1, title: `${NINE1_TAB_GROUP_TITLE_PREFIX}: second` },
+    ])
+    setTabs([
+      { id: 3, windowId: 1, groupId: 21, active: false },
+      { id: 4, windowId: 1, groupId: 22, active: true },
+    ])
+
+    await expect(getActiveNine1GroupId(1)).resolves.toBe(22)
+
+    const diagnostics = await getTabGroupDiagnostics(1)
+    expect(diagnostics.lastResolutionByWindow['1']?.matchedGroupIds).toEqual([21, 22])
+    expect(diagnostics.lastResolutionByWindow['1']?.recoverySource).toBe('active-tab-match')
+  })
+
+  test('migrates the legacy single-value storage key to window-scoped bindings', async () => {
+    setGroups([{ id: 30, windowId: 5, title: NINE1_TAB_GROUP_TITLE_PREFIX }])
+    setTabs([{ id: 5, windowId: 5, groupId: 30, active: true }])
+    state.storage[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY] = 30
+    state.currentWindowId = 5
+
+    await expect(getActiveNine1GroupId(5)).resolves.toBe(30)
+
+    const diagnostics = await getTabGroupDiagnostics(5)
+    expect(diagnostics.bindings['5']?.groupId).toBe(30)
+    expect(state.storage[ACTIVE_NINE1_TAB_GROUP_STORAGE_KEY]).toBeUndefined()
+  })
+})

--- a/packages/browser-mcp-server/src/bridge/relay-routes.ts
+++ b/packages/browser-mcp-server/src/bridge/relay-routes.ts
@@ -10,6 +10,7 @@
 import { Hono } from 'hono'
 import { upgradeWebSocket } from 'hono/bun'
 import type { WSContext } from 'hono/ws'
+import type { Tab, TabGroupDiagnostics } from '../core/types'
 
 export interface TargetInfo {
   targetId: string
@@ -39,6 +40,28 @@ export interface ExtensionHealthPayload {
   lastPongAt?: number
   activeCommands?: number
   reconnectAttempt?: number
+  diagnostics?: {
+    authoritativeTabs: Array<{
+      tabId: number
+      windowId: number
+      title: string
+      url: string
+    }>
+    activeSessions: Array<{
+      tabId: number
+      sessionId: string
+    }>
+    tabGroups: TabGroupDiagnostics
+    lastResync: {
+      reason: string
+      windowId: number | null
+      attachedTabIds: number[]
+      detachedTabIds: number[]
+      updatedTabIds: number[]
+      authoritativeTabIds: number[]
+      at: number
+    } | null
+  }
 }
 
 export interface ExtensionAgentStatePayload {
@@ -54,9 +77,11 @@ export interface ExtensionRelay {
   getTools: () => string[]
   getCapabilities: () => Record<string, unknown>
   getHealth: () => ExtensionHealthPayload | null
+  getDiagnostics: () => ExtensionHealthPayload['diagnostics'] | null
   getHelloAt: () => number | null
   getHello: () => ExtensionHelloPayload | null
   getAgentStates: () => ExtensionAgentStatePayload[]
+  upsertTargetsFromTabs: (tabs: Tab[]) => ConnectedTarget[]
   sendCommand: (method: string, params?: unknown, targetId?: string) => Promise<unknown>
   stop: () => Promise<void>
 }
@@ -138,6 +163,48 @@ function findSessionIdForTarget(targetId: string): string | undefined {
     }
   }
   return undefined
+}
+
+function stableSessionIdForTarget(targetId: string): string {
+  return /^\d+$/.test(targetId) ? `tab_${targetId}` : `target_${targetId}`
+}
+
+function upsertConnectedTarget(target: ConnectedTarget, broadcast = true): ConnectedTarget {
+  const previous = connectedTargets.get(target.sessionId)
+  connectedTargets.set(target.sessionId, target)
+
+  if (!broadcast) {
+    return target
+  }
+
+  if (!previous) {
+    broadcastToCdpClients({
+      method: 'Target.attachedToTarget',
+      params: {
+        sessionId: target.sessionId,
+        targetInfo: { ...target.targetInfo, attached: true },
+        waitingForDebugger: false,
+      },
+      sessionId: target.sessionId,
+    })
+    return target
+  }
+
+  if (
+    previous.targetId !== target.targetId
+    || previous.targetInfo.title !== target.targetInfo.title
+    || previous.targetInfo.url !== target.targetInfo.url
+  ) {
+    broadcastToCdpClients({
+      method: 'Target.targetInfoChanged',
+      params: {
+        targetInfo: { ...target.targetInfo, attached: true },
+      },
+      sessionId: target.sessionId,
+    })
+  }
+
+  return target
 }
 
 async function routeCdpCommand(cmd: { id: number; method: string; params?: unknown; sessionId?: string }): Promise<unknown> {
@@ -284,6 +351,7 @@ function handleExtensionMessage(data: string): void {
       lastPongAt: params?.lastPongAt,
       activeCommands: params?.activeCommands,
       reconnectAttempt: params?.reconnectAttempt,
+      diagnostics: params?.diagnostics ?? undefined,
     }
     return
   }
@@ -317,11 +385,11 @@ function handleExtensionMessage(data: string): void {
       const prevTargetId = prev?.targetId
       const changedTarget = Boolean(prev && prevTargetId && prevTargetId !== nextTargetId)
 
-      connectedTargets.set(attached.sessionId, {
+      upsertConnectedTarget({
         sessionId: attached.sessionId,
         targetId: nextTargetId,
         targetInfo: attached.targetInfo,
-      })
+      }, false)
 
       if (changedTarget && prevTargetId) {
         broadcastToCdpClients({
@@ -516,9 +584,28 @@ export function getExtensionRelay(): ExtensionRelay {
     getTools: () => [...extensionTools],
     getCapabilities: () => ({ ...extensionCapabilities }),
     getHealth: () => (extensionHealth ? { ...extensionHealth } : null),
+    getDiagnostics: () => (extensionHealth?.diagnostics ? structuredClone(extensionHealth.diagnostics) : null),
     getHelloAt: () => extensionHelloAt,
     getHello: () => (extensionHello ? { ...extensionHello } : null),
     getAgentStates: () => Array.from(extensionAgentStates.values()).map((state) => ({ ...state })),
+    upsertTargetsFromTabs: (tabs: Tab[]) => {
+      const nextTargets = tabs.map((tab) => {
+        const targetId = String(tab.id)
+        const sessionId = tab.sessionId ?? stableSessionIdForTarget(targetId)
+        return upsertConnectedTarget({
+          sessionId,
+          targetId,
+          targetInfo: {
+            targetId,
+            type: 'page',
+            title: tab.title,
+            url: tab.url,
+            attached: true,
+          },
+        })
+      })
+      return nextTargets
+    },
     sendCommand: async (method: string, params?: unknown, targetId?: string) => {
       if (!extensionWs || extensionWs.readyState !== 1) {
         throw new Error('Chrome extension not connected')

--- a/packages/browser-mcp-server/src/bridge/relay-routes.ts
+++ b/packages/browser-mcp-server/src/bridge/relay-routes.ts
@@ -207,6 +207,18 @@ function upsertConnectedTarget(target: ConnectedTarget, broadcast = true): Conne
   return target
 }
 
+function detachConnectedTarget(sessionId: string, targetId: string): void {
+  connectedTargets.delete(sessionId)
+  broadcastToCdpClients({
+    method: 'Target.detachedFromTarget',
+    params: {
+      sessionId,
+      targetId,
+    },
+    sessionId,
+  })
+}
+
 async function routeCdpCommand(cmd: { id: number; method: string; params?: unknown; sessionId?: string }): Promise<unknown> {
   switch (cmd.method) {
     case 'Browser.getVersion':
@@ -589,6 +601,24 @@ export function getExtensionRelay(): ExtensionRelay {
     getHello: () => (extensionHello ? { ...extensionHello } : null),
     getAgentStates: () => Array.from(extensionAgentStates.values()).map((state) => ({ ...state })),
     upsertTargetsFromTabs: (tabs: Tab[]) => {
+      const desiredSessionIds = new Set<string>()
+      const desiredSessionIdByTargetId = new Map<string, string>()
+
+      for (const tab of tabs) {
+        const targetId = String(tab.id)
+        const sessionId = tab.sessionId ?? stableSessionIdForTarget(targetId)
+        desiredSessionIds.add(sessionId)
+        desiredSessionIdByTargetId.set(targetId, sessionId)
+      }
+
+      for (const [sessionId, target] of Array.from(connectedTargets.entries())) {
+        const desiredSessionId = desiredSessionIdByTargetId.get(target.targetId)
+        if (desiredSessionId === sessionId) continue
+        if (!desiredSessionIds.has(sessionId) || desiredSessionId !== sessionId) {
+          detachConnectedTarget(sessionId, target.targetId)
+        }
+      }
+
       const nextTargets = tabs.map((tab) => {
         const targetId = String(tab.id)
         const sessionId = tab.sessionId ?? stableSessionIdForTarget(targetId)

--- a/packages/browser-mcp-server/src/bridge/server.ts
+++ b/packages/browser-mcp-server/src/bridge/server.ts
@@ -301,6 +301,34 @@ export class BridgeServer {
         },
       ) as ExtensionToolResult
       const text = result.content?.find(c => c.type === 'text')?.text ?? '{}'
+      if (result.isError) {
+        return {
+          tabs: [],
+          source: 'none',
+          issues: [
+            {
+              code: 'tab_scan_failed',
+              severity: 'error',
+              message: `Extension tab scan failed: ${text}`,
+            },
+          ],
+        }
+      }
+
+      if (!text.trim().startsWith('{')) {
+        return {
+          tabs: [],
+          source: 'none',
+          issues: [
+            {
+              code: 'tab_scan_failed',
+              severity: 'error',
+              message: `Extension tab scan returned a non-JSON payload: ${text}`,
+            },
+          ],
+        }
+      }
+
       const parsed = JSON.parse(text) as {
         allTabs?: Array<{ id?: number; title?: string; url?: string; active?: boolean; windowId?: number }>
         activeTab?: { id?: number; title?: string; url?: string; windowId?: number } | null

--- a/packages/browser-mcp-server/src/bridge/server.ts
+++ b/packages/browser-mcp-server/src/bridge/server.ts
@@ -105,6 +105,14 @@ function normalizeLocateResult(value: unknown, query: string): LocateResult {
   }
 }
 
+type ExtensionTabListSource = 'authoritative_group_scan' | 'relay_cache_fallback' | 'none'
+
+interface RefreshExtensionTabsResult {
+  tabs: Tab[]
+  source: ExtensionTabListSource
+  issues: BrowserRuntimeStatus['issues']
+}
+
 async function isLocalPortListening(host: string, port: number): Promise<boolean> {
   return await new Promise((resolve) => {
     const socket = new Socket()
@@ -217,22 +225,19 @@ export class BridgeServer {
   async getStatus(): Promise<BrowserStatus> {
     let userStatus: BrowserStatus['user'] = null
     let botStatus: BrowserStatus['bot'] = null
+    const runtimeIssues: BrowserRuntimeStatus['issues'] = []
 
     // User browser (Extension)
     if (this.isExtensionConnected) {
-      const targets = this.relay!.getTargets()
       const refreshedTabs = await this.refreshExtensionTabs()
+      runtimeIssues.push(...refreshedTabs.issues)
       userStatus = {
         connected: true,
-        tabs: refreshedTabs ?? targets.map(t => ({
-          id: t.targetId,
-          sessionId: t.sessionId,
-          title: t.targetInfo.title,
-          url: t.targetInfo.url,
-        })),
+        tabs: refreshedTabs.tabs,
+        tabListSource: refreshedTabs.source,
       }
     } else {
-      userStatus = { connected: false, tabs: [] }
+      userStatus = { connected: false, tabs: [], tabListSource: 'none' }
     }
 
     // Bot browser (Direct CDP)
@@ -256,14 +261,34 @@ export class BridgeServer {
     return {
       user: userStatus,
       bot: botStatus,
-      runtime: await this.getRuntimeStatus(),
+      runtime: await this.getRuntimeStatus(runtimeIssues),
     }
   }
 
-  private async refreshExtensionTabs(): Promise<Tab[] | null> {
-    if (!this.relay?.extensionConnected()) return null
+  private async refreshExtensionTabs(): Promise<RefreshExtensionTabsResult> {
+    if (!this.relay?.extensionConnected()) {
+      return { tabs: [], source: 'none', issues: [] }
+    }
     const supportedTools = this.relay.getTools()
-    if (supportedTools.length > 0 && !supportedTools.includes('tabs_context_mcp')) return null
+    if (supportedTools.length > 0 && !supportedTools.includes('tabs_context_mcp')) {
+      const targets = this.relay.getTargets()
+      return {
+        tabs: targets.map((target) => ({
+          id: target.targetId,
+          sessionId: target.sessionId,
+          title: target.targetInfo.title,
+          url: target.targetInfo.url,
+        })),
+        source: targets.length > 0 ? 'relay_cache_fallback' : 'none',
+        issues: targets.length > 0
+          ? [{
+            code: 'relay_cache_fallback',
+            severity: 'warning',
+            message: 'Extension tabs_context_mcp is unavailable; using relay cache fallback.',
+          }]
+          : [],
+      }
+    }
 
     try {
       const result = await this.relay.sendCommand(
@@ -279,37 +304,101 @@ export class BridgeServer {
       const parsed = JSON.parse(text) as {
         allTabs?: Array<{ id?: number; title?: string; url?: string; active?: boolean; windowId?: number }>
         activeTab?: { id?: number; title?: string; url?: string; windowId?: number } | null
+        tabScanStatus?: {
+          source?: string
+          reasonCode?: string
+          recoverySource?: string
+          windowId?: number | null
+          matchedGroupIds?: number[]
+        }
       }
       const allTabs = Array.isArray(parsed.allTabs) ? parsed.allTabs : []
+      const issues: BrowserRuntimeStatus['issues'] = []
       if (allTabs.length > 0) {
-        return allTabs
+        const tabs = allTabs
           .filter(tab => typeof tab.id === 'number')
           .map(tab => ({
             id: String(tab.id),
+            sessionId: `tab_${tab.id}`,
             title: tab.title ?? '',
             url: tab.url ?? '',
             active: tab.active,
             windowId: tab.windowId,
           }))
+        const beforeTargets = this.relay.getTargets()
+        this.relay.upsertTargetsFromTabs(tabs)
+        if (beforeTargets.length === 0) {
+          issues.push({
+            code: 'relay_cache_empty',
+            severity: 'warning',
+            message: 'Relay target cache was empty; rebuilt it from authoritative extension tab scan.',
+          })
+        }
+        return {
+          tabs,
+          source: 'authoritative_group_scan',
+          issues,
+        }
       }
-      if (parsed.activeTab?.id) {
-        return [{
-          id: String(parsed.activeTab.id),
-          title: parsed.activeTab.title ?? '',
-          url: parsed.activeTab.url ?? '',
-          active: true,
-          windowId: parsed.activeTab.windowId,
-        }]
+
+      const reasonCode = parsed.tabScanStatus?.reasonCode ?? 'no_active_group'
+      if (reasonCode !== 'ok') {
+        issues.push({
+          code: reasonCode,
+          severity: reasonCode === 'tab_scan_failed' ? 'error' : 'warning',
+          message: `Extension tab scan reported ${reasonCode}.`,
+        })
+      }
+
+      return {
+        tabs: [],
+        source: 'none',
+        issues,
       }
     } catch {
-      return null
+      const cachedTargets = this.relay.getTargets()
+      if (cachedTargets.length > 0) {
+        return {
+          tabs: cachedTargets.map((target) => ({
+            id: target.targetId,
+            sessionId: target.sessionId,
+            title: target.targetInfo.title,
+            url: target.targetInfo.url,
+          })),
+          source: 'relay_cache_fallback',
+          issues: [
+            {
+              code: 'tab_scan_failed',
+              severity: 'error',
+              message: 'Extension tab scan failed; using relay cache fallback.',
+            },
+            {
+              code: 'relay_cache_fallback',
+              severity: 'warning',
+              message: 'Using relay cache fallback because authoritative extension tab scan failed.',
+            },
+          ],
+        }
+      }
+
+      return {
+        tabs: [],
+        source: 'none',
+        issues: [
+          {
+            code: 'tab_scan_failed',
+            severity: 'error',
+            message: 'Extension tab scan failed and relay cache is empty.',
+          },
+        ],
+      }
     }
-    return null
   }
 
-  private async getRuntimeStatus(): Promise<BrowserRuntimeStatus> {
+  private async getRuntimeStatus(additionalIssues: BrowserRuntimeStatus['issues'] = []): Promise<BrowserRuntimeStatus> {
     const hello = this.relay?.getHello() ?? null
     const helloAt = this.relay?.getHelloAt() ?? null
+    const diagnostics = this.relay?.getDiagnostics() ?? null
     const conflicts = await this.detectLegacyPortConflicts()
     const issues: BrowserRuntimeStatus['issues'] = []
 
@@ -337,6 +426,8 @@ export class BridgeServer {
       })
     }
 
+    issues.push(...additionalIssues)
+
     return {
       mode: 'embedded',
       serverOrigin: this.options.serverOrigin,
@@ -348,6 +439,7 @@ export class BridgeServer {
         protocolVersion: hello?.protocolVersion ?? null,
         serverOrigin: hello?.serverOrigin ?? null,
         pairedInstanceId: hello?.pairedInstanceId ?? null,
+        diagnostics,
       },
       conflicts,
       issues,
@@ -413,14 +505,7 @@ export class BridgeServer {
 
     if (channel === 'extension') {
       const refreshedTabs = await this.refreshExtensionTabs()
-      if (refreshedTabs) return refreshedTabs
-      const targets = this.relay!.getTargets()
-      return targets.map(t => ({
-        id: t.targetId,
-        sessionId: t.sessionId,
-        title: t.targetInfo.title,
-        url: t.targetInfo.url,
-      }))
+      return refreshedTabs.tabs
     }
 
     const cdpUrl = await this.ensureBrowserAvailable()

--- a/packages/browser-mcp-server/src/core/types.ts
+++ b/packages/browser-mcp-server/src/core/types.ts
@@ -22,6 +22,35 @@ export interface Tab {
   windowId?: number
 }
 
+export interface TabGroupDiagnostics {
+  currentWindowId: number | null
+  bindings: Record<string, {
+    groupId: number
+    windowId: number
+    openNonce?: string
+    updatedAt: number
+  }>
+  lastResolutionByWindow: Record<string, {
+    windowId: number | null
+    groupId: number | null
+    binding: {
+      groupId: number
+      windowId: number
+      openNonce?: string
+      updatedAt: number
+    } | null
+    recoverySource: 'stored' | 'active-tab-match' | 'single-title-match' | 'none'
+    issueCode?: string
+    matchedGroupIds: number[]
+    resolvedAt: number
+  }>
+  lastError: {
+    code: string
+    message: string
+    at: number
+  } | null
+}
+
 export interface PageContent {
   title: string
   url: string
@@ -56,6 +85,7 @@ export interface BrowserStatus {
   user: {
     connected: boolean
     tabs: Tab[]
+    tabListSource?: 'authoritative_group_scan' | 'relay_cache_fallback' | 'none'
   } | null
   bot: {
     running: boolean
@@ -87,6 +117,28 @@ export interface BrowserRuntimeStatus {
     protocolVersion: string | null
     serverOrigin: string | null
     pairedInstanceId: string | null
+    diagnostics?: {
+      authoritativeTabs: Array<{
+        tabId: number
+        windowId: number
+        title: string
+        url: string
+      }>
+      activeSessions: Array<{
+        tabId: number
+        sessionId: string
+      }>
+      tabGroups: TabGroupDiagnostics
+      lastResync: {
+        reason: string
+        windowId: number | null
+        attachedTabIds: number[]
+        detachedTabIds: number[]
+        updatedTabIds: number[]
+        authoritativeTabIds: number[]
+        at: number
+      } | null
+    } | null
   }
   conflicts: BrowserRuntimeConflict[]
   issues: BrowserStatusIssue[]

--- a/packages/browser-mcp-server/test/bridge-server.test.ts
+++ b/packages/browser-mcp-server/test/bridge-server.test.ts
@@ -49,4 +49,99 @@ describe('BridgeServer form fill', () => {
 
     await expect(bridge.clickElement('123', {}, 'bot')).rejects.toThrow('targetId')
   })
+
+  test('rebuilds stable extension targets from authoritative tab scans', async () => {
+    const bridge = new BridgeServer()
+    let relayTargets: Array<{
+      sessionId: string
+      targetId: string
+      targetInfo: { targetId: string; title: string; url: string; type: string }
+    }> = []
+    const bridgeWithRelay = bridge as any
+
+    bridgeWithRelay.relay = {
+      extensionConnected: () => true,
+      getTools: () => ['tabs_context_mcp'],
+      getTargets: () => relayTargets,
+      upsertTargetsFromTabs: (tabs: Array<{ id: string; title: string; url: string; sessionId?: string }>) => {
+        relayTargets = tabs.map((tab) => ({
+          sessionId: tab.sessionId ?? `tab_${tab.id}`,
+          targetId: String(tab.id),
+          targetInfo: {
+            targetId: String(tab.id),
+            title: tab.title,
+            url: tab.url,
+            type: 'page',
+          },
+        }))
+        return relayTargets
+      },
+      sendCommand: async () => ({
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            allTabs: [{
+              id: 12,
+              title: 'Authoritative Tab',
+              url: 'https://example.com',
+              active: true,
+              windowId: 7,
+            }],
+            tabScanStatus: {
+              source: 'authoritative_group_scan',
+              reasonCode: 'ok',
+            },
+          }),
+        }],
+      }),
+      getHealth: () => null,
+      getDiagnostics: () => null,
+      getHelloAt: () => null,
+      getHello: () => null,
+      getAgentStates: () => [],
+    }
+
+    const status = await bridge.getStatus()
+
+    expect(status.user?.tabs[0]?.sessionId).toBe('tab_12')
+    expect(status.user?.tabListSource).toBe('authoritative_group_scan')
+    expect(status.runtime?.issues.map((issue) => issue.code)).toContain('relay_cache_empty')
+  })
+
+  test('falls back to relay cache when authoritative tab scans fail', async () => {
+    const bridge = new BridgeServer()
+    const bridgeWithRelay = bridge as any
+
+    bridgeWithRelay.relay = {
+      extensionConnected: () => true,
+      getTools: () => ['tabs_context_mcp'],
+      getTargets: () => [{
+        sessionId: 'tab_44',
+        targetId: '44',
+        targetInfo: {
+          targetId: '44',
+          title: 'Cached Tab',
+          url: 'https://cached.example.com',
+          type: 'page',
+        },
+      }],
+      upsertTargetsFromTabs: () => [],
+      sendCommand: async () => {
+        throw new Error('boom')
+      },
+      getHealth: () => null,
+      getDiagnostics: () => null,
+      getHelloAt: () => null,
+      getHello: () => null,
+      getAgentStates: () => [],
+    }
+
+    const status = await bridge.getStatus()
+    const issueCodes = status.runtime?.issues.map((issue) => issue.code) ?? []
+
+    expect(status.user?.tabs[0]?.id).toBe('44')
+    expect(status.user?.tabListSource).toBe('relay_cache_fallback')
+    expect(issueCodes).toContain('tab_scan_failed')
+    expect(issueCodes).toContain('relay_cache_fallback')
+  })
 })

--- a/packages/browser-mcp-server/test/bridge-server.test.ts
+++ b/packages/browser-mcp-server/test/bridge-server.test.ts
@@ -144,4 +144,37 @@ describe('BridgeServer form fill', () => {
     expect(issueCodes).toContain('tab_scan_failed')
     expect(issueCodes).toContain('relay_cache_fallback')
   })
+
+  test('surfaces extension tool errors from authoritative tab scans', async () => {
+    const bridge = new BridgeServer()
+    const bridgeWithRelay = bridge as any
+
+    bridgeWithRelay.relay = {
+      extensionConnected: () => true,
+      getTools: () => ['tabs_context_mcp'],
+      getTargets: () => [],
+      upsertTargetsFromTabs: () => [],
+      sendCommand: async () => ({
+        isError: true,
+        content: [{
+          type: 'text',
+          text: 'Error getting tabs context: no active group',
+        }],
+      }),
+      getHealth: () => null,
+      getDiagnostics: () => null,
+      getHelloAt: () => null,
+      getHello: () => null,
+      getAgentStates: () => [],
+    }
+
+    const status = await bridge.getStatus()
+
+    expect(status.user?.tabs).toEqual([])
+    expect(status.runtime?.issues).toContainEqual({
+      code: 'tab_scan_failed',
+      severity: 'error',
+      message: 'Extension tab scan failed: Error getting tabs context: no active group',
+    })
+  })
 })

--- a/packages/browser-mcp-server/test/relay-routes.test.ts
+++ b/packages/browser-mcp-server/test/relay-routes.test.ts
@@ -7,4 +7,21 @@ describe('extension relay target validation', () => {
       getExtensionRelay().sendCommand('Runtime.evaluate', { expression: '1 + 1' }, 'missing-target'),
     ).rejects.toThrow('Chrome extension not connected')
   })
+
+  test('prunes stale cached targets when authoritative tabs are rebuilt', async () => {
+    const relay = getExtensionRelay()
+    await relay.stop()
+
+    relay.upsertTargetsFromTabs([
+      { id: '1', sessionId: 'tab_1', title: 'First', url: 'https://first.example.com' },
+      { id: '2', sessionId: 'tab_2', title: 'Second', url: 'https://second.example.com' },
+    ])
+    expect(relay.getTargets().map((target) => target.targetId)).toEqual(['1', '2'])
+
+    relay.upsertTargetsFromTabs([
+      { id: '2', sessionId: 'tab_2', title: 'Second', url: 'https://second.example.com' },
+    ])
+
+    expect(relay.getTargets().map((target) => target.targetId)).toEqual(['2'])
+  })
 })

--- a/packages/nine1bot/src/launcher/server.ts
+++ b/packages/nine1bot/src/launcher/server.ts
@@ -212,11 +212,25 @@ export async function startServer(options: StartServerOptions): Promise<ServerIn
   }
 
   // 使用静态导入的 OpenCode 服务器启动
-  const serverInstance = await OpencodeServer.listen({
-    port: server.port,
-    hostname: server.hostname,
-    cors: [],
-  })
+  let serverInstance: Awaited<ReturnType<typeof OpencodeServer.listen>> | undefined
+  try {
+    serverInstance = await OpencodeServer.listen({
+      port: server.port,
+      hostname: server.hostname,
+      cors: [],
+    })
+  } catch (error) {
+    if (bridgeServer) {
+      try {
+        await bridgeServer.stop()
+      } catch {
+        // Best-effort cleanup when the main server fails to start.
+      } finally {
+        clearBridgeServer()
+      }
+    }
+    throw error
+  }
 
   return {
     url: serverInstance.url.toString(),


### PR DESCRIPTION
# 描述 / Summary

修复浏览器扩展在 `Nine1Bot` 标签组场景下的稳定性问题，重点解决“标签组仍存在，但 runtime/bridge 识别不到标签页”的问题。  
这次改动把标签组绑定从全局单例改成按窗口恢复，补上扩展侧 target/session 的权威重同步，以及 server 侧基于权威扫描结果的自愈与诊断信息，降低 sidepanel 重开、扩展重连、service worker 重启后的失联概率。

## 类型 / Type of change

- [x] Bug 修复 (bugfix)
- [x] 重构 (refactor)

## 关联的 issue（如果有）/ Related issues

/ 暂无 /

## 变更点 / What changed

- 将浏览器扩展的活跃标签组绑定从单一 `activeNine1TabGroupId` 升级为按 `windowId` 存储的 `activeNine1TabGroups`，并保留旧存储键迁移逻辑。
- 新增标签组恢复策略：优先使用有效存储绑定；若失效则扫描当前窗口 `Nine1Bot*` 标签组，并优先选择当前活动 tab 所在组，其次单一匹配组。
- sidepanel 初始化不再每次无条件重绑标签组，只在当前窗口缺少有效绑定时才 ensure。
- 扩展 relay sessionId 改为稳定值 `tab_<tabId>`，避免断连/重连后 target 身份漂移。
- 新增扩展侧权威 resync 机制，按窗口对 managed tabs 执行 attach / detach / targetInfoChanged，同步替代原先全量 detach 再重建的粗暴逻辑。
- 在 relay 连接成功、group 激活、tab 创建/关闭、group 变化、URL/标题变化、debugger detach 等场景触发重同步。
- `tabs_context_mcp` 增强返回结果，补充 `tabScanStatus`、group diagnostics、reason code，显式区分 `no_active_group`、`group_binding_stale`、`no_automatable_tabs` 等状态。
- bridge/server 侧 `browser_status` 优先使用扩展权威扫描结果；当 relay cache 为空但权威 tab 列表可用时，自动重建 targets。
- 仅在权威扫描失败时才回退 relay cache，并通过 `runtime.issues` 暴露 `tab_scan_failed` / `relay_cache_fallback` 等诊断码。
- `BrowserStatus.user` 新增 `tabListSource`，模型侧 `browser_status` 输出会显示 tab 列表来源。
- 改善 server 启动失败提示：端口占用时给出更明确的错误信息，并在主服务启动失败时清理已初始化的 browser bridge。
- 新增回归测试，覆盖标签组恢复、旧存储迁移、稳定 session、自愈重建与 fallback 行为。

## 如何测试 / How to test

1. 运行定向测试：
   `bun test opencode/packages/opencode/test/server/listen-errors.test.ts packages/browser-extension/test/tab-group-manager.test.ts packages/browser-mcp-server/test/bridge-server.test.ts packages/browser-mcp-server/test/relay-routes.test.ts packages/browser-extension/test/server-config.test.ts`
2. 运行类型检查：
   `cd packages/browser-extension && bun run typecheck`
   `cd packages/browser-mcp-server && bun run typecheck`
3. 手动验证浏览器扩展场景：
   打开带有 `Nine1Bot` 标签组的窗口，反复打开 sidepanel、重连扩展或触发 service worker 恢复，确认 `browser_status` 仍能识别已有 tabs，且不会因为 sidepanel 重开丢失当前窗口绑定。
4. 预期结果：
   `browser_status` 能稳定返回用户浏览器 tabs；group 存在时可自动恢复；无有效 group / 无可自动化 tab 时返回明确诊断；端口占用时启动报错更明确。

## 截图（UI 变更时提供）/ Screenshots for UI changed

无重大 UI 改动。

## Checklist（合并前请确认） / Checklist

- [x] 本地已通过测试

## 备注 / Notes for reviewers

建议重点看这几块：

- `packages/browser-extension/src/background/tab-group-manager.ts`
  这里是标签组绑定模型和恢复策略的核心改动。
- `packages/browser-extension/src/background/relay-client.ts`
  这里实现了稳定 sessionId 和权威 resync，是本次稳定性修复的关键路径。
- `packages/browser-mcp-server/src/bridge/server.ts`
  这里补了 authoritative scan 优先、relay cache fallback、自愈重建和 runtime issue 输出。
- `packages/browser-mcp-server/src/bridge/relay-routes.ts`
  这里补了 target 重建与 diagnostics 透传逻辑。

另外有一个和本次修复无关但在本地验证中暴露的问题：如果 `127.0.0.1:4096` 已被其他进程占用，`dev:test` 仍会启动失败；这次已把错误信息补得更明确，但没有改成自动切换端口策略。

fix issue:
   [Bug] 浏览器插件页面识别不稳定问题 #50